### PR TITLE
docs: add Claude Design output handoff

### DIFF
--- a/docs/design/DESIGN_HANDOFF_OUTPUT.md
+++ b/docs/design/DESIGN_HANDOFF_OUTPUT.md
@@ -3,7 +3,7 @@
 
 Acompaña al brief y a `DESIGN_HANDOFF_INPUT.md`. v1.1 incorpora las correcciones del PM (Tailwind v4 `@theme inline`, subset `latin`, CTA data-driven, componentes custom, fallback de flyer).
 
-> **Ver también:** `DESIGN_HANDOFF_OUTPUT_v2.md` cubre las 4 pantallas auxiliares (sign-in, sign-up, solicitud enviada, user-pending/blocked) que quedaron afuera de v1.
+> **Ver también:** `DESIGN_HANDOFF_OUTPUT_v2.md` cubre las 5 pantallas auxiliares (sign-in, sign-up, solicitud enviada, user-pending, user-blocked) que quedaron afuera de v1.
 
 ---
 
@@ -259,7 +259,7 @@ Las rutas se mantienen como están hoy (`/[locale]/events`, no `/de/veranstaltun
 
 ### 4.1 Nuevos a crear (custom, alineados a los tokens)
 
-```
+```text
 src/components/brand/BrandMark.tsx        — ícono cuadrado (huella + sangre)
 src/components/brand/BrandLockup.tsx      — ícono + "La Huella / del Caminante"
 src/components/events/EventCard.tsx       — card 4:5 con date tile, badge género, late marker
@@ -276,7 +276,7 @@ src/components/dashboard/DashboardShell.tsx — sidebar + main, role-aware
 
 ### 4.2 Existentes a modificar
 
-```
+```text
 Header.tsx       — nueva lockup, lang switcher en pill, nav con underline-on-active sangre
 Footer.tsx       — 4 columnas con eyebrow titles, copy compacto
 EventCard.tsx    — cambio fuerte: imagen 4:5 (no landscape), date tile overlay
@@ -285,7 +285,7 @@ Layout root      — body con bg dark forzado, sin theme toggle
 
 ### 4.3 Existentes a eliminar (o deprecar)
 
-```
+```text
 Cualquier componente de light-mode (no se usa hasta nueva orden)
 El bloque "Want to post your events?" como hero card oscuro fullwidth — reemplazado por la sección CTA inline en home
 ```
@@ -317,7 +317,7 @@ El bloque "Want to post your events?" como hero card oscuro fullwidth — reempl
 1. **Las cards de evento usan `<a>`** envolviendo todo el bloque. No usar `onClick` en el `<div>` — perdemos accesibilidad, abrir-en-pestaña-nueva, etc.
 2. **Los hovers transicionan en 200ms ease-out.** Es la "respiración" del producto. No los acortes a 100ms ni los extendas a 400ms.
 3. **El flyer del evento nunca se recorta.** Contener + blur fill como fallback. Comportamiento crítico.
-4. **El switch de idioma vive en el header, siempre visible.** Tres pills `ES · EN · DE`. No es un dropdown.
+4. **El language switcher siempre se renderiza como tres pills (`ES · EN · DE`) tappables.** NUNCA se convierte en dropdown, en ningún breakpoint. En mobile, las pills se compactan (font-size menor, sin separador `·` entre ellas), pero siguen siendo tres elementos visibles e individualmente tappables.
 5. **La sangre se usa una vez por pantalla, máximo dos.**
 6. **Densidad: respetar las escalas de spacing.** No agregar paddings ad-hoc; si falta uno, agregar al token system.
 7. **El h1 del home es data-driven** según el estado de la agenda (cascada §7.3 del input de respuesta):
@@ -345,7 +345,7 @@ El bloque "Want to post your events?" como hero card oscuro fullwidth — reempl
 
 ### Breakpoints (alineados con Tailwind defaults)
 
-```
+```text
 sm:  640px
 md:  768px
 lg: 1024px
@@ -370,7 +370,7 @@ xl: 1280px
 
 - Header nav: drawer con icono `≡` a la derecha.
 - Tab bar inferior fija con Inicio · Eventos · Artistas · Guardado.
-- Lang switcher: texto chico en el header (`ES`) — abre dropdown al tocar.
+- Lang switcher: las tres pills (`ES · EN · DE`) se compactan (font-size `var(--text-caption)`, padding reducido, sin separador `·` entre ellas). El componente ocupa el mismo espacio horizontal en el header que la hamburguesa de nav, equilibrando el header simétricamente. **NO dropdown** — la decisión es pills siempre, en todos los breakpoints (ver §5.3, regla 4).
 - En event detail desktop, el flyer es sticky en la columna izquierda. En mobile, scroll normal.
 
 ---

--- a/docs/design/DESIGN_HANDOFF_OUTPUT.md
+++ b/docs/design/DESIGN_HANDOFF_OUTPUT.md
@@ -1,0 +1,424 @@
+# DESIGN_HANDOFF_OUTPUT.md
+## Rediseño La Huella del Caminante — paquete de entrega a desarrollo (v1.1)
+
+Acompaña al brief y a `DESIGN_HANDOFF_INPUT.md`. v1.1 incorpora las correcciones del PM (Tailwind v4 `@theme inline`, subset `latin`, CTA data-driven, componentes custom, fallback de flyer).
+
+> **Ver también:** `DESIGN_HANDOFF_OUTPUT_v2.md` cubre las 4 pantallas auxiliares (sign-in, sign-up, solicitud enviada, user-pending/blocked) que quedaron afuera de v1.
+
+---
+
+## 1. Decisiones de diseño tomadas
+
+### 1.1 Dirección visual (firme)
+
+| | |
+|---|---|
+| Modo | **Dark only**, forzado. Sin toggle de light. |
+| Temperatura | Negro tibio (oklch lightness ≈ 0.14, hue 50°). NO negro azulado. |
+| Densidad | Estilo RA.co / Songkick (alta densidad de agenda), pero con textura editorial. |
+| Imágenes | **4:5 vertical** para hero y cards. **1:1 cuadrado** para artistas en grilla compacta. Nunca landscape forzado. |
+| Iconografía latina | Cero. La identidad viene del color, la tipografía y el tono. |
+
+### 1.2 Tipografía elegida — Bricolage Grotesque
+
+| Token | Familia | Por qué |
+|---|---|---|
+| `--font-display` | **Bricolage Grotesque** (Google) | Sans con personalidad humanista. Variable. Renders bien en hero (96px) y card title (20px). |
+| `--font-body` | **Hanken Grotesk** (Google) | Sans neutra con buen ritmo. Limpia para body, datos, navegación. |
+| `--font-mono` | **JetBrains Mono** (Google) | Fechas, precios, eyebrows. Marca el "ritmo de máquina" que diferencia metadata del contenido. |
+
+**Subset: `latin` únicamente.** Cubre todos los acentos ES, EN y los caracteres alemanes (`ä/ö/ü/ß/Ä/Ö/Ü`). El subset `latin-ext` agrega diacríticos de polaco/checo/turco que no usamos — ahorrar ese KB importa con el VPS de 1GB.
+
+### 1.3 Roles de color — cerrados
+
+| Color | Hex | Rol | Aparece en |
+|---|---|---|---|
+| **Sangre** | `#D43029` | Brand público · CTA primario · brand mark | Botón "Conseguir entradas", logo, links activos, badge "EN VIVO" |
+| **Dorado** | `#E5A93B` | Editorial · curaduría · destacado · "esta semana" | Eyebrow "DESTACADOS", badge "★ DESTACADO", date tile en eventos featured |
+| **Fucsia** | `#E4458A` | Creator panel · noche tarde · contexto urbano | Sidebar del panel creator, badge "● NOCHE TARDE", géneros urbanos |
+
+**Regla dura:** sangre aparece **una vez por pantalla, dos como máximo**. Si empieza a aparecer en chips, separadores y hovers, perdió el rol.
+
+### 1.4 Tratamiento de imagen + fallback
+
+- **Hero (detalle de evento / artista):** 4:5, contenida (no recortada) sobre padding de 12px en surface elevada.
+- **Cards en grilla:** 4:5.
+- **Compactos (agenda strip, dashboard, avatar):** 1:1.
+- **Imagen mal ratio'd:** contener sobre blur de la misma imagen. Nunca recortar texto del flyer.
+- **Hover de cards:** transición 200ms ease-out — *no es decorativo, es parte del feel*.
+
+#### Fallback de `FlyerImage` (comportamiento por defecto — no caso de borde)
+
+Si un evento no tiene flyer subido, la card / hero muestra el **portrait del artista headliner** con el patrón de **iniciales gigantes** (mismo recurso que `MS / WP / FC` en el listado de artistas). Si tampoco hay portrait del artista, cae a iniciales gigantes sobre el color de acento que corresponda al evento (sangre, dorado o fucsia según las reglas de §1.3).
+
+```ts
+// FlyerImage.tsx — selector de imagen (pseudocódigo)
+function pickFlyerSource(event: Event): FlyerSource {
+  if (event.flyerUrl)                       return { kind: 'flyer',    url: event.flyerUrl };
+  if (event.headliner?.portraitUrl)         return { kind: 'portrait', url: event.headliner.portraitUrl, initials: event.headliner.initials };
+  return { kind: 'initials', initials: event.headliner?.initials ?? event.title.slice(0, 2), accent: accentFor(event) };
+}
+```
+
+El fallback es parte del contrato del componente, no un edge case. Documentar en el JSDoc del componente.
+
+### 1.5 Estados vacíos como onboarding
+
+Aplicado en `Creator · primer ingreso`: tres step-cards (perfil, evento, share) con preview de cómo se verá el contenido del creator antes de que exista. El "No events available" actual queda eliminado.
+
+---
+
+## 2. Design tokens — Tailwind v4 `@theme inline`
+
+El proyecto usa **Tailwind v4** con `@theme inline` en `src/app/globals.css` (no hay `tailwind.config.ts`). Este es el bloque canónico para pegar:
+
+```css
+/* src/app/globals.css */
+@import "tailwindcss";
+
+@theme inline {
+  /* ── Color · surfaces ───────────────────────────────────── */
+  --color-bg-page:        #15100B;
+  --color-bg-surface:     #1C150F;
+  --color-bg-surface-2:   #241B13;
+  --color-bg-surface-3:   #2E2419;   /* hover / pressed */
+  --color-border:         #332618;
+  --color-border-hi:      #4A3826;
+
+  /* ── Color · text ───────────────────────────────────────── */
+  --color-fg-primary:     #F4ECE0;
+  --color-fg-secondary:   #A89889;
+  --color-fg-tertiary:    #6E6053;
+
+  /* ── Color · accents (semantic, role-bound) ─────────────── */
+  --color-brand:          #D43029;   /* sangre */
+  --color-brand-dim:      #7E1B16;
+  --color-on-brand:       #FFE6E3;
+
+  --color-editorial:      #E5A93B;   /* dorado */
+  --color-editorial-dim:  #7C5A1A;
+  --color-on-editorial:   #1F1407;
+
+  --color-creator:        #E4458A;   /* fucsia */
+  --color-creator-dim:    #7B1F46;
+  --color-on-creator:     #FFE7F0;
+
+  /* ── Color · status ─────────────────────────────────────── */
+  --color-status-ok:      #8DB87A;
+  --color-status-warn:    #E5A93B;
+  --color-status-danger:  #D43029;
+
+  /* ── Type · families ────────────────────────────────────── */
+  --font-display: "Bricolage Grotesque", system-ui, sans-serif;
+  --font-body:    "Hanken Grotesk", system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+
+  /* ── Type · text utilities (Tailwind v4 text-*) ─────────── */
+  --text-display-xl:                96px;
+  --text-display-xl--line-height:   0.92;
+  --text-display-xl--letter-spacing: -0.04em;
+  --text-display-xl--font-weight:   800;
+
+  --text-display-l:                 72px;
+  --text-display-l--line-height:    0.94;
+  --text-display-l--letter-spacing: -0.035em;
+  --text-display-l--font-weight:    800;
+
+  --text-display-m:                 56px;
+  --text-display-m--line-height:    0.98;
+  --text-display-m--letter-spacing: -0.03em;
+  --text-display-m--font-weight:    700;
+
+  --text-heading-l:                 40px;
+  --text-heading-l--line-height:    1.05;
+  --text-heading-l--letter-spacing: -0.025em;
+  --text-heading-l--font-weight:    700;
+
+  --text-heading-m:                 28px;
+  --text-heading-m--line-height:    1.15;
+  --text-heading-m--letter-spacing: -0.015em;
+  --text-heading-m--font-weight:    700;
+
+  --text-heading-s:                 20px;
+  --text-heading-s--line-height:    1.25;
+  --text-heading-s--letter-spacing: -0.01em;
+  --text-heading-s--font-weight:    600;
+
+  --text-body-l:                    17px;
+  --text-body-l--line-height:       1.5;
+
+  --text-body:                      15px;
+  --text-body--line-height:         1.5;
+
+  --text-body-s:                    13px;
+  --text-body-s--line-height:       1.45;
+
+  --text-caption:                   12px;
+  --text-caption--line-height:      1.35;
+  --text-caption--letter-spacing:   0.02em;
+  --text-caption--font-weight:      500;
+
+  --text-eyebrow:                   11px;
+  --text-eyebrow--line-height:      1.2;
+  --text-eyebrow--letter-spacing:   0.16em;
+  --text-eyebrow--font-weight:      600;
+
+  --text-mono:                      12px;
+  --text-mono--line-height:         1.3;
+  --text-mono--letter-spacing:      0.02em;
+  --text-mono--font-weight:         500;
+
+  /* ── Spacing (base 4) ───────────────────────────────────── */
+  --spacing-xs:   4px;
+  --spacing-s:    8px;
+  --spacing-m:   16px;
+  --spacing-l:   24px;
+  --spacing-xl:  40px;
+  --spacing-2xl: 64px;
+  --spacing-3xl: 96px;
+
+  /* ── Radius ─────────────────────────────────────────────── */
+  --radius-s:    4px;
+  --radius-m:    8px;
+  --radius-l:   12px;
+  --radius-xl:  18px;
+  --radius-pill: 9999px;
+}
+
+/* Layout primitives no semánticos quedan fuera de @theme:
+   ancho máximo, header height, gutter del contenedor. */
+:root {
+  --layout-max-w:    1280px;
+  --layout-gutter:     32px;
+  --layout-header-h:   72px;
+}
+
+/* Forzar dark warm en body. Sin theme toggle por ahora. */
+html, body {
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+  font-family: var(--font-body);
+}
+```
+
+Tras pegar este bloque, Tailwind v4 expone automáticamente las utilities derivadas: `bg-brand`, `text-on-brand`, `text-display-l`, `font-display`, `rounded-l`, `p-xl`, etc.
+
+### Fuentes — next/font
+
+```ts
+// app/layout.tsx
+import { Bricolage_Grotesque, Hanken_Grotesk, JetBrains_Mono } from 'next/font/google';
+
+const display = Bricolage_Grotesque({
+  subsets: ['latin'],                                // NO latin-ext
+  weight: ['400','500','600','700','800'],
+  variable: '--font-display',
+  display: 'swap',
+});
+const body = Hanken_Grotesk({
+  subsets: ['latin'],
+  weight: ['400','500','600','700'],
+  variable: '--font-body',
+  display: 'swap',
+});
+const mono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400','500','600'],
+  variable: '--font-mono',
+  display: 'swap',
+});
+```
+
+---
+
+## 3. Mapeo pantallas → rutas del repo
+
+Las rutas se mantienen como están hoy (`/[locale]/events`, no `/de/veranstaltungen`). Ver §7 (Backlog) para localización SEO.
+
+| Pantalla diseñada | Reemplaza / modifica |
+|---|---|
+| Home pública | `src/app/[locale]/(public)/page.tsx` |
+| Listado de eventos | `src/app/[locale]/(public)/events/page.tsx` |
+| Detalle de evento | `src/app/[locale]/(public)/events/[slug]/page.tsx` |
+| Listado de artistas | `src/app/[locale]/(public)/artists/page.tsx` |
+| Detalle de artista | `src/app/[locale]/(public)/artists/[slug]/page.tsx` |
+| Header / Footer | `src/components/layout/Header.tsx` · `Footer.tsx` |
+| Dashboard creator — overview | `src/app/[locale]/(creator)/dashboard/page.tsx` |
+| Dashboard creator — eventos | `src/app/[locale]/(creator)/dashboard/events/page.tsx` |
+| Dashboard creator — artistas | `src/app/[locale]/(creator)/dashboard/artists/page.tsx` |
+| 404 | `src/app/[locale]/not-found.tsx` |
+| Loading skeletons | `loading.tsx` files al nivel de cada ruta |
+
+**Nuevo (no existe hoy):** la sección "Esta semana" en home, los date-grouping headers en /events, la pantalla de onboarding del creator (reemplaza al estado vacío actual).
+
+---
+
+## 4. Inventario de componentes propuestos
+
+**Todos los componentes del §4.1 son custom puros — no extienden shadcn ni base-ui.** Los shadcn ya instalados (`Button`, `Dialog`, `Select`, `Input`) se mantienen donde están en uso; se reemplazan gradualmente cuando molesten, no en una épica formal.
+
+### 4.1 Nuevos a crear (custom, alineados a los tokens)
+
+```
+src/components/brand/BrandMark.tsx        — ícono cuadrado (huella + sangre)
+src/components/brand/BrandLockup.tsx      — ícono + "La Huella / del Caminante"
+src/components/events/EventCard.tsx       — card 4:5 con date tile, badge género, late marker
+src/components/events/EventRow.tsx        — fila densa para agenda compacta
+src/components/events/DateTile.tsx        — bloque "JUN 7" reutilizable
+src/components/events/EventCta.tsx        — CTA data-driven según Event.price (ver §5.3)
+src/components/artists/ArtistCard.tsx     — card cuadrada con portrait + initials watermark
+src/components/ui/Chip.tsx                — filter chip pill con accent prop
+src/components/ui/SectionHeader.tsx       — eyebrow + h2 + acción a la derecha
+src/components/ui/FlyerImage.tsx          — wrapper con fallback a portrait → iniciales (ver §1.4)
+src/components/dashboard/StepCard.tsx     — card de onboarding (3 pasos)
+src/components/dashboard/DashboardShell.tsx — sidebar + main, role-aware
+```
+
+### 4.2 Existentes a modificar
+
+```
+Header.tsx       — nueva lockup, lang switcher en pill, nav con underline-on-active sangre
+Footer.tsx       — 4 columnas con eyebrow titles, copy compacto
+EventCard.tsx    — cambio fuerte: imagen 4:5 (no landscape), date tile overlay
+Layout root      — body con bg dark forzado, sin theme toggle
+```
+
+### 4.3 Existentes a eliminar (o deprecar)
+
+```
+Cualquier componente de light-mode (no se usa hasta nueva orden)
+El bloque "Want to post your events?" como hero card oscuro fullwidth — reemplazado por la sección CTA inline en home
+```
+
+---
+
+## 5. Notas de implementación
+
+### 5.1 Crítico vs. simplificable (para MVP visual)
+
+| Crítico | Simplificable en v1 |
+|---|---|
+| Dark warm + tipografía + paleta + ratio 4:5 — todo eso es la marca | Hover micro-animaciones (200ms ease-out) — pueden quedar para v2 |
+| Date tile + badge sobre flyer | Pattern de fondo del flyer placeholder cuando falta imagen — un solid color sirve para v1 |
+| Onboarding del creator (3 step cards) | Las preview-chips de "así te verán" — pueden ser texto simple en v1 |
+| **Fallback de FlyerImage a portrait → iniciales** | — (es parte del contrato, no MVP-able) |
+| **CTA data-driven** según Event.price | — (es parte de la corrección de copy, no MVP-able) |
+| Estados vacíos como guía | Filtros combinados con sugerencias — el JSON de sugerencias puede ser hardcoded por ahora |
+| Loading skeletons en lugar de "No events available" | Skeleton con animación de pulse — un static gray sirve para v1 |
+
+### 5.2 Iconos — política
+
+- **Componentes nuevos:** preferir iconos como texto cuando sea posible (`←`, `→`, `●`, `↗`, `+`, `×`).
+- **Cuando no se puede expresar en texto:** importar de **lucide-react** (ya está en el repo, tree-shakeable; cada import suma ~0.5–1KB).
+- **No remover** lucide-react del bundle — sigue en uso en componentes existentes que no se reemplazan en esta vuelta.
+
+### 5.3 Decisiones implícitas que el dev debe respetar
+
+1. **Las cards de evento usan `<a>`** envolviendo todo el bloque. No usar `onClick` en el `<div>` — perdemos accesibilidad, abrir-en-pestaña-nueva, etc.
+2. **Los hovers transicionan en 200ms ease-out.** Es la "respiración" del producto. No los acortes a 100ms ni los extendas a 400ms.
+3. **El flyer del evento nunca se recorta.** Contener + blur fill como fallback. Comportamiento crítico.
+4. **El switch de idioma vive en el header, siempre visible.** Tres pills `ES · EN · DE`. No es un dropdown.
+5. **La sangre se usa una vez por pantalla, máximo dos.**
+6. **Densidad: respetar las escalas de spacing.** No agregar paddings ad-hoc; si falta uno, agregar al token system.
+7. **El h1 del home es data-driven** según el estado de la agenda (cascada §7.3 del input de respuesta):
+   - Si hay shows esta semana → `home.hero.h1.thisWeek` → *"La huella **de esta semana**."*
+   - Sino, si hay shows el mes que viene → `home.hero.h1.nextMonth` → *"La huella **del mes que viene**."*
+   - Sino → `home.hero.h1.fallback` → *"La huella, **lo que viene**."*
+   Las tres viven en `messages/{es,en,de}.json`, nunca hardcoded.
+8. **El CTA del detalle de evento es data-driven** según el modo de acceso (derivado de `Event.price`):
+
+   | `Event.price` (normalizado) | UI | Comportamiento |
+   |---|---|---|
+   | `{ kind: 'external', url: 'https://…' }` | Botón sangre **"Conseguir entradas ↗"** | `<a target="_blank" rel="noopener noreferrer">` |
+   | `{ kind: 'donation' }` | Etiqueta **"Aporte voluntario"** (no clickeable, fondo `surface`, borde `border-hi`) | — |
+   | `{ kind: 'free' }` | Etiqueta **"Entrada libre"** (no clickeable) | — |
+   | `{ kind: 'door' }` | Etiqueta **"Entrada en puerta"** (no clickeable) | — |
+   | `null` o `kind: 'unknown'` | No mostrar CTA; solo bloque de precio si existe | — |
+
+   La normalización del campo `Event.price` (hoy string libre) se hace en server o en migración — fuera del scope de diseño, pero el componente `EventCta.tsx` ya recibe el shape estructurado.
+
+   Etiquetas i18n: `event.cta.tickets`, `event.cta.donation`, `event.cta.free`, `event.cta.door`. Ver demo en la artboard "Evento · variantes de CTA" del canvas.
+
+---
+
+## 6. Comportamiento responsive
+
+### Breakpoints (alineados con Tailwind defaults)
+
+```
+sm:  640px
+md:  768px
+lg: 1024px
+xl: 1280px
+2xl: 1536px
+```
+
+### Por pantalla
+
+| Pantalla | Mobile (< 768) | Tablet (768–1024) | Desktop (≥ 1024) |
+|---|---|---|---|
+| **Home hero** | h1 a 40px en una columna, stats stack vertical | h1 a 64px, stats en 2 cols | h1 a 96px, stats en 4 cols |
+| **Featured grid** | 1 col, full width | 2 cols | 3 cols |
+| **Agenda strip** | Stack vertical, oculta el badge género | Filtros wrap | Filtros inline |
+| **Artistas grid** | 2 cols compactas | 3 cols | 4 cols |
+| **Events list** | Cards full-width agrupadas por día, filtros en scroll horizontal | 2 cols | 3 cols |
+| **Event detail** | Flyer al tope, fact grid 2 cols, ticket button sticky bottom | igual mobile, flyer al tope | 5+7 cols: flyer sticky izq, info derecha |
+| **Artist detail** | Portrait al tope, info debajo | igual | 4+8 cols |
+| **Dashboard creator** | Sidebar colapsa a tab bar inferior + drawer | Sidebar 220px | Sidebar 260px + main |
+
+### Qué se oculta / muestra en mobile
+
+- Header nav: drawer con icono `≡` a la derecha.
+- Tab bar inferior fija con Inicio · Eventos · Artistas · Guardado.
+- Lang switcher: texto chico en el header (`ES`) — abre dropdown al tocar.
+- En event detail desktop, el flyer es sticky en la columna izquierda. En mobile, scroll normal.
+
+---
+
+## 7. Backlog post-rediseño (épicas aparte)
+
+Estas no son decisiones abiertas — son cosas que **decidimos no abordar en este rediseño** y se planifican como épicas posteriores:
+
+1. **Rutas localizadas por idioma para SEO local** (`/de/veranstaltungen`, `/de/künstler`, etc.). Hoy las rutas están en inglés en los tres idiomas — funcional, pero subóptimo para SEO alemán. Mover post-rediseño.
+2. **OG image / share preview templates.** Template del flyer + branding para previews en redes (1 día de trabajo). No bloquea.
+3. **Cookie banner + Impressum + Datenschutz + AGB.** El footer ya reserva el slot. Se completa cuando esté el contenido legal redactado.
+4. **Autoposteo a Instagram / Facebook / TikTok.** Marcado en el brief original como fuera del scope.
+5. **Sistema de tickets in-house / pagos.** Fuera del scope: solo redirección externa.
+6. **Sistema de notificaciones in-app.** No existe hoy, no se diseña.
+7. **Migración total fuera de shadcn.** Reemplazos custom van ocurriendo a medida que los componentes shadcn molesten — no es épica formal.
+
+---
+
+## 8. Cómo está armado el archivo de diseño
+
+`index.html` es un canvas con secciones:
+
+1. **Dirección visual** (moodboard + roles de color)
+2. **Sistema visual** (tokens, type scale, espaciado, componentes núcleo)
+3. **Pantallas públicas desktop** — incluye un **prototipo navegable** (la primera artboard) donde podés clickear de home → detalle de evento → artista. También incluye la artboard *"Evento · variantes de CTA"* con los 4 modos.
+4. **Panel creator + admin** (empty/onboarding y filled)
+5. **Mobile** (375px — home, eventos, detalle)
+6. **Estados especiales** (loading, sin resultados, 404)
+7. **Auth + estados de cuenta** (sign-in, sign-up, solicitud enviada, user-pending, user-blocked) → ver `DESIGN_HANDOFF_OUTPUT_v2.md`
+
+**Tweaks panel** (toggleable desde la toolbar): tipografía display/body, color brand, temperatura del dark.
+
+---
+
+## 9. Trabajo restante después de v1
+
+Cubierto en `DESIGN_HANDOFF_OUTPUT_v2.md`:
+
+- Sign-in / sign-up (desktop + mobile)
+- "Solicitud enviada" (post-apply)
+- User-pending (cuenta en revisión)
+- User-blocked
+
+**A implementar por el equipo sin diseño dedicado** (siguiendo tokens + patrones del handoff):
+
+- Formularios de creación / edición de evento y artista en el dashboard creator
+- Formulario público de `/apply`
+- Panel admin completo (gestión de usuarios, vista global de eventos, cola de aplicaciones)
+- Páginas legales (cuando esté el contenido legal redactado)
+
+— Claude Design · 2026-05-15 · v1.1

--- a/docs/design/DESIGN_HANDOFF_OUTPUT_v2.md
+++ b/docs/design/DESIGN_HANDOFF_OUTPUT_v2.md
@@ -1,7 +1,7 @@
 # DESIGN_HANDOFF_OUTPUT_v2.md
 ## Auth + estados de cuenta — paquete de entrega complementario (final)
 
-Complemento de `DESIGN_HANDOFF_OUTPUT.md` v1.1. Mismos tokens, mismos patrones, sin sistema nuevo. Cubre las 4 pantallas que quedaron afuera de v1, con los 3 ajustes del segundo pase incorporados:
+Complemento de `DESIGN_HANDOFF_OUTPUT.md` v1.1. Mismos tokens, mismos patrones, sin sistema nuevo. Cubre las 5 pantallas que quedaron afuera de v1, con los 3 ajustes del segundo pase incorporados:
 
 - Sin checkbox "Mantener sesión" en sign-in (Better Auth maneja la sesión).
 - Sin nombres hardcoded en el copy del timeline ("Un humano mira tu perfil").
@@ -110,7 +110,7 @@ Mismo layout que pending pero rojo y sin animación (es estado terminal).
 
 ### 3.1 Nuevos a crear
 
-```
+```text
 src/components/auth/AuthShell.tsx           — layout 2-col (form izq, panel atmosférico der)
                                               acepta `hero` prop para customizar la columna derecha
 src/components/auth/AuthField.tsx           — label + input + hint estilizado a los tokens
@@ -125,7 +125,7 @@ src/components/auth/StepTimeline.tsx        — timeline vertical de 4 estados c
 
 ### 3.2 Existentes a modificar
 
-```
+```text
 src/components/layout/Header.tsx  — agregar variante "auth" (oculta nav, deja solo BrandLockup)
                                     O bien: que las páginas /sign-in y /sign-up usen su propio
                                     layout root sin Header. Decisión del dev.

--- a/docs/design/DESIGN_HANDOFF_OUTPUT_v2.md
+++ b/docs/design/DESIGN_HANDOFF_OUTPUT_v2.md
@@ -1,0 +1,272 @@
+# DESIGN_HANDOFF_OUTPUT_v2.md
+## Auth + estados de cuenta — paquete de entrega complementario (final)
+
+Complemento de `DESIGN_HANDOFF_OUTPUT.md` v1.1. Mismos tokens, mismos patrones, sin sistema nuevo. Cubre las 4 pantallas que quedaron afuera de v1, con los 3 ajustes del segundo pase incorporados:
+
+- Sin checkbox "Mantener sesión" en sign-in (Better Auth maneja la sesión).
+- Sin nombres hardcoded en el copy del timeline ("Un humano mira tu perfil").
+- Mapeo explícito de los dos destinos del footer del sign-in.
+
+> Pantallas: sign-in · sign-up · solicitud enviada · user-pending · user-blocked. Listadas en la sección **07** del canvas.
+
+---
+
+## 1. Pantallas
+
+### 1.1 Sign-in
+
+Layout en dos columnas (7:5) en desktop, single-column en mobile.
+
+- **Izquierda:** lockup arriba, formulario centrado en columna estrecha (`max-width: 440px`). Orden:
+  1. Botón Google ("Continuar con Google")
+  2. Divider "O CON EMAIL"
+  3. Email
+  4. Contraseña
+  5. Link "¿Olvidaste tu contraseña?" alineado a la derecha (sin checkbox "Mantener sesión" — la sesión la maneja Better Auth de forma transparente)
+  6. CTA primario sangre "Iniciar sesión →"
+- **Derecha:** panel atmosférico con el manifiesto editorial:
+  > *"Hecho por uno **de ustedes**. La Huella es un portal independiente. No vendemos entradas, no tomamos comisión. Solo mostramos lo que está sonando."*
+  + 3 thumbnails 1:1 + tira de metadata ("12 SHOWS PRÓXIMOS · 3 CIUDADES").
+
+**Footer del form — dos destinos distintos:**
+
+> *"¿Primera vez por acá? **Crear cuenta** o **aplicá como artista** →"*
+
+| Link | Ruta | Resultado |
+|---|---|---|
+| **Crear cuenta** | `/[locale]/(auth)/sign-up` | Usuario nuevo con rol `user` (público). Lo único que habilita es guardar eventos / hacer follow de artistas (post-MVP). |
+| **Aplicá como artista** | `/[locale]/(public)/apply` | Form público de solicitud. Tras aprobación del admin, el rol pasa a `creator`. |
+
+Son **dos rutas reales distintas, no variantes del mismo form**. El dev no debe colapsarlas en una sola pantalla.
+
+**Mobile:** la columna derecha desaparece; el formulario queda full-bleed con padding generoso.
+
+### 1.2 Sign-up
+
+Mismo shell que sign-in, con el panel derecho cambiado: ahora explicita los **3 pasos** (creás cuenta → aplicás → publicás) con tiempos estimados:
+
+| # | Paso | Tiempo |
+|---|---|---|
+| 01 | Creás la cuenta | Ahora mismo · 1 min. |
+| 02 | Aplicás como creator | Nosotros revisamos · 1-2 días. |
+| 03 | Publicás tu primer evento | Cuando quieras · 3 min. |
+
+Aclarar "tomamos 1-2 días" donde lo va a ver primero — reduce ansiedad futura en `user-pending`.
+
+Campos: nombre, email, password (con hint de fortaleza), checkbox de términos.
+
+### 1.3 Solicitud enviada
+
+Es el **último touchpoint del journey de aplicación** y hoy es texto plano. Lo rediseñé con peso editorial:
+
+- **Eyebrow pill dorado** ("✓ SOLICITUD RECIBIDA") — la confirmación viva.
+- **Display h1** con cierre afectivo: *"Recibimos tu solicitud, **caminante**."* Caminante en sangre + itálica. Es el momento para ser cálido.
+- **Right card "QUÉ SIGUE":** timeline visual de 4 estados con timestamps:
+
+  | Estado | Subtítulo | Cuándo |
+  |---|---|---|
+  | ✓ Recibida | Hace un momento | `{now}` |
+  | ◐ En revisión | **Un humano mira tu perfil** | ~ 1-2 días |
+  | ○ Aprobada · email | Te llega un mail con el link a tu panel | Cuando aprobemos |
+  | ○ Publicás | Subís tu primer evento | Cuando estés |
+
+  El paso "En revisión" está visualmente activo (dot dorado). El copy es **deliberadamente genérico** ("un humano") — sin nombres hardcoded.
+
+- **CTA secundaria:** "Ver agenda mientras tanto" (mantiene al usuario en el sitio público mientras espera).
+- **Footnote:** call-out a Instagram para que no se desconecte del proyecto.
+
+### 1.4 User pending
+
+Aparece cuando el usuario hace login y su cuenta sigue en revisión. Distinto de "solicitud enviada" — esto es para los logins recurrentes que vuelven a ver el estado.
+
+- **Bombilla con glow** (radial gradient + glow del color dorado) — metáfora visual de la peña.
+- **Eyebrow dorado** "CUENTA EN REVISIÓN", h1 *"Tu solicitud está prendida y se está horneando."*
+- **Fecha de aplicación visible** ("Aplicaste como creator el **{date}**").
+- **Escape hatch:** *"¿Pasaron más de 3 días y no tuviste respuesta? Algo se rompió. Escribinos a info@lahuelladelcaminante.de y lo resolvemos."* → reduce ansiedad sin saturar de info.
+
+### 1.5 User blocked
+
+Mismo layout que pending pero rojo y sin animación (es estado terminal).
+
+- Eyebrow `sangre` "ACCESO SUSPENDIDO" — directo, sin eufemismos.
+- H1 explícita: *"Tu cuenta no puede acceder al panel."*
+- **Lista clara de "QUÉ SIGUE FUNCIONANDO":**
+  - Eventos públicos del sitio.
+  - Perfiles de artistas.
+  - NO publicar, editar ni acceder al panel creator.
+
+  Es lo que distingue "bloqueado del panel" de "bloqueado del sitio entero". Sin esta lista el usuario asume lo peor.
+- **CTA primario:** "Escribirnos →". Es la única acción que puede tomar para resolver.
+
+---
+
+## 2. Tokens nuevos
+
+**Ninguno.** Estas pantallas usan el sistema cerrado en v1.1.
+
+---
+
+## 3. Componentes
+
+### 3.1 Nuevos a crear
+
+```
+src/components/auth/AuthShell.tsx           — layout 2-col (form izq, panel atmosférico der)
+                                              acepta `hero` prop para customizar la columna derecha
+src/components/auth/AuthField.tsx           — label + input + hint estilizado a los tokens
+src/components/auth/OAuthButton.tsx         — botón "Continuar con [provider]"
+src/components/auth/OrDivider.tsx           — divisor "O CON EMAIL" entre OAuth y form
+src/components/auth/StatusHero.tsx          — bombilla glow / sello / icono central reutilizable
+                                              variantes: 'pending' (dorado + glow) | 'blocked' (sangre + dash)
+src/components/auth/StepTimeline.tsx        — timeline vertical de 4 estados con dots + connector
+                                              usado en "Solicitud enviada"; reusable si lo necesitamos
+                                              en otra parte del journey
+```
+
+### 3.2 Existentes a modificar
+
+```
+src/components/layout/Header.tsx  — agregar variante "auth" (oculta nav, deja solo BrandLockup)
+                                    O bien: que las páginas /sign-in y /sign-up usen su propio
+                                    layout root sin Header. Decisión del dev.
+```
+
+### 3.3 Glyph de Google
+
+La "G" de Google la dibujamos como **letra en monospace** dentro de un círculo del color del foreground. No usamos la "G" cuatricromática oficial — evita issues de licencia y queda alineada al sistema. Si Better Auth requiere el glyph oficial por TOS, reemplazar `<GoogleGlyph />` por el SVG provisto sin tocar el resto.
+
+---
+
+## 4. Mapeo pantallas → rutas
+
+| Pantalla | Ruta del repo |
+|---|---|
+| Sign-in | `src/app/[locale]/(auth)/sign-in/page.tsx` |
+| Sign-up | `src/app/[locale]/(auth)/sign-up/page.tsx` |
+| Forgot password | `src/app/[locale]/(auth)/forgot-password/page.tsx` *(reusa AuthShell + AuthField; trivial)* |
+| Form `/apply` | `src/app/[locale]/(public)/apply/page.tsx` |
+| Solicitud enviada (estado post-submit) | Mismo archivo que `/apply` con `useState` / server state, **O** ruta separada `/apply/sent`. Decisión del dev en implementación, no necesita ser explícita en el handoff. |
+| User pending | `src/app/[locale]/user-pending/page.tsx` |
+| User blocked | `src/app/[locale]/user-blocked/page.tsx` |
+
+---
+
+## 5. i18n — claves de copy
+
+Para que las tres versiones funcionen sin hardcode, se proponen estas keys en `messages/{es,en,de}.json`:
+
+```jsonc
+{
+  "auth": {
+    "signIn": {
+      "eyebrow": "BIENVENIDO DE VUELTA",
+      "title": "Iniciá sesión.",
+      "subtitle": "¿Sos público? No necesitás cuenta para ver shows. Esto es para artistas y organizadores.",
+      "continueWith": "Continuar con {provider}",
+      "orEmail": "O CON EMAIL",
+      "email": "Email",
+      "password": "Contraseña",
+      "forgot": "¿Olvidaste tu contraseña?",
+      "submit": "Iniciar sesión →",
+      "footer": "¿Primera vez por acá? <createAccount>Crear cuenta</createAccount> o <applyAsArtist>aplicá como artista →</applyAsArtist>"
+    },
+    "signUp": {
+      "eyebrow": "CREAR CUENTA",
+      "title": "Empezá a publicar.",
+      "subtitle": "Crear cuenta es el primer paso. Después aplicás como creator y revisamos tu perfil — suele tomar 1-2 días.",
+      "name": "Nombre",
+      "nameHint": "Cómo te llamamos",
+      "passwordHint": "Mezclá mayúsculas, números y un símbolo.",
+      "acceptTerms": "Acepto los <terms>términos</terms> y la <privacy>política de privacidad</privacy>.",
+      "submit": "Crear cuenta →",
+      "hasAccount": "¿Ya tenés cuenta?",
+      "signInLink": "Iniciar sesión"
+    }
+  },
+  "apply": {
+    "submitted": {
+      "badge": "✓ SOLICITUD RECIBIDA",
+      "title": "Recibimos tu solicitud, <accent>caminante</accent>.",
+      "body": "Un humano la mira en los próximos 1-2 días. Si todo da, te avisamos por mail y desbloqueamos tu panel para que publiques.",
+      "ctaPrimary": "Ver agenda mientras tanto →",
+      "ctaSecondary": "Volver al inicio",
+      "timeline": {
+        "title": "QUÉ SIGUE",
+        "received": "Recibida",
+        "receivedSub": "Hace un momento",
+        "reviewing": "En revisión",
+        "reviewingSub": "Un humano mira tu perfil",
+        "approval": "Aprobada · email",
+        "approvalSub": "Te llega un mail con el link a tu panel",
+        "publishing": "Publicás",
+        "publishingSub": "Subís tu primer evento"
+      },
+      "instagramHint": "Mientras tanto: seguinos en <ig>Instagram @lahuelladelcaminante</ig> — ahí avisamos cada vez que aprobamos un creator nuevo."
+    }
+  },
+  "account": {
+    "pending": {
+      "eyebrow": "CUENTA EN REVISIÓN",
+      "title": "Tu solicitud está prendida y se está horneando.",
+      "body": "Aplicaste como creator el <strong>{date}</strong>. La revisamos en orden de llegada — solemos tardar 1-2 días hábiles. Te avisamos por mail apenas se apruebe.",
+      "ctaPrimary": "Ver agenda pública",
+      "ctaSecondary": "Cerrar sesión",
+      "escapeHatch": "¿Pasaron más de 3 días y no tuviste respuesta? Algo se rompió. Escribinos a <email>info@lahuelladelcaminante.de</email> y lo resolvemos."
+    },
+    "blocked": {
+      "eyebrow": "ACCESO SUSPENDIDO",
+      "title": "Tu cuenta no puede acceder al panel.",
+      "body": "Esto puede pasar por varias razones — incumplimiento de las normas de la comunidad, contenido reportado, o un error nuestro. Si creés que es un error, hablamos.",
+      "stillWorksTitle": "QUÉ SIGUE FUNCIONANDO",
+      "stillWorks": [
+        "Podés ver todos los eventos públicos del sitio.",
+        "Podés seguir consultando perfiles de artistas.",
+        "No podés publicar, editar ni acceder al panel creator."
+      ],
+      "ctaContact": "Escribirnos →",
+      "ctaLogout": "Cerrar sesión"
+    }
+  }
+}
+```
+
+Los wrappers `<accent>…</accent>`, `<strong>…</strong>`, `<terms>…</terms>`, `<createAccount>…</createAccount>` los resuelve **next-intl rich text** — esto deja envolver palabras clave en color o linkearlas sin partir la oración por idioma.
+
+`{date}` en `account.pending.body` se interpola desde el server con el formato local correspondiente (es: `13 de mayo` / en: `May 13` / de: `13. Mai`).
+
+---
+
+## 6. Notas de implementación
+
+1. **Bombilla en `UserPendingScreen`** — radial gradient + glow del color dorado vía `box-shadow`. Visualmente importante: es lo que diferencia "estás esperando" de "fracasaste". Si después se quiere añadir animación sutil (slight pulse en el glow), está bien — fuera del MVP.
+2. **El sello rojo en `UserBlockedScreen`** — `—` (em-dash) dentro de un círculo grande con borde sangre. Intencionalmente austero, sin iconos de alarma ni emoji. Es estado terminal, no error técnico.
+3. **`AppSubmittedScreen` no es un "exitoso pequeño con un check verde y un botón".** Es el touchpoint emocional del journey de aplicación. Por eso el h1 ocupa medio viewport y el copy es afectivo. Mantener.
+4. **El timeline de "QUÉ SIGUE"** es un componente (`StepTimeline.tsx`). Si después aparece en el dashboard del creator pre-aprobación, reusarlo — no duplicar.
+5. **Sin checkbox "Mantener sesión".** La sesión es transparente — Better Auth la persiste por su cuenta. Si en algún momento se quiere exponer "olvidarme en este dispositivo", ese es un setting distinto y va en perfil, no en sign-in.
+6. **El copy nunca menciona admins por nombre.** "Un humano", "el equipo", "nosotros" — no "Antonio". Esto es para que la copy sobreviva cambios de equipo y reduzca presión personalizada.
+
+---
+
+## 7. Responsive
+
+| Pantalla | Mobile (< 768) | Desktop |
+|---|---|---|
+| Sign-in / Sign-up | Single column, panel atmosférico oculto, BrandLockup arriba, form full-bleed con padding `16px` lateral | 7:5 split, ambos paneles visibles |
+| Solicitud enviada | h1 a 36px, timeline card debajo en el mismo scroll, CTA primario sticky bottom | 1:1 split: hero a la izquierda, timeline card al costado |
+| User pending / blocked | Hero icon arriba, copy + CTA debajo, contenido centrado, max-width 100% con padding `24px` | Misma arquitectura, max-width 560px centrado |
+
+---
+
+## 8. Trabajo restante después de v2
+
+A implementar por el equipo sin diseño dedicado, siguiendo tokens + patrones de v1.1 + v2:
+
+- Formularios de creación/edición de evento y artista (dashboard creator)
+- Formulario público de `/apply` (el form mismo — la pantalla de "submitted" sí está diseñada)
+- Panel admin completo (gestión de usuarios, vista global de eventos, cola de aplicaciones)
+- Forgot password (reusa `AuthShell` + `AuthField` — trivial)
+- Páginas legales (cuando esté redactado el contenido)
+
+Con esto cerramos el paquete de diseño. Listos para implementación con Claude Code en PRs incrementales.
+
+— Claude Design · 2026-05-15 · v2 (final)


### PR DESCRIPTION
## Summary

Agrega los outputs de Claude Design al repo, en `docs/design/`:

- `DESIGN_HANDOFF_OUTPUT.md` — primer entregable de Claude Design (424 líneas).
- `DESIGN_HANDOFF_OUTPUT_v2.md` — segunda iteración (272 líneas).

Complementa al `DESIGN_HANDOFF_INPUT.md` mergeado en PR #6: aquel era el inventario técnico que le pasamos a Claude Design; estos son las propuestas que devolvió.

## Por qué los dos archivos

Mantengo `v1` y `v2` por separado para preservar la trazabilidad del proceso de diseño (qué cambió entre iteraciones, qué se descartó). Si en el futuro decidimos consolidar en un único output canónico, lo hacemos en un PR aparte.

## No incluye

- Cambios en código de la app.
- Implementación de ninguna propuesta del diseño.
- Información sensible.

## Test plan

- [ ] Revisar que ambos archivos rendericen bien en GitHub.
- [ ] Adjuntar al brief de implementación cuando se arranque el rediseño visual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design handoff v1 describing visual direction, typography, color roles, responsive rules, component inventory, token architecture, and implementation guidelines for the redesign.
  * Added design handoff v2 with detailed auth/account screen specs, layout/copy rules, state-specific UX patterns, component requirements, route mappings, and i18n guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->