### PR TITLE
fix: pre-redesign bugfixes (requireRole role + getEventsByUser soft-delete filter)

### DIFF
--- a/src/app/[locale]/(admin)/layout.tsx
+++ b/src/app/[locale]/(admin)/layout.tsx
@@ -11,7 +11,7 @@ export default async function AdminLayout({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params
-  const user = await requireRole("ADMIN", locale)
+  const user = await requireRole("admin", locale)
 
   return (
     <>

--- a/src/app/[locale]/(protected)/dashboard/artists/create/page.tsx
+++ b/src/app/[locale]/(protected)/dashboard/artists/create/page.tsx
@@ -8,7 +8,7 @@ export default async function CreateArtistPage({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params
-  await requireRole("ARTIST", locale)
+  await requireRole("creator", locale)
   const tForms = await getTranslations({ locale, namespace: "forms" })
 
   return (

--- a/src/app/[locale]/(protected)/dashboard/events/create/page.tsx
+++ b/src/app/[locale]/(protected)/dashboard/events/create/page.tsx
@@ -9,7 +9,7 @@ export default async function CreateEventPage({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params
-  const user = await requireRole("ARTIST", locale)
+  const user = await requireRole("creator", locale)
   const tForms = await getTranslations({ locale, namespace: "forms" })
   const artists = await getArtistsByUser(user.id)
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -5,6 +5,15 @@ import { headers } from "next/headers"
 import { redirect } from "next/navigation"
 import { prisma } from "@/lib/prisma"
 
+/**
+ * Roles canónicos del sistema. Alineado con cómo se setea `user.role`
+ * en `src/lib/auth.ts` (`"creator"`) y con el enum del endpoint de cambio
+ * de rol en `src/app/api/users/[id]/role/route.ts` (`["user", "creator", "admin"]`).
+ *
+ * Importarlo desde otros archivos en vez de redefinir strings o enums sueltos.
+ */
+export type Role = "user" | "creator" | "admin"
+
 export function isAdmin(role?: string | null) {
   return role?.toLowerCase() === "admin"
 }
@@ -39,11 +48,10 @@ export async function requireActive(locale = "es") {
   return { user, profile }
 }
 
-export async function requireRole(role: "ADMIN" | "ARTIST", locale = "es") {
+export async function requireRole(role: Exclude<Role, "user">, locale = "es") {
   const { user } = await requireActive(locale)
   const r = user.role?.toLowerCase()
-  const required = role.toLowerCase()
-  if (r !== required && r !== "admin") {
+  if (r !== role && r !== "admin") {
     redirect(`/${locale}/dashboard`)
   }
   return user

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -224,7 +224,7 @@ export async function getEventsByArtist(artistId: string): Promise<EventSummary[
 
 export async function getEventsByUser(userId: string): Promise<EventSummary[]> {
   const events = await prisma.event.findMany({
-    where: { createdById: userId },
+    where: { createdById: userId, isDeleted: false },
     include: eventInclude,
     orderBy: { createdAt: "desc" },
   })


### PR DESCRIPTION
## Summary

Resuelve los **dos hallazgos ALTO** del review de arquitectura sobre el CRUD de eventos. Se hacen **antes del rediseño visual** para tener el código base sano: el rediseño va a tocar exactamente estos archivos y conviene partir de un estado correcto.

Cero cambios de UI, i18n, schema, agentes o configuración. Solo lógica de auth y query.

## Bug 1 — `requireRole("ARTIST")` rompía la creación para creators

**Antes:** `requireRole(role: "ADMIN" | "ARTIST")` comparaba `.toLowerCase()` contra `user.role.toLowerCase()`. Los roles reales del sistema son `user`/`creator`/`admin` (no `artist`), así que un creator que entraba a `/dashboard/events/create` o `/dashboard/artists/create` caía en el `redirect("/dashboard")` y la página quedaba inaccesible salvo para admins.

**Ahora:**

- Se exporta `type Role = "user" | "creator" | "admin"` desde `services/auth.ts` con JSDoc apuntando a las dos fuentes de verdad del rol (`lib/auth.ts` y el endpoint de cambio de rol que ya tenía `z.enum(["user", "creator", "admin"])`).
- `requireRole` ahora acepta `Exclude<Role, "user">` (= `"creator" | "admin"`). Los 3 call sites pasan strings canónicos en minúsculas.

**Archivos tocados:**

- `src/services/auth.ts` (tipo + firma del helper)
- `src/app/[locale]/(protected)/dashboard/artists/create/page.tsx` (`"ARTIST"` → `"creator"`)
- `src/app/[locale]/(protected)/dashboard/events/create/page.tsx` (`"ARTIST"` → `"creator"`)
- `src/app/[locale]/(admin)/layout.tsx` (`"ADMIN"` → `"admin"`, necesario por el nuevo tipado estricto)

## Bug 2 — `getEventsByUser` no filtraba soft-deleted

**Antes:** `where: { createdById: userId }` sin `isDeleted: false`. Resultado: el dashboard del creator (`/dashboard/events`) mostraba eventos ya borrados con botones "Editar" (rompía: el formulario sí filtra y devuelve 404) y "Borrar" (volvía a soft-deletar lo borrado).

**Ahora:** `where: { createdById: userId, isDeleted: false }`. `getDeletedEvents` queda intacto — sigue siendo la única función que ve soft-deleted, por diseño.

**Archivos tocados:**

- `src/services/events.ts` (1 línea)

## Comportamiento esperado post-merge

- Un usuario con rol `creator` puede entrar a `/dashboard/events/create` y `/dashboard/artists/create` sin ser redirigido. ✅
- Un usuario con rol `admin` sigue pudiendo entrar a todas las pantallas anteriores y a `/admin/*`. ✅
- Un usuario con rol `user` (o sin rol) sigue siendo redirigido al `/dashboard`. ✅
- El dashboard del creator (`/dashboard/events`) ya no muestra eventos borrados. ✅

## Review interno (paso 3 del flujo del repo)

Pasé el diff completo por el agente `architecture-reviewer`. Resultado:

- 0 hallazgos ALTO nuevos
- 0 hallazgos MEDIO nuevos
- 2 hallazgos BAJO, ambos explícitamente marcados como "no bloqueante" y "mejora futura":
  1. Considerar alias dedicado `RequirableRole` en vez de `Exclude<Role, "user">` si se prevén más roles.
  2. Narrowing aguas arriba de `user.role` (que sigue siendo `string | null` desde Better Auth) con un type guard contra `Role`.

Ambos quedan para abordar en su propio PR si decidimos hacerlo.

## Fuera de alcance

- Otros hallazgos del review (imágenes huérfanas de `restoreEvent`, atomicidad de `updateEvent`, índices de Prisma, dedup con admin, server actions, refactor de `EventForm`). Van a sus propios PRs.
- Cambios en el modelo de Prisma.
- Cualquier cosa cosmética / de rediseño visual.

## Test plan

- [ ] Logearse como `creator` y verificar que `/dashboard/events/create` y `/dashboard/artists/create` se renderizan.
- [ ] Logearse como `admin` y verificar `/admin/*` sigue funcionando.
- [ ] Logearse como `user` y verificar que las pantallas protegidas redirigen a `/dashboard`.
- [ ] Borrar un evento desde `/dashboard/events`, confirmar que desaparece del listado.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleted events could appear in user event lists.

* **Improvements**
  * Standardized role-based authorization system for dashboard features to ensure consistent access control across admin, creator, and user roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->