### PR TITLE
feat: design tokens + fonts + forced dark mode (base for redesign)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { Geist } from "next/font/google"
+import { Bricolage_Grotesque, Hanken_Grotesk, JetBrains_Mono } from "next/font/google"
 import { NextIntlClientProvider } from "next-intl"
 import { getMessages } from "next-intl/server"
 import { notFound } from "next/navigation"
@@ -7,7 +7,26 @@ import { routing } from "@/i18n/routing"
 import { Toaster } from "@/components/ui/sonner"
 import "../globals.css"
 
-const geist = Geist({ subsets: ["latin"], variable: "--font-geist" })
+const display = Bricolage_Grotesque({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
+  variable: "--font-display",
+  display: "swap",
+})
+
+const body = Hanken_Grotesk({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-body",
+  display: "swap",
+})
+
+const mono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-mono",
+  display: "swap",
+})
 
 export const metadata: Metadata = {
   title: "La Huella del Caminante — Música Latinoamericana en Berlín",
@@ -30,8 +49,11 @@ export default async function LocaleLayout({
   const messages = await getMessages()
 
   return (
-    <html lang={locale} className={`${geist.variable} h-full antialiased`}>
-      <body className="min-h-full flex flex-col bg-background text-foreground">
+    <html
+      lang={locale}
+      className={`dark ${display.variable} ${body.variable} ${mono.variable} h-full antialiased`}
+    >
+      <body className="min-h-full flex flex-col bg-bg-page text-fg-primary">
         <NextIntlClientProvider messages={messages}>
           {children}
           <Toaster />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,111 +1,140 @@
 @import "tailwindcss";
-@import "tw-animate-css";
-
-@custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 2px);
-  --radius-md: calc(var(--radius) - 1px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* ── Color · surfaces ─────────────────────────────────────── */
+  --color-bg-page: #15100B;
+  --color-bg-surface: #1C150F;
+  --color-bg-surface-2: #241B13;
+  --color-bg-surface-3: #2E2419;
+  --color-border: #332618;
+  --color-border-hi: #4A3826;
+
+  /* ── Color · text ─────────────────────────────────────────── */
+  --color-fg-primary: #F4ECE0;
+  --color-fg-secondary: #A89889;
+  --color-fg-tertiary: #6E6053;
+
+  /* ── Color · accents (semantic, role-bound) ───────────────── */
+  --color-brand: #D43029;      /* sangre */
+  --color-brand-dim: #7E1B16;
+  --color-on-brand: #FFE6E3;
+
+  --color-editorial: #E5A93B;  /* dorado */
+  --color-editorial-dim: #7C5A1A;
+  --color-on-editorial: #1F1407;
+
+  --color-creator: #E4458A;    /* fucsia */
+  --color-creator-dim: #7B1F46;
+  --color-on-creator: #FFE7F0;
+
+  /* ── Color · status ───────────────────────────────────────── */
+  --color-status-ok: #8DB87A;
+  --color-status-warn: #E5A93B;
+  --color-status-danger: #D43029;
+
+  /* ── Type · families (variables wired up via next/font in layout) ─ */
+  --font-display: var(--font-display), system-ui, sans-serif;
+  --font-body: var(--font-body), system-ui, sans-serif;
+  --font-mono: var(--font-mono), ui-monospace, "SF Mono", monospace;
+
+  /* ── Type · text utilities (Tailwind v4 text-*) ───────────── */
+  --text-display-xl: 96px;
+  --text-display-xl--line-height: 0.92;
+  --text-display-xl--letter-spacing: -0.04em;
+  --text-display-xl--font-weight: 800;
+
+  --text-display-l: 72px;
+  --text-display-l--line-height: 0.94;
+  --text-display-l--letter-spacing: -0.035em;
+  --text-display-l--font-weight: 800;
+
+  --text-display-m: 56px;
+  --text-display-m--line-height: 0.98;
+  --text-display-m--letter-spacing: -0.03em;
+  --text-display-m--font-weight: 700;
+
+  --text-heading-l: 40px;
+  --text-heading-l--line-height: 1.05;
+  --text-heading-l--letter-spacing: -0.025em;
+  --text-heading-l--font-weight: 700;
+
+  --text-heading-m: 28px;
+  --text-heading-m--line-height: 1.15;
+  --text-heading-m--letter-spacing: -0.015em;
+  --text-heading-m--font-weight: 700;
+
+  --text-heading-s: 20px;
+  --text-heading-s--line-height: 1.25;
+  --text-heading-s--letter-spacing: -0.01em;
+  --text-heading-s--font-weight: 600;
+
+  --text-body-l: 17px;
+  --text-body-l--line-height: 1.5;
+
+  --text-body: 15px;
+  --text-body--line-height: 1.5;
+
+  --text-body-s: 13px;
+  --text-body-s--line-height: 1.45;
+
+  --text-caption: 12px;
+  --text-caption--line-height: 1.35;
+  --text-caption--letter-spacing: 0.02em;
+  --text-caption--font-weight: 500;
+
+  --text-eyebrow: 11px;
+  --text-eyebrow--line-height: 1.2;
+  --text-eyebrow--letter-spacing: 0.16em;
+  --text-eyebrow--font-weight: 600;
+
+  --text-mono: 12px;
+  --text-mono--line-height: 1.3;
+  --text-mono--letter-spacing: 0.02em;
+  --text-mono--font-weight: 500;
+
+  /* ── Spacing (base 4) ─────────────────────────────────────── */
+  --spacing-xs: 4px;
+  --spacing-s: 8px;
+  --spacing-m: 16px;
+  --spacing-l: 24px;
+  --spacing-xl: 40px;
+  --spacing-2xl: 64px;
+  --spacing-3xl: 96px;
+
+  /* ── Radius ───────────────────────────────────────────────── */
+  --radius-s: 4px;
+  --radius-m: 8px;
+  --radius-l: 12px;
+  --radius-xl: 18px;
+  --radius-pill: 9999px;
 }
 
+/* Layout primitives no semánticos quedan fuera de @theme:
+   ancho máximo, header height, gutter del contenedor. */
 :root {
-  --radius: 0.625rem;
-
-  --background: oklch(0.985 0.003 60);
-  --foreground: oklch(0.15 0.02 30);
-
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.15 0.02 30);
-
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.15 0.02 30);
-
-  /* Crimson tango */
-  --primary: oklch(0.50 0.22 20);
-  --primary-foreground: oklch(0.99 0 0);
-
-  --secondary: oklch(0.94 0.02 60);
-  --secondary-foreground: oklch(0.20 0.02 30);
-
-  --muted: oklch(0.95 0.01 60);
-  --muted-foreground: oklch(0.50 0.02 30);
-
-  /* Warm gold */
-  --accent: oklch(0.90 0.06 75);
-  --accent-foreground: oklch(0.20 0.02 30);
-
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.98 0 0);
-
-  --border: oklch(0.90 0.01 60);
-  --input: oklch(0.90 0.01 60);
-  --ring: oklch(0.50 0.22 20);
+  --layout-max-w: 1280px;
+  --layout-gutter: 32px;
+  --layout-header-h: 72px;
 }
 
-.dark {
-  --background: oklch(0.12 0.015 30);
-  --foreground: oklch(0.94 0.01 60);
-
-  --card: oklch(0.17 0.018 30);
-  --card-foreground: oklch(0.94 0.01 60);
-
-  --popover: oklch(0.17 0.018 30);
-  --popover-foreground: oklch(0.94 0.01 60);
-
-  --primary: oklch(0.62 0.22 20);
-  --primary-foreground: oklch(0.99 0 0);
-
-  --secondary: oklch(0.23 0.02 30);
-  --secondary-foreground: oklch(0.94 0.01 60);
-
-  --muted: oklch(0.23 0.02 30);
-  --muted-foreground: oklch(0.62 0.02 30);
-
-  --accent: oklch(0.28 0.04 60);
-  --accent-foreground: oklch(0.94 0.01 60);
-
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.98 0 0);
-
-  --border: oklch(1 0 0 / 8%);
-  --input: oklch(1 0 0 / 10%);
-  --ring: oklch(0.62 0.22 20);
+/* Dark warm forzado en body. No hay toggle de tema. */
+html,
+body {
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
+  font-family: var(--font-body);
 }
 
-@layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground antialiased;
-  }
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 @layer utilities {
   .scrollbar-none {
     scrollbar-width: none;
-    &::-webkit-scrollbar { display: none; }
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,11 @@
 @import "tailwindcss";
+@import "tw-animate-css";
+
+/* `class="dark"` en <html> activa modificadores `dark:*` de Tailwind.
+   Necesario porque el default de Tailwind v4 mapea `dark:` a `prefers-color-scheme`,
+   no a una clase ancestor. Mientras los componentes shadcn aún tengan modificadores
+   `dark:*`, mantener este variant. */
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
   /* ── Color · surfaces ─────────────────────────────────────── */
@@ -32,7 +39,15 @@
   --color-status-warn: #E5A93B;
   --color-status-danger: #D43029;
 
-  /* ── Type · families (variables wired up via next/font in layout) ─ */
+  /* ── Type · families ──────────────────────────────────────
+     Las variables `--font-display`, `--font-body`, `--font-mono` las
+     setea next/font/google en el <html> (ver layout.tsx). La
+     auto-referencia adentro de @theme inline funciona porque Tailwind
+     v4 inlinea el valor en cada utility y `var()` resuelve contra el
+     cascade (donde <html> shadowea :root). El cycle a nivel :root es
+     inerte. Si en el futuro se quita el `inline`, renombrar las
+     variables source (ej. `--font-display-source`) para evitar
+     ambigüedad. */
   --font-display: var(--font-display), system-ui, sans-serif;
   --font-body: var(--font-body), system-ui, sans-serif;
   --font-mono: var(--font-mono), ui-monospace, "SF Mono", monospace;
@@ -107,11 +122,46 @@
   --radius-l: 12px;
   --radius-xl: 18px;
   --radius-pill: 9999px;
+
+  /* ── Compatibilidad shadcn (temporal) ──────────────────────
+     Los componentes shadcn ya instalados (button, card, dialog,
+     dropdown-menu, input, select, table, tabs, badge, textarea,
+     sonner) consumen utilities `bg-background`, `text-foreground`,
+     `bg-primary`, `bg-card`, etc. Hasta que los próximos PRs del
+     rediseño los reemplacen por componentes custom de §4.1 del
+     handoff, mapeamos los tokens viejos a sus equivalentes nuevos
+     para que las pantallas no queden sin color de fondo, borde, ni
+     texto. Esto pisa la regla "sangre una vez por pantalla" del
+     handoff §1.3 mientras dure este compatibility layer — es
+     deuda explícita declarada en la épica. */
+  --color-background: var(--color-bg-page);
+  --color-foreground: var(--color-fg-primary);
+  --color-card: var(--color-bg-surface);
+  --color-card-foreground: var(--color-fg-primary);
+  --color-popover: var(--color-bg-surface-2);
+  --color-popover-foreground: var(--color-fg-primary);
+  --color-primary: var(--color-brand);
+  --color-primary-foreground: var(--color-on-brand);
+  --color-secondary: var(--color-bg-surface-2);
+  --color-secondary-foreground: var(--color-fg-primary);
+  --color-muted: var(--color-bg-surface-2);
+  --color-muted-foreground: var(--color-fg-secondary);
+  --color-accent: var(--color-bg-surface-3);
+  --color-accent-foreground: var(--color-fg-primary);
+  --color-destructive: var(--color-status-danger);
+  --color-destructive-foreground: var(--color-on-brand);
+  --color-input: var(--color-border);
+  --color-ring: var(--color-brand);
 }
 
-/* Layout primitives no semánticos quedan fuera de @theme:
-   ancho máximo, header height, gutter del contenedor. */
+/* Variables sueltas que no van en @theme:
+   - `--radius` legacy de shadcn: algunos componentes la leen via var()
+     directo en lugar de utility. La dejamos apuntando al radius-l del
+     sistema nuevo (12px, vs 10px del legacy).
+   - Layout primitives no semánticos: ancho máximo, header height,
+     gutter del contenedor. */
 :root {
+  --radius: var(--radius-l);
   --layout-max-w: 1280px;
   --layout-gutter: 32px;
   --layout-header-h: 72px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -154,14 +154,26 @@
   --color-ring: var(--color-brand);
 }
 
-/* Variables sueltas que no van en @theme:
-   - `--radius` legacy de shadcn: algunos componentes la leen via var()
-     directo en lugar de utility. La dejamos apuntando al radius-l del
-     sistema nuevo (12px, vs 10px del legacy).
-   - Layout primitives no semánticos: ancho máximo, header height,
-     gutter del contenedor. */
+/* Variables sueltas en :root (no en @theme).
+   Con Tailwind v4 `@theme inline`, los tokens del bloque @theme se
+   inlinean en las utilities pero no se emiten como custom properties
+   al `:root`. Cualquier consumidor que use `var()` directo desde
+   `style={}` o CSS arbitrario necesita la variable acá.
+
+   Hoy los consumidores legacy son:
+   - `components/ui/sonner.tsx` usa `var(--popover)`, `var(--popover-foreground)`,
+     `var(--border)`, `var(--radius)` en su style inline.
+
+   Mapeamos cada uno al token nuevo del sistema. Se va con sonner cuando
+   sea reemplazado por el toaster del rediseño. */
 :root {
+  --popover: var(--color-bg-surface-2);
+  --popover-foreground: var(--color-fg-primary);
+  --border: var(--color-border);
   --radius: var(--radius-l);
+
+  /* Layout primitives no semánticos: ancho máximo, header height,
+     gutter del contenedor. */
   --layout-max-w: 1280px;
   --layout-gutter: 32px;
   --layout-header-h: 72px;

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,3 +1,7 @@
+// @deprecated — dark mode is forced globally since the redesign base PR.
+// This component is no longer rendered anywhere in the app. Kept for reference
+// until the cleanup PR removes it (and possibly `next-themes` from package.json
+// once `components/ui/sonner.tsx` stops importing `useTheme`).
 "use client"
 
 import { useEffect, useState } from "react"


### PR DESCRIPTION
## Summary

PR **base** del rediseño visual. **No toca ninguna pantalla todavía.** Establece el sistema sobre el que se van a construir los próximos PRs (Header/Footer, EventCard, Home, etc.).

Tres cambios:

1. **Tokens nuevos en `globals.css`** con Tailwind v4 `@theme inline`: paleta sangre/dorado/fucsia sobre dark warm, escala tipográfica `display-xl..mono`, spacing base 4, radius escalar incluido `pill`. Fuente canónica: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §2 (Claude Design v1.1, viene en PR #7).
2. **Tres fuentes nuevas** cargadas con `next/font/google` y subset `latin`: Bricolage Grotesque (display), Hanken Grotesk (body), JetBrains Mono (mono). Geist queda fuera.
3. **Dark mode forzado**: el `<html>` tiene `class="dark"` siempre. Se conserva el `@custom-variant dark` para que esa clase active las variantes `dark:*` de los componentes shadcn aún presentes. El `ThemeToggle` queda marcado `@deprecated` (no se renderizaba en ningún lado, lo confirma `grep`).

## Compatibilidad shadcn (deuda explícita)

Los componentes shadcn ya instalados (`button`, `card`, `dialog`, `dropdown-menu`, `input`, `select`, `sonner`, `table`, `tabs`, `badge`, `textarea`) consumen utilities como `bg-background`, `text-foreground`, `bg-primary`, `bg-card`, `text-muted-foreground`, etc. y algunas vars via `style={}` (`sonner.tsx` usa `var(--popover)`, `var(--popover-foreground)`, `var(--border)`, `var(--radius)`).

Para que las pantallas no queden sin color de fondo / bordes / texto hasta que los próximos PRs reemplacen los componentes shadcn por los custom de `§4.1` del handoff, este PR incluye un **compat layer** en `globals.css`:

- Tokens shadcn → tokens nuevos vía `@theme inline` (`--color-primary → --color-brand`, `--color-card → --color-bg-surface`, `--color-muted-foreground → --color-fg-secondary`, etc.).
- Vars legacy consumidas via `var()` directo → mapeadas también en `:root` (`--popover`, `--popover-foreground`, `--border`, `--radius`).

**Trade-off conocido:** el mapeo `primary → brand` (sangre) hace que decoraciones como `bg-primary/12` aparezcan como sangre desaturada en algunas pantallas, pisando temporalmente la regla "sangre una vez por pantalla" del handoff §1.3. Se resuelve cuando los componentes que las usan se reemplacen.

## Review interno (paso 3 del flujo)

Pasé el diff por el `architecture-reviewer` **dos veces**:

**Pasada 1** (sobre el commit inicial `72cf7ed`): 4 hallazgos — 2 ALTO, 1 MEDIO, 1 BAJO.
- ALTO 1: pérdida del `@custom-variant dark` dejaba los modificadores `dark:*` de shadcn solo respondiendo a `prefers-color-scheme` (dark mode no era forzado para usuarios con SO light).
- ALTO 2: eliminación de tokens shadcn dejaba sin valor a utilities aún consumidas en home, listados, dashboard, sonner. No era "desalineación visual", era ausencia de estilo.
- MEDIO: eliminación de `@import "tw-animate-css"` dejaba huérfanas las animaciones de Dialog/DropdownMenu/Select (el paquete sigue en `package.json`).
- BAJO: auto-referencia de `--font-display` en `@theme inline`. Funcionalmente OK por cómo Tailwind v4 inlinea valores, pero amerita comentario explicativo.

Aplicado en commit `a8519f8`: restauro `@custom-variant dark`, restauro `@import "tw-animate-css"`, agrego compat layer shadcn, dejo comentario sobre la auto-referencia.

**Pasada 2** (sobre `a8519f8`): los 3 hallazgos previos quedan cerrados; 1 hallazgo nuevo ALTO — el compat layer cubría utilities (`bg-primary`, etc.) pero no las custom properties que `sonner.tsx` consume via `var()` directo desde `style={}`.

Aplicado en commit `2a287ab`: expongo las 3 vars legacy (`--popover`, `--popover-foreground`, `--border`) al `:root`, igual que ya se hacía con `--radius`.

Después de los dos fixes el agente da por cerrado el alcance del review.

## Archivos tocados

- `src/app/globals.css` — reescritura completa (los 4 commits acumulados convergen acá).
- `src/app/[locale]/layout.tsx` — quita Geist, carga las 3 fuentes nuevas, agrega `class="dark"` y las variables de fuente al `<html>`.
- `src/components/layout/ThemeToggle.tsx` — solo comentario `@deprecated`. Componente no renderizado en ningún lado del repo.

3 archivos. Cero cambios en pantallas, componentes de dominio, schema, i18n, auth, middleware. Cero deps nuevas en `package.json`.

## Verificación manual sugerida post-merge

1. `npm run dev` levanta sin errores nuevos.
2. `npm run build` ejecuta sin errores nuevos.
3. Abrir la home con SO en light y luego con SO en dark — debe verse siempre dark.
4. Inspeccionar `<html>` → debe tener `dark` + las 3 clases de fuente (`__Bricolage_Grotesque_xxx`, etc.).
5. Inspeccionar utilities Tailwind nuevas con DevTools: `bg-bg-page`, `text-fg-primary`, `text-display-xl`, `font-display`, `p-m`, `rounded-l` deben resolver a los valores del handoff §2.
6. Algunos componentes shadcn pueden verse "rojizos" donde antes eran neutros (efecto del compat layer mapeando `primary → brand`). Es esperado — se resuelve cuando los reemplacemos en PRs siguientes.

## Test plan

- [ ] CI / CodeRabbit pasa sin errores.
- [ ] `npm run dev` y `npm run build` localmente sin errores nuevos.
- [ ] Smoke visual: home, listado de eventos, detalle de evento, dashboard, sonner toast.
- [ ] Validar que NO se ve light en ningún caso (cambiar el SO theme para probar).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated application typography with new Google Fonts
  * Refreshed color palette and visual theme
  * Dark mode is now permanently enabled; theme toggle functionality has been deprecated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/9)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->