### PR TITLE
feat: design system components (10 new components, no integration yet)

### DIFF
--- a/src/components/brand/BrandLockup.tsx
+++ b/src/components/brand/BrandLockup.tsx
@@ -1,0 +1,71 @@
+/**
+ * BrandLockup — BrandMark + texto "La Huella / del Caminante".
+ *
+ * Versiones:
+ *  - `horizontal` (default): mark size `m` a la izquierda, dos líneas a la derecha.
+ *  - `vertical`: mark size `l` arriba centrado, dos líneas debajo centradas.
+ *
+ * Si recibe `href`, el lockup entero se renderiza como `<Link>`. Si no, como
+ * `<div>`. Esto le permite servir tanto como logo clickeable en Header como
+ * para usos no-interactivos (footer, splash, emails).
+ *
+ * El texto "La Huella / del Caminante" está hardcodeado porque es el nombre
+ * del producto y no se traduce. La segunda línea siempre va en `text-brand`.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import BrandMark from "./BrandMark"
+
+export interface BrandLockupProps {
+  orientation?: "horizontal" | "vertical"
+  href?: string
+  className?: string
+}
+
+export default function BrandLockup({
+  orientation = "horizontal",
+  href,
+  className,
+}: BrandLockupProps) {
+  const isHorizontal = orientation === "horizontal"
+
+  const content = (
+    <span
+      className={cn(
+        "inline-flex font-display font-bold leading-[0.95] tracking-tight",
+        isHorizontal
+          ? "flex-row items-center gap-m"
+          : "flex-col items-center gap-s text-center",
+        className
+      )}
+    >
+      <BrandMark size={isHorizontal ? "m" : "l"} />
+      <span
+        className={cn(
+          "flex flex-col",
+          isHorizontal ? "text-body-l" : "text-heading-m"
+        )}
+      >
+        <span>La Huella</span>
+        <span className="text-brand">del Caminante</span>
+      </span>
+    </span>
+  )
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="inline-flex shrink-0 group"
+        aria-label="La Huella del Caminante — inicio"
+      >
+        {content}
+      </Link>
+    )
+  }
+
+  return content
+}

--- a/src/components/brand/BrandLockup.tsx
+++ b/src/components/brand/BrandLockup.tsx
@@ -5,9 +5,13 @@
  *  - `horizontal` (default): mark size `m` a la izquierda, dos líneas a la derecha.
  *  - `vertical`: mark size `l` arriba centrado, dos líneas debajo centradas.
  *
- * Si recibe `href`, el lockup entero se renderiza como `<Link>`. Si no, como
- * `<div>`. Esto le permite servir tanto como logo clickeable en Header como
- * para usos no-interactivos (footer, splash, emails).
+ * Si recibe `href`, el lockup entero se renderiza como `<Link>` con
+ * `aria-label` de marca. Si no, como `<span>` no interactivo. En ambos casos
+ * `className` se aplica al elemento root (Link o span) para que el caller
+ * pueda controlar márgenes/layout desde afuera.
+ *
+ * El `BrandMark` interno se renderiza con `decorative` para que el lector
+ * de pantalla no anuncie dos veces el nombre del producto.
  *
  * El texto "La Huella / del Caminante" está hardcodeado porque es el nombre
  * del producto y no se traduce. La segunda línea siempre va en `text-brand`.
@@ -32,17 +36,17 @@ export default function BrandLockup({
 }: BrandLockupProps) {
   const isHorizontal = orientation === "horizontal"
 
-  const content = (
-    <span
-      className={cn(
-        "inline-flex font-display font-bold leading-[0.95] tracking-tight",
-        isHorizontal
-          ? "flex-row items-center gap-m"
-          : "flex-col items-center gap-s text-center",
-        className
-      )}
-    >
-      <BrandMark size={isHorizontal ? "m" : "l"} />
+  const rootClass = cn(
+    "inline-flex shrink-0 font-display font-bold leading-[0.95] tracking-tight",
+    isHorizontal
+      ? "flex-row items-center gap-m"
+      : "flex-col items-center gap-s text-center",
+    className
+  )
+
+  const inner = (
+    <>
+      <BrandMark size={isHorizontal ? "m" : "l"} decorative />
       <span
         className={cn(
           "flex flex-col",
@@ -52,20 +56,20 @@ export default function BrandLockup({
         <span>La Huella</span>
         <span className="text-brand">del Caminante</span>
       </span>
-    </span>
+    </>
   )
 
   if (href) {
     return (
       <Link
         href={href}
-        className="inline-flex shrink-0 group"
         aria-label="La Huella del Caminante — inicio"
+        className={rootClass}
       >
-        {content}
+        {inner}
       </Link>
     )
   }
 
-  return content
+  return <span className={rootClass}>{inner}</span>
 }

--- a/src/components/brand/BrandMark.tsx
+++ b/src/components/brand/BrandMark.tsx
@@ -1,0 +1,87 @@
+/**
+ * BrandMark — ícono cuadrado de la marca (huella estilizada sobre fondo sangre).
+ *
+ * Variantes:
+ *  - `default` (sangre, huella crema): uso primario, header, lockup.
+ *  - `muted` (surface-2, huella crema): contextos secundarios o sobre fondos
+ *    ya marcados (ej. dentro de cards con accent propio).
+ *
+ * Tamaños s/m/l mapean a 24px/40px/72px.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import { cn } from "@/lib/utils"
+import type { Size } from "@/components/types"
+
+export interface BrandMarkProps {
+  size?: Size
+  variant?: "default" | "muted"
+  className?: string
+}
+
+const SIZE_PX: Record<Size, number> = {
+  s: 24,
+  m: 40,
+  l: 72,
+}
+
+const SIZE_RADIUS: Record<Size, string> = {
+  s: "rounded-s",
+  m: "rounded-m",
+  l: "rounded-l",
+}
+
+export default function BrandMark({
+  size = "m",
+  variant = "default",
+  className,
+}: BrandMarkProps) {
+  const px = SIZE_PX[size]
+  const bg = variant === "default" ? "bg-brand" : "bg-bg-surface-2"
+  const fg = variant === "default" ? "text-on-brand" : "text-fg-primary"
+
+  return (
+    <span
+      role="img"
+      aria-label="La Huella del Caminante"
+      className={cn(
+        "inline-flex items-center justify-center shrink-0",
+        SIZE_RADIUS[size],
+        bg,
+        fg,
+        className
+      )}
+      style={{ width: px, height: px }}
+    >
+      <FootprintSvg size={px} />
+    </span>
+  )
+}
+
+/**
+ * SVG inline: huella estilizada simple. Tres "dedos" pequeños arriba y
+ * la planta debajo, todo en `currentColor` para que herede el `text-*`
+ * del contenedor.
+ */
+function FootprintSvg({ size }: { size: number }) {
+  // El SVG ocupa el 55% del contenedor para que el ícono tenga aire.
+  const inner = Math.round(size * 0.55)
+  return (
+    <svg
+      width={inner}
+      height={inner}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      {/* Dedo central (más grande) */}
+      <ellipse cx="12" cy="4.5" rx="2" ry="2.5" />
+      {/* Dedos laterales */}
+      <ellipse cx="7" cy="6" rx="1.6" ry="2" />
+      <ellipse cx="17" cy="6" rx="1.6" ry="2" />
+      {/* Planta del pie (forma de gota invertida) */}
+      <path d="M12 10c-3.5 0-6 2.7-6 6.5 0 2.6 1.8 4.5 3.6 4.5 1 0 1.8-.5 2.4-1.2.6.7 1.4 1.2 2.4 1.2 1.8 0 3.6-1.9 3.6-4.5 0-3.8-2.5-6.5-6-6.5z" />
+    </svg>
+  )
+}

--- a/src/components/brand/BrandMark.tsx
+++ b/src/components/brand/BrandMark.tsx
@@ -17,6 +17,11 @@ import type { Size } from "@/components/types"
 export interface BrandMarkProps {
   size?: Size
   variant?: "default" | "muted"
+  /** Cuando es `true`, marca el elemento como `aria-hidden` y omite el
+   * `aria-label`. Pasar `true` cuando se usa adentro de un componente que
+   * ya provee el nombre accesible (ej. `BrandLockup` con texto visible) y
+   * el mark es puramente decorativo. */
+  decorative?: boolean
   className?: string
 }
 
@@ -35,16 +40,20 @@ const SIZE_RADIUS: Record<Size, string> = {
 export default function BrandMark({
   size = "m",
   variant = "default",
+  decorative = false,
   className,
 }: BrandMarkProps) {
   const px = SIZE_PX[size]
   const bg = variant === "default" ? "bg-brand" : "bg-bg-surface-2"
   const fg = variant === "default" ? "text-on-brand" : "text-fg-primary"
 
+  const ariaProps = decorative
+    ? { "aria-hidden": true as const }
+    : { role: "img" as const, "aria-label": "La Huella del Caminante" }
+
   return (
     <span
-      role="img"
-      aria-label="La Huella del Caminante"
+      {...ariaProps}
       className={cn(
         "inline-flex items-center justify-center shrink-0",
         SIZE_RADIUS[size],

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -1,0 +1,144 @@
+/**
+ * DashboardShell — layout sidebar + main para el panel del creator y el admin.
+ *
+ * Sidebar role-aware: el indicador del item activo se tiñe con `creator`
+ * (fucsia) para creators y `brand` (sangre) para admins. Es el principal
+ * recurso visual que diferencia los dos paneles sin agregar más cromo.
+ *
+ * En v1 implementamos SOLO la versión desktop (sidebar fija a la izquierda).
+ * El comportamiento responsive en mobile (tab bar inferior + drawer
+ * accesible desde un hamburger en el header) está pensado y descripto pero
+ * se implementa en el PR de integración del dashboard, cuando ya tengamos
+ * el contenido real adentro. Por eso este componente es server: no necesita
+ * estado para desktop. Cuando se sume el drawer mobile, se va a hacer split
+ * (un wrapper server + un `MobileDrawer` client).
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+
+export type DashboardRole = "creator" | "admin"
+
+export interface DashboardNavItem {
+  label: string
+  href: string
+}
+
+export interface DashboardShellProps {
+  children: React.ReactNode
+  userRole: DashboardRole
+  userName?: string
+  /** Ruta activa para resaltar el item correspondiente (match exacto). */
+  activeRoute?: string
+  /** Locale para construir las rutas. Default `"es"`. */
+  locale?: string
+  /** Sobreescribir los items por defecto (los del rol). Útil para testing
+   * o pantallas que necesiten una nav reducida. Si no se pasa, se usan los
+   * items por defecto del rol. */
+  navItems?: DashboardNavItem[]
+  className?: string
+}
+
+const ACCENT_BY_ROLE: Record<
+  DashboardRole,
+  { border: string; text: string; greeting: string }
+> = {
+  creator: {
+    border: "border-l-creator",
+    text: "text-creator",
+    greeting: "text-creator",
+  },
+  admin: {
+    border: "border-l-brand",
+    text: "text-brand",
+    greeting: "text-brand",
+  },
+}
+
+/** Items por defecto por rol. Hardcodeados en español por ahora — cuando se
+ * integre con i18n en el PR siguiente, esto se reemplaza por `useTranslations`
+ * en el caller que arme `navItems` y lo pase. */
+function defaultNavItems(role: DashboardRole, locale: string): DashboardNavItem[] {
+  const base = `/${locale}`
+  if (role === "creator") {
+    return [
+      { label: "Mi panel", href: `${base}/dashboard` },
+      { label: "Mis eventos", href: `${base}/dashboard/events` },
+      { label: "Mis artistas", href: `${base}/dashboard/artists` },
+      { label: "Mi perfil", href: `${base}/dashboard/profile` },
+    ]
+  }
+  return [
+    { label: "Aplicaciones", href: `${base}/admin/applications` },
+    { label: "Usuarios", href: `${base}/admin/users` },
+    { label: "Eventos", href: `${base}/admin/events` },
+  ]
+}
+
+export default function DashboardShell({
+  children,
+  userRole,
+  userName,
+  activeRoute,
+  locale = "es",
+  navItems,
+  className,
+}: DashboardShellProps) {
+  const accent = ACCENT_BY_ROLE[userRole]
+  const items = navItems ?? defaultNavItems(userRole, locale)
+  const greeting = userName ? `Hola, ${userName}` : "Panel"
+  const publicHref = `/${locale}`
+
+  return (
+    <div className={cn("flex flex-1 min-h-0", className)}>
+      {/* Sidebar (desktop). En mobile queda fuera de viewport por ahora —
+          la nav inferior + drawer se agregan en el PR de integración. */}
+      <aside className="hidden md:flex md:w-[240px] md:flex-col md:border-r md:border-border md:bg-bg-surface md:py-l md:px-m">
+        <div className="px-m mb-l">
+          <p className={cn("text-eyebrow font-mono mb-xs", accent.greeting)}>
+            {userRole === "creator" ? "CREATOR" : "ADMIN"}
+          </p>
+          <p className="text-body font-display font-semibold text-fg-primary">
+            {greeting}
+          </p>
+        </div>
+
+        <nav className="flex flex-col gap-xs">
+          {items.map((item) => {
+            const isActive = activeRoute === item.href
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "text-body-s rounded-r-m border-l-2 px-m py-s transition-colors",
+                  isActive
+                    ? cn("bg-bg-surface-2", accent.border, accent.text, "font-semibold")
+                    : "border-l-transparent text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary"
+                )}
+              >
+                {item.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="mt-auto pt-l">
+          <Link
+            href={publicHref}
+            className="text-caption font-mono text-fg-tertiary hover:text-fg-primary transition-colors"
+          >
+            ← Volver al sitio público
+          </Link>
+        </div>
+      </aside>
+
+      <main className="flex-1 min-w-0 px-m py-l md:px-l md:py-xl">
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -7,11 +7,14 @@
  *
  * En v1 implementamos SOLO la versión desktop (sidebar fija a la izquierda).
  * El comportamiento responsive en mobile (tab bar inferior + drawer
- * accesible desde un hamburger en el header) está pensado y descripto pero
- * se implementa en el PR de integración del dashboard, cuando ya tengamos
- * el contenido real adentro. Por eso este componente es server: no necesita
- * estado para desktop. Cuando se sume el drawer mobile, se va a hacer split
- * (un wrapper server + un `MobileDrawer` client).
+ * accesible desde un hamburger en el header) se implementa en el PR de
+ * integración del dashboard, cuando ya tengamos el contenido real adentro.
+ * Por eso este componente es server: no necesita estado para desktop.
+ *
+ * Para preparar ese split futuro, las constantes de estilo del item de nav
+ * (`navItemClass`/`navItemActiveClass`) y la lista por defecto
+ * (`defaultDashboardNavItems`) se exportan: el `MobileDrawer` client que
+ * se sume después puede reusarlas sin duplicar Tailwind.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
  */
@@ -32,36 +35,43 @@ export interface DashboardShellProps {
   userName?: string
   /** Ruta activa para resaltar el item correspondiente (match exacto). */
   activeRoute?: string
-  /** Locale para construir las rutas. Default `"es"`. */
-  locale?: string
+  /** Locale usado para construir las rutas por defecto. NO se usa para
+   * traducir labels — los labels son strings hardcoded por ahora; cuando
+   * se integre con i18n el caller debe armar `navItems` con
+   * `useTranslations` y pasarlos. Default `"es"`. */
+  pathLocale?: string
   /** Sobreescribir los items por defecto (los del rol). Útil para testing
-   * o pantallas que necesiten una nav reducida. Si no se pasa, se usan los
-   * items por defecto del rol. */
+   * o pantallas que necesiten una nav reducida. */
   navItems?: DashboardNavItem[]
   className?: string
 }
 
 const ACCENT_BY_ROLE: Record<
   DashboardRole,
-  { border: string; text: string; greeting: string }
+  { border: string; text: string; greeting: string; label: string }
 > = {
   creator: {
     border: "border-l-creator",
     text: "text-creator",
     greeting: "text-creator",
+    label: "CREATOR",
   },
   admin: {
     border: "border-l-brand",
     text: "text-brand",
     greeting: "text-brand",
+    label: "ADMIN",
   },
 }
 
-/** Items por defecto por rol. Hardcodeados en español por ahora — cuando se
- * integre con i18n en el PR siguiente, esto se reemplaza por `useTranslations`
- * en el caller que arme `navItems` y lo pase. */
-function defaultNavItems(role: DashboardRole, locale: string): DashboardNavItem[] {
-  const base = `/${locale}`
+/** Items por defecto por rol. Strings hardcoded en español por ahora —
+ * cuando se integre i18n en el PR siguiente, el caller arma esta lista con
+ * `useTranslations` y la pasa via prop `navItems`. */
+export function defaultDashboardNavItems(
+  role: DashboardRole,
+  pathLocale: string
+): DashboardNavItem[] {
+  const base = `/${pathLocale}`
   if (role === "creator") {
     return [
       { label: "Mi panel", href: `${base}/dashboard` },
@@ -77,19 +87,30 @@ function defaultNavItems(role: DashboardRole, locale: string): DashboardNavItem[
   ]
 }
 
+/** Clases base del item de nav del sidebar. Reusable desde el futuro
+ * `MobileDrawer` para mantener el look consistente. */
+export const navItemClass =
+  "text-body-s rounded-r-m border-l-2 px-m py-s transition-colors " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand " +
+  "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+
+/** Clases que se suman cuando el item está activo (role-aware via
+ * `accent.border` + `accent.text`). */
+export const navItemActiveClass = "bg-bg-surface-2 font-semibold"
+
 export default function DashboardShell({
   children,
   userRole,
   userName,
   activeRoute,
-  locale = "es",
+  pathLocale = "es",
   navItems,
   className,
 }: DashboardShellProps) {
   const accent = ACCENT_BY_ROLE[userRole]
-  const items = navItems ?? defaultNavItems(userRole, locale)
+  const items = navItems ?? defaultDashboardNavItems(userRole, pathLocale)
   const greeting = userName ? `Hola, ${userName}` : "Panel"
-  const publicHref = `/${locale}`
+  const publicHref = `/${pathLocale}`
 
   return (
     <div className={cn("flex flex-1 min-h-0", className)}>
@@ -98,9 +119,9 @@ export default function DashboardShell({
       <aside className="hidden md:flex md:w-[240px] md:flex-col md:border-r md:border-border md:bg-bg-surface md:py-l md:px-m">
         <div className="px-m mb-l">
           <p className={cn("text-eyebrow font-mono mb-xs", accent.greeting)}>
-            {userRole === "creator" ? "CREATOR" : "ADMIN"}
+            {accent.label}
           </p>
-          <p className="text-body font-display font-semibold text-fg-primary">
+          <p className="text-body-l font-display font-semibold text-fg-primary">
             {greeting}
           </p>
         </div>
@@ -114,9 +135,9 @@ export default function DashboardShell({
                 href={item.href}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
-                  "text-body-s rounded-r-m border-l-2 px-m py-s transition-colors",
+                  navItemClass,
                   isActive
-                    ? cn("bg-bg-surface-2", accent.border, accent.text, "font-semibold")
+                    ? cn(navItemActiveClass, accent.border, accent.text)
                     : "border-l-transparent text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary"
                 )}
               >

--- a/src/components/dashboard/StepCard.tsx
+++ b/src/components/dashboard/StepCard.tsx
@@ -1,0 +1,74 @@
+/**
+ * StepCard — card numerada del onboarding del creator. Tres aparecen en fila
+ * en desktop (grid 3 cols), apiladas en mobile, en la home del dashboard cuando
+ * el creator no tiene contenido todavía.
+ *
+ * Composición vertical: número en eyebrow ("01"), título, descripción, preview
+ * opcional (un mock visual del paso) y CTA opcional al final.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §1.5 + §4.1.
+ */
+
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import Eyebrow from "@/components/ui/Eyebrow"
+
+export interface StepCardCta {
+  label: string
+  href: string
+}
+
+export interface StepCardProps {
+  /** Número del paso (1-based). Se renderiza con dos dígitos ("01", "02"). */
+  number: number
+  title: string
+  description: string
+  cta?: StepCardCta
+  /** Mock visual del paso (preview). Opcional. */
+  preview?: React.ReactNode
+  className?: string
+}
+
+export default function StepCard({
+  number,
+  title,
+  description,
+  cta,
+  preview,
+  className,
+}: StepCardProps) {
+  const numberLabel = String(number).padStart(2, "0")
+
+  return (
+    <article
+      className={cn(
+        "flex flex-col gap-m rounded-l border border-border bg-bg-surface p-l",
+        "transition-colors hover:border-border-hi",
+        className
+      )}
+    >
+      <Eyebrow accent="creator">{numberLabel}</Eyebrow>
+
+      <h3 className="text-heading-s font-display text-fg-primary">{title}</h3>
+
+      <p className="text-body-s text-fg-secondary leading-relaxed">{description}</p>
+
+      {preview ? (
+        <div className="mt-s rounded-m bg-bg-surface-2 p-m">{preview}</div>
+      ) : null}
+
+      {cta ? (
+        <Link
+          href={cta.href}
+          className={cn(
+            "mt-auto inline-flex items-center gap-xs text-body-s font-semibold text-creator",
+            "hover:text-creator/80 transition-colors"
+          )}
+        >
+          {cta.label}
+          <span aria-hidden="true">→</span>
+        </Link>
+      ) : null}
+    </article>
+  )
+}

--- a/src/components/events/DateTile.tsx
+++ b/src/components/events/DateTile.tsx
@@ -74,6 +74,7 @@ export default async function DateTile({
         className
       )}
       aria-label={isValid ? `${month} ${day}` : undefined}
+      aria-hidden={!isValid || undefined}
     >
       <span className="text-eyebrow font-mono">{month}</span>
       <span className={cn(dayClass, "font-display")}>{day}</span>

--- a/src/components/events/DateTile.tsx
+++ b/src/components/events/DateTile.tsx
@@ -1,24 +1,28 @@
 /**
  * DateTile — bloque "JUN 7" reutilizable. Mes en eyebrow (mono, mayúsculas)
- * encima del día en display weight 800.
+ * encima del día en display weight derivado del token (`text-heading-*`).
  *
  * Usado sobre cards de evento, en el detalle, y en agendas compactas. El día
  * se formatea siempre con dos dígitos para alineación visual consistente.
  *
- * El mes respeta el locale (`getLocale()` por defecto; puede pasarse como prop
- * si el caller ya lo tiene a mano). En la práctica `JUN` coincide en es/en/de,
- * pero `OCT` (es/en) vs `OKT` (de) sí difiere, así que delegamos a `Intl`.
+ * El mes respeta el locale. Para listings de muchos tiles, **pasar `locale`
+ * explícito** (resuelto una vez en el page con `getLocale()`) en lugar de
+ * dejar que cada tile lo pida solo — evita N awaits redundantes aunque
+ * `next-intl` cachee por request. En usos sueltos, omitir `locale` es OK.
+ *
+ * En la práctica `JUN` coincide en es/en/de, pero `OCT` (es/en) vs `OKT`
+ * (de) sí difiere, así que delegamos a `Intl.DateTimeFormat`.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
  */
 
 import { getLocale } from "next-intl/server"
 import { cn } from "@/lib/utils"
-import type { AccentBound } from "@/components/types"
+import type { AccentBound, SmallSize } from "@/components/types"
 
 export interface DateTileProps {
   date: Date | string
-  size?: "s" | "m"
+  size?: SmallSize
   accent?: AccentBound
   locale?: string
   className?: string
@@ -59,19 +63,20 @@ export default async function DateTile({
   const day = isValid ? String(d.getDate()).padStart(2, "0") : "—"
 
   const colors = accent ? ACCENT_BG[accent] : "bg-bg-surface-2 text-fg-primary"
+  // El peso del día viene del propio token `text-heading-*` (700 / 800).
   const dayClass = size === "m" ? "text-heading-l" : "text-heading-m"
 
   return (
     <div
       className={cn(
-        "inline-flex flex-col items-center justify-center rounded-m px-s py-xs",
+        "flex flex-col items-center justify-center rounded-m px-s py-xs w-fit",
         colors,
         className
       )}
       aria-label={isValid ? `${month} ${day}` : undefined}
     >
       <span className="text-eyebrow font-mono">{month}</span>
-      <span className={cn(dayClass, "font-display font-extrabold")}>{day}</span>
+      <span className={cn(dayClass, "font-display")}>{day}</span>
     </div>
   )
 }

--- a/src/components/events/DateTile.tsx
+++ b/src/components/events/DateTile.tsx
@@ -1,0 +1,77 @@
+/**
+ * DateTile — bloque "JUN 7" reutilizable. Mes en eyebrow (mono, mayúsculas)
+ * encima del día en display weight 800.
+ *
+ * Usado sobre cards de evento, en el detalle, y en agendas compactas. El día
+ * se formatea siempre con dos dígitos para alineación visual consistente.
+ *
+ * El mes respeta el locale (`getLocale()` por defecto; puede pasarse como prop
+ * si el caller ya lo tiene a mano). En la práctica `JUN` coincide en es/en/de,
+ * pero `OCT` (es/en) vs `OKT` (de) sí difiere, así que delegamos a `Intl`.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import { getLocale } from "next-intl/server"
+import { cn } from "@/lib/utils"
+import type { AccentBound } from "@/components/types"
+
+export interface DateTileProps {
+  date: Date | string
+  size?: "s" | "m"
+  accent?: AccentBound
+  locale?: string
+  className?: string
+}
+
+const LOCALE_MAP: Record<string, string> = {
+  es: "es-ES",
+  en: "en-US",
+  de: "de-DE",
+}
+
+const ACCENT_BG: Record<AccentBound, string> = {
+  brand: "bg-brand text-on-brand",
+  editorial: "bg-editorial text-on-editorial",
+  creator: "bg-creator text-on-creator",
+}
+
+export default async function DateTile({
+  date,
+  size = "m",
+  accent,
+  locale,
+  className,
+}: DateTileProps) {
+  const resolvedLocale = locale ?? (await getLocale())
+  const d = typeof date === "string" ? new Date(date) : date
+  const isValid = !isNaN(d.getTime())
+
+  const month = isValid
+    ? new Intl.DateTimeFormat(LOCALE_MAP[resolvedLocale] ?? "es-ES", {
+        month: "short",
+      })
+        .format(d)
+        .replace(/\./g, "")
+        .toUpperCase()
+        .slice(0, 3)
+    : "—"
+  const day = isValid ? String(d.getDate()).padStart(2, "0") : "—"
+
+  const colors = accent ? ACCENT_BG[accent] : "bg-bg-surface-2 text-fg-primary"
+  const dayClass = size === "m" ? "text-heading-l" : "text-heading-m"
+
+  return (
+    <div
+      className={cn(
+        "inline-flex flex-col items-center justify-center rounded-m px-s py-xs",
+        colors,
+        className
+      )}
+      aria-label={isValid ? `${month} ${day}` : undefined}
+    >
+      <span className="text-eyebrow font-mono">{month}</span>
+      <span className={cn(dayClass, "font-display font-extrabold")}>{day}</span>
+    </div>
+  )
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Tipos compartidos entre componentes del sistema visual (PR 3).
+ * Centralizados para mantener consistencia entre Chip, BrandMark, DateTile,
+ * SectionHeader, FlyerImage, Eyebrow, etc.
+ */
+
+/** Roles de accent del sistema. `neutral` es la opción no-acentuada. */
+export type Accent = "brand" | "editorial" | "creator" | "neutral"
+
+/** Subset de `Accent` para casos donde no aplica el neutral
+ * (ej. fallback de FlyerImage, tinte de SectionHeader). */
+export type AccentBound = "brand" | "editorial" | "creator"
+
+/** Escala de tamaños usada por componentes con tamaño variable. */
+export type Size = "s" | "m" | "l"

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -13,3 +13,13 @@ export type AccentBound = "brand" | "editorial" | "creator"
 
 /** Escala de tamaños usada por componentes con tamaño variable. */
 export type Size = "s" | "m" | "l"
+
+/** Subset de `Size` para componentes que no tienen variante grande
+ * (ej. DateTile, Chip, ChipButton — donde una `l` no tiene sentido visual). */
+export type SmallSize = Exclude<Size, "l">
+
+/**
+ * Convención de imports: importar componentes directamente desde su archivo
+ * (`import BrandMark from "@/components/brand/BrandMark"`), no via barrels.
+ * Esto preserva tree-shaking del default export en todos los bundlers.
+ */

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,62 @@
+/**
+ * Chip — pill estático para tags, etiquetas de género, badges no-interactivos.
+ *
+ * Para chips clickeables (filtros, toggles), usar `ChipButton` (mismo look,
+ * client component con `onClick`).
+ *
+ * Props clave:
+ *  - `accent`: tinte del pill cuando `active`. Default `neutral`.
+ *  - `active`: si `true`, el chip toma el color del accent. Si `false`,
+ *    se renderiza como un pill muteado (surface-2).
+ *  - `size`: `s` (compacto, en cards) o `m` (default, en filter bars).
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import { cn } from "@/lib/utils"
+import type { Accent } from "@/components/types"
+
+export interface ChipProps {
+  children: React.ReactNode
+  accent?: Accent
+  active?: boolean
+  size?: "s" | "m"
+  className?: string
+}
+
+const ACTIVE_BG: Record<Accent, string> = {
+  brand: "bg-brand text-on-brand border-brand",
+  editorial: "bg-editorial text-on-editorial border-editorial",
+  creator: "bg-creator text-on-creator border-creator",
+  neutral: "bg-fg-primary text-bg-page border-fg-primary",
+}
+
+const SIZE_CLASS: Record<"s" | "m", string> = {
+  s: "text-caption px-s py-[2px]",
+  m: "text-body-s px-m py-xs",
+}
+
+export default function Chip({
+  children,
+  accent = "neutral",
+  active = false,
+  size = "m",
+  className,
+}: ChipProps) {
+  const colors = active
+    ? ACTIVE_BG[accent]
+    : "bg-bg-surface-2 text-fg-secondary border-border"
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-pill border font-medium",
+        SIZE_CLASS[size],
+        colors,
+        className
+      )}
+    >
+      {children}
+    </span>
+  )
+}

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -2,38 +2,30 @@
  * Chip — pill estático para tags, etiquetas de género, badges no-interactivos.
  *
  * Para chips clickeables (filtros, toggles), usar `ChipButton` (mismo look,
- * client component con `onClick`).
+ * client component con `onClick`). Las clases compartidas viven en
+ * `chip-styles.ts` — modificar ahí si cambian.
  *
  * Props clave:
- *  - `accent`: tinte del pill cuando `active`. Default `neutral`.
- *  - `active`: si `true`, el chip toma el color del accent. Si `false`,
- *    se renderiza como un pill muteado (surface-2).
- *  - `size`: `s` (compacto, en cards) o `m` (default, en filter bars).
+ *  - `accent`: tinte del pill cuando `active`. Default `neutral` (incluido
+ *    en el set porque el "neutral activo" es un estado válido distinto al
+ *    pill idle muteado).
+ *  - `active`: si `true`, el chip toma el color del accent. Si `false`, se
+ *    renderiza muteado (surface-2 + fg-secondary).
+ *  - `size`: `s` compacto (cards densas) o `m` default (filter bars).
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
  */
 
 import { cn } from "@/lib/utils"
-import type { Accent } from "@/components/types"
+import type { Accent, SmallSize } from "@/components/types"
+import { CHIP_ACTIVE_BG, CHIP_BASE, CHIP_IDLE_BG, CHIP_SIZE } from "./chip-styles"
 
 export interface ChipProps {
   children: React.ReactNode
   accent?: Accent
   active?: boolean
-  size?: "s" | "m"
+  size?: SmallSize
   className?: string
-}
-
-const ACTIVE_BG: Record<Accent, string> = {
-  brand: "bg-brand text-on-brand border-brand",
-  editorial: "bg-editorial text-on-editorial border-editorial",
-  creator: "bg-creator text-on-creator border-creator",
-  neutral: "bg-fg-primary text-bg-page border-fg-primary",
-}
-
-const SIZE_CLASS: Record<"s" | "m", string> = {
-  s: "text-caption px-s py-[2px]",
-  m: "text-body-s px-m py-xs",
 }
 
 export default function Chip({
@@ -43,16 +35,12 @@ export default function Chip({
   size = "m",
   className,
 }: ChipProps) {
-  const colors = active
-    ? ACTIVE_BG[accent]
-    : "bg-bg-surface-2 text-fg-secondary border-border"
-
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-pill border font-medium",
-        SIZE_CLASS[size],
-        colors,
+        CHIP_BASE,
+        CHIP_SIZE[size],
+        active ? CHIP_ACTIVE_BG[accent] : CHIP_IDLE_BG,
         className
       )}
     >

--- a/src/components/ui/ChipButton.tsx
+++ b/src/components/ui/ChipButton.tsx
@@ -1,0 +1,73 @@
+/**
+ * ChipButton — versión interactiva de `Chip`. Mismo look, pero render como
+ * `<button>` con `onClick`, focus ring, hover, y aria-pressed cuando es toggle.
+ *
+ * Usado en filter bars (toggle de género/ciudad), tabs no-stateful, etc. Para
+ * tags estáticos o badges, usar `Chip` (server component).
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { Accent } from "@/components/types"
+
+export interface ChipButtonProps {
+  children: React.ReactNode
+  onClick?: () => void
+  accent?: Accent
+  active?: boolean
+  size?: "s" | "m"
+  disabled?: boolean
+  className?: string
+  /** Si el chip funciona como toggle (on/off), pasar `true` para que se
+   * exponga `aria-pressed`. Si funciona como acción simple, dejar `false`. */
+  toggle?: boolean
+}
+
+const ACTIVE_BG: Record<Accent, string> = {
+  brand: "bg-brand text-on-brand border-brand",
+  editorial: "bg-editorial text-on-editorial border-editorial",
+  creator: "bg-creator text-on-creator border-creator",
+  neutral: "bg-fg-primary text-bg-page border-fg-primary",
+}
+
+const SIZE_CLASS: Record<"s" | "m", string> = {
+  s: "text-caption px-s py-[2px]",
+  m: "text-body-s px-m py-xs",
+}
+
+export default function ChipButton({
+  children,
+  onClick,
+  accent = "neutral",
+  active = false,
+  size = "m",
+  disabled = false,
+  className,
+  toggle = false,
+}: ChipButtonProps) {
+  const colors = active
+    ? ACTIVE_BG[accent]
+    : "bg-bg-surface-2 text-fg-secondary border-border hover:bg-bg-surface-3 hover:text-fg-primary"
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={toggle ? active : undefined}
+      className={cn(
+        "inline-flex items-center rounded-pill border font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        SIZE_CLASS[size],
+        colors,
+        className
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/ui/ChipButton.tsx
+++ b/src/components/ui/ChipButton.tsx
@@ -1,9 +1,14 @@
 /**
  * ChipButton — versión interactiva de `Chip`. Mismo look, pero render como
- * `<button>` con `onClick`, focus ring, hover, y aria-pressed cuando es toggle.
+ * `<button>` con `onClick`, focus ring, hover, y `aria-pressed` cuando es
+ * toggle. Las clases compartidas viven en `chip-styles.ts`.
  *
- * Usado en filter bars (toggle de género/ciudad), tabs no-stateful, etc. Para
- * tags estáticos o badges, usar `Chip` (server component).
+ * Usado en filter bars (toggle de género/ciudad), tabs no-stateful, etc.
+ * Para tags estáticos o badges, usar `Chip` (server component).
+ *
+ * Nota sobre `accent`: igual que `Chip`, se acepta `Accent` completo
+ * (incluye `neutral`) porque hay casos donde el toggle activo neutral es un
+ * estado válido distinto al idle muteado.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
  */
@@ -11,31 +16,20 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import type { Accent } from "@/components/types"
+import type { Accent, SmallSize } from "@/components/types"
+import { CHIP_ACTIVE_BG, CHIP_BASE, CHIP_IDLE_BG, CHIP_SIZE } from "./chip-styles"
 
 export interface ChipButtonProps {
   children: React.ReactNode
   onClick?: () => void
   accent?: Accent
   active?: boolean
-  size?: "s" | "m"
+  size?: SmallSize
   disabled?: boolean
   className?: string
   /** Si el chip funciona como toggle (on/off), pasar `true` para que se
    * exponga `aria-pressed`. Si funciona como acción simple, dejar `false`. */
   toggle?: boolean
-}
-
-const ACTIVE_BG: Record<Accent, string> = {
-  brand: "bg-brand text-on-brand border-brand",
-  editorial: "bg-editorial text-on-editorial border-editorial",
-  creator: "bg-creator text-on-creator border-creator",
-  neutral: "bg-fg-primary text-bg-page border-fg-primary",
-}
-
-const SIZE_CLASS: Record<"s" | "m", string> = {
-  s: "text-caption px-s py-[2px]",
-  m: "text-body-s px-m py-xs",
 }
 
 export default function ChipButton({
@@ -48,9 +42,10 @@ export default function ChipButton({
   className,
   toggle = false,
 }: ChipButtonProps) {
-  const colors = active
-    ? ACTIVE_BG[accent]
-    : "bg-bg-surface-2 text-fg-secondary border-border hover:bg-bg-surface-3 hover:text-fg-primary"
+  const idleWithInteraction = cn(
+    CHIP_IDLE_BG,
+    "hover:bg-bg-surface-3 hover:text-fg-primary"
+  )
 
   return (
     <button
@@ -59,11 +54,12 @@ export default function ChipButton({
       disabled={disabled}
       aria-pressed={toggle ? active : undefined}
       className={cn(
-        "inline-flex items-center rounded-pill border font-medium transition-colors",
+        CHIP_BASE,
+        "transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page",
         "disabled:opacity-50 disabled:cursor-not-allowed",
-        SIZE_CLASS[size],
-        colors,
+        CHIP_SIZE[size],
+        active ? CHIP_ACTIVE_BG[accent] : idleWithInteraction,
         className
       )}
     >

--- a/src/components/ui/Eyebrow.tsx
+++ b/src/components/ui/Eyebrow.tsx
@@ -1,0 +1,48 @@
+/**
+ * Eyebrow — texto chico todo mayúsculas con tracking ancho, en mono.
+ *
+ * Útil para los "EN VIVO · MÚSICA LATINA · ALEMANIA" del hero, "DESTACADOS"
+ * arriba de SectionHeader, "01 / 03" de StepCard, etc. Centraliza las clases
+ * para no repetirlas en cada lugar.
+ *
+ * Tinte opcional con `accent` (brand/editorial/creator). Default neutral
+ * usa `text-fg-secondary` para no competir con el título debajo.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import { cn } from "@/lib/utils"
+import type { Accent } from "@/components/types"
+
+export interface EyebrowProps {
+  children: React.ReactNode
+  accent?: Accent
+  className?: string
+  as?: "span" | "p" | "div"
+}
+
+const ACCENT_COLOR: Record<Accent, string> = {
+  brand: "text-brand",
+  editorial: "text-editorial",
+  creator: "text-creator",
+  neutral: "text-fg-secondary",
+}
+
+export default function Eyebrow({
+  children,
+  accent = "neutral",
+  className,
+  as: Tag = "span",
+}: EyebrowProps) {
+  return (
+    <Tag
+      className={cn(
+        "text-eyebrow font-mono uppercase",
+        ACCENT_COLOR[accent],
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/src/components/ui/Eyebrow.tsx
+++ b/src/components/ui/Eyebrow.tsx
@@ -5,8 +5,10 @@
  * arriba de SectionHeader, "01 / 03" de StepCard, etc. Centraliza las clases
  * para no repetirlas en cada lugar.
  *
- * Tinte opcional con `accent` (brand/editorial/creator). Default neutral
- * usa `text-fg-secondary` para no competir con el título debajo.
+ * Acepta `Accent` completo (no `AccentBound`) porque `neutral` es el estilo
+ * por defecto (sin tinte de marca, en `text-fg-secondary`) — distinto a
+ * "ausencia de accent" que el caller decidiría omitiendo el prop. Útil para
+ * eyebrows debajo de un hero ya marcado donde un accent extra distraería.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
  */

--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -1,0 +1,147 @@
+/**
+ * FlyerImage — wrapper unificado para renderizar flyers de evento o portraits
+ * de artista. Resuelve el problema principal del rediseño: las imágenes vienen
+ * en ratio Instagram (4:5 o 1:1), no en landscape, y no deben recortarse.
+ *
+ * Comportamiento por orden de prioridad:
+ *  1. Si hay `publicId`: usa `<CldImage>` (Cloudinary) con `crop="fill"` +
+ *     `gravity="auto"` y format/quality automáticos.
+ *  2. Si hay `src` pero no `publicId`: usa `<Image>` de Next con object-cover.
+ *  3. Si no hay ninguno: renderiza fallback de iniciales gigantes sobre un
+ *     fondo con radial gradient del color accent (estilo "MS / WP / FC" del
+ *     listado de artistas en el handoff).
+ *
+ * En v1 NO se implementa el blur-de-contención para imágenes en ratio
+ * incorrecto. Si Cloudinary recorta mal, se ajusta gravity por evento desde
+ * el caller. Está marcado como TODO para una iteración posterior.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §1.4 + §4.1.
+ */
+
+import Image from "next/image"
+import { CldImage } from "next-cloudinary"
+import { cn } from "@/lib/utils"
+import type { AccentBound } from "@/components/types"
+
+export interface FlyerImageProps {
+  /** Cloudinary public ID. Si existe, se prefiere sobre `src`. */
+  publicId?: string
+  /** URL plana de la imagen (S3, externo, etc). Se usa solo si no hay publicId. */
+  src?: string
+  /** Texto alternativo. Requerido para accesibilidad. */
+  alt: string
+  /** Ratio del contenedor. Default `4:5` (vertical, flyer Instagram). */
+  aspectRatio?: "4:5" | "1:1"
+  /** Iniciales para el fallback cuando no hay imagen. Default: derivado de `alt`. */
+  fallbackInitials?: string
+  /** Tinte del fallback. Default `brand`. */
+  fallbackAccent?: AccentBound
+  /** Pasar `true` en el hero LCP para optimizar carga. */
+  priority?: boolean
+  className?: string
+}
+
+const ASPECT_CLASS: Record<NonNullable<FlyerImageProps["aspectRatio"]>, string> = {
+  "4:5": "aspect-[4/5]",
+  "1:1": "aspect-square",
+}
+
+const ASPECT_DIMENSIONS: Record<
+  NonNullable<FlyerImageProps["aspectRatio"]>,
+  { width: number; height: number }
+> = {
+  "4:5": { width: 800, height: 1000 },
+  "1:1": { width: 800, height: 800 },
+}
+
+const ACCENT_GRADIENT: Record<AccentBound, string> = {
+  brand:
+    "from-brand-dim/40 via-bg-surface-2 to-bg-surface-2 text-on-brand",
+  editorial:
+    "from-editorial-dim/40 via-bg-surface-2 to-bg-surface-2 text-on-editorial",
+  creator:
+    "from-creator-dim/40 via-bg-surface-2 to-bg-surface-2 text-on-creator",
+}
+
+function deriveInitials(text: string): string {
+  const parts = text
+    .trim()
+    .split(/\s+/)
+    .filter((p) => /^[\p{L}\p{N}]/u.test(p))
+  if (parts.length === 0) return text.slice(0, 2).toUpperCase()
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export default function FlyerImage({
+  publicId,
+  src,
+  alt,
+  aspectRatio = "4:5",
+  fallbackInitials,
+  fallbackAccent = "brand",
+  priority = false,
+  className,
+}: FlyerImageProps) {
+  const containerClass = cn(
+    "relative overflow-hidden rounded-l bg-bg-surface-2",
+    ASPECT_CLASS[aspectRatio],
+    className
+  )
+
+  // 1. Cloudinary
+  if (publicId) {
+    const { width, height } = ASPECT_DIMENSIONS[aspectRatio]
+    return (
+      <div className={containerClass}>
+        <CldImage
+          src={publicId}
+          alt={alt}
+          width={width}
+          height={height}
+          crop="fill"
+          gravity="auto"
+          format="auto"
+          quality="auto"
+          priority={priority}
+          className="h-full w-full object-cover"
+        />
+        {/* TODO (post-PR3): blur-de-contención para flyers en ratio raro. */}
+      </div>
+    )
+  }
+
+  // 2. URL plana
+  if (src) {
+    return (
+      <div className={containerClass}>
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          priority={priority}
+          sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+          className="object-cover"
+        />
+      </div>
+    )
+  }
+
+  // 3. Fallback de iniciales
+  const initials = fallbackInitials ?? deriveInitials(alt)
+  return (
+    <div
+      role="img"
+      aria-label={alt}
+      className={cn(
+        containerClass,
+        "flex items-center justify-center bg-gradient-to-br",
+        ACCENT_GRADIENT[fallbackAccent]
+      )}
+    >
+      <span className="text-display-xl font-display font-extrabold leading-none select-none">
+        {initials}
+      </span>
+    </div>
+  )
+}

--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -11,12 +11,17 @@
  *     fondo con radial gradient del color accent (estilo "MS / WP / FC" del
  *     listado de artistas en el handoff).
  *
+ * **Es client component** porque `<CldImage>` de `next-cloudinary` requiere
+ * hooks/refs del browser. El resto del árbol que lo consume puede ser server.
+ *
  * En v1 NO se implementa el blur-de-contención para imágenes en ratio
  * incorrecto. Si Cloudinary recorta mal, se ajusta gravity por evento desde
  * el caller. Está marcado como TODO para una iteración posterior.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §1.4 + §4.1.
  */
+
+"use client"
 
 import Image from "next/image"
 import { CldImage } from "next-cloudinary"
@@ -54,13 +59,17 @@ const ASPECT_DIMENSIONS: Record<
   "1:1": { width: 800, height: 800 },
 }
 
+/**
+ * Fondo del fallback: gradient teñido con el accent sobre surface-2. El texto
+ * (iniciales) va en `fg-primary` (crema) para ser legible en los tres accents:
+ * `on-<accent>` está pensado para texto sobre superficie acentuada plana, no
+ * sobre estos gradients oscuros (en particular `on-editorial` es casi negro
+ * y quedaría invisible acá).
+ */
 const ACCENT_GRADIENT: Record<AccentBound, string> = {
-  brand:
-    "from-brand-dim/40 via-bg-surface-2 to-bg-surface-2 text-on-brand",
-  editorial:
-    "from-editorial-dim/40 via-bg-surface-2 to-bg-surface-2 text-on-editorial",
-  creator:
-    "from-creator-dim/40 via-bg-surface-2 to-bg-surface-2 text-on-creator",
+  brand: "from-brand-dim/40 via-bg-surface-2 to-bg-surface-2",
+  editorial: "from-editorial-dim/40 via-bg-surface-2 to-bg-surface-2",
+  creator: "from-creator-dim/40 via-bg-surface-2 to-bg-surface-2",
 }
 
 function deriveInitials(text: string): string {
@@ -135,11 +144,11 @@ export default function FlyerImage({
       aria-label={alt}
       className={cn(
         containerClass,
-        "flex items-center justify-center bg-gradient-to-br",
+        "flex items-center justify-center bg-gradient-to-br text-fg-primary",
         ACCENT_GRADIENT[fallbackAccent]
       )}
     >
-      <span className="text-display-xl font-display font-extrabold leading-none select-none">
+      <span className="text-display-xl font-display leading-none select-none">
         {initials}
       </span>
     </div>

--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -108,14 +108,17 @@ export default function FlyerImage({
           alt={alt}
           width={width}
           height={height}
-          crop="fill"
+          crop="pad"
           gravity="auto"
           format="auto"
           quality="auto"
           priority={priority}
-          className="h-full w-full object-cover"
+          className="h-full w-full object-contain"
         />
-        {/* TODO (post-PR3): blur-de-contención para flyers en ratio raro. */}
+        {/* TODO: implement blurred background fallback (Apple Music style)
+            cuando el ratio de la imagen no coincide con el aspect target.
+            Hasta entonces, el padding queda sobre `bg-bg-surface-2` (letterbox
+            sólido). Tracked como PR 5.5. */}
       </div>
     )
   }
@@ -130,7 +133,7 @@ export default function FlyerImage({
           fill
           priority={priority}
           sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-          className="object-cover"
+          className="object-contain"
         />
       </div>
     )

--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -4,7 +4,7 @@
  * en ratio Instagram (4:5 o 1:1), no en landscape, y no deben recortarse.
  *
  * Comportamiento por orden de prioridad:
- *  1. Si hay `publicId`: usa `<CldImage>` (Cloudinary) con `crop="fill"` +
+ *  1. Si hay `publicId`: usa `<CldImage>` (Cloudinary) con `crop="pad"` +
  *     `gravity="auto"` y format/quality automáticos.
  *  2. Si hay `src` pero no `publicId`: usa `<Image>` de Next con object-cover.
  *  3. Si no hay ninguno: renderiza fallback de iniciales gigantes sobre un

--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -6,7 +6,7 @@
  * Comportamiento por orden de prioridad:
  *  1. Si hay `publicId`: usa `<CldImage>` (Cloudinary) con `crop="pad"` +
  *     `gravity="auto"` y format/quality automáticos.
- *  2. Si hay `src` pero no `publicId`: usa `<Image>` de Next con object-cover.
+ *  2. Si hay `src` pero no `publicId`: usa `<Image>` de Next con object-contain.
  *  3. Si no hay ninguno: renderiza fallback de iniciales gigantes sobre un
  *     fondo con radial gradient del color accent (estilo "MS / WP / FC" del
  *     listado de artistas en el handoff).
@@ -14,9 +14,11 @@
  * **Es client component** porque `<CldImage>` de `next-cloudinary` requiere
  * hooks/refs del browser. El resto del árbol que lo consume puede ser server.
  *
- * En v1 NO se implementa el blur-de-contención para imágenes en ratio
- * incorrecto. Si Cloudinary recorta mal, se ajusta gravity por evento desde
- * el caller. Está marcado como TODO para una iteración posterior.
+ * Las imágenes que no vengan en el aspect ratio target se renderizan
+ * contenidas (`crop="pad"` + `object-contain`) sobre `bg-bg-surface-2`,
+ * con bandas sólidas (letterbox). Es lo que pide el handoff §1.4: nunca
+ * recortar texto del flyer. El blur-de-contención estilo Apple Music está
+ * marcado como TODO en el cuerpo del componente, planeado para PR 5.5.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §1.4 + §4.1.
  */

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,50 @@
+/**
+ * SectionHeader — eyebrow + título grande + slot de acción a la derecha.
+ *
+ * Encabezado estándar de secciones en home, listings y dashboard. La acción
+ * típica es un link "Ver todo →" o un botón. En mobile (< 640px) la acción
+ * baja debajo del título; en desktop queda alineada a la derecha.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1.
+ */
+
+import { cn } from "@/lib/utils"
+import type { AccentBound } from "@/components/types"
+import Eyebrow from "./Eyebrow"
+
+export interface SectionHeaderProps {
+  /** Texto pequeño en mono que va arriba del título. Opcional. */
+  eyebrow?: string
+  title: string
+  /** Tinte del eyebrow. Default `neutral` (sin tinte). */
+  accent?: AccentBound
+  /** Slot a la derecha: link "Ver todo →", botón, chip, etc. */
+  action?: React.ReactNode
+  /** Nivel semántico del título (h1/h2/h3). Default `h2`. */
+  as?: "h1" | "h2" | "h3"
+  className?: string
+}
+
+export default function SectionHeader({
+  eyebrow,
+  title,
+  accent,
+  action,
+  as: Tag = "h2",
+  className,
+}: SectionHeaderProps) {
+  return (
+    <header
+      className={cn(
+        "flex flex-col gap-s sm:flex-row sm:items-end sm:justify-between sm:gap-m",
+        className
+      )}
+    >
+      <div className="flex flex-col gap-xs">
+        {eyebrow ? <Eyebrow accent={accent ?? "neutral"}>{eyebrow}</Eyebrow> : null}
+        <Tag className="text-heading-l font-display text-fg-primary">{title}</Tag>
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </header>
+  )
+}

--- a/src/components/ui/chip-styles.ts
+++ b/src/components/ui/chip-styles.ts
@@ -1,0 +1,28 @@
+/**
+ * Estilos compartidos entre `Chip` (server, estático) y `ChipButton` (client,
+ * interactivo). Cualquier ajuste de paddings, accent, o tamaños se hace acá
+ * y se refleja en los dos.
+ */
+
+import type { Accent, SmallSize } from "@/components/types"
+
+/** Clases base que comparten Chip y ChipButton (sin estados ni colores). */
+export const CHIP_BASE = "inline-flex items-center rounded-pill border font-medium"
+
+/** Background + texto + borde cuando el chip está en estado `active`. */
+export const CHIP_ACTIVE_BG: Record<Accent, string> = {
+  brand: "bg-brand text-on-brand border-brand",
+  editorial: "bg-editorial text-on-editorial border-editorial",
+  creator: "bg-creator text-on-creator border-creator",
+  neutral: "bg-fg-primary text-bg-page border-fg-primary",
+}
+
+/** Background + texto + borde cuando el chip está en estado idle (no active).
+ * No incluye hover/focus (esos los pone `ChipButton`). */
+export const CHIP_IDLE_BG = "bg-bg-surface-2 text-fg-secondary border-border"
+
+/** Paddings + tipografía según tamaño. */
+export const CHIP_SIZE: Record<SmallSize, string> = {
+  s: "text-caption px-s py-[2px]",
+  m: "text-body-s px-m py-xs",
+}


### PR DESCRIPTION
## Summary

Tercer PR del rediseño visual. Crea los **componentes nuevos** del sistema visual definidos en `docs/design/DESIGN_HANDOFF_OUTPUT.md` §4.1. **Ningún componente se integra a una pantalla todavía** — la integración va en PRs siguientes (Header/Footer, Home, Listings, Dashboard).

Razón de separar la creación de la integración: un PR que toca 10 componentes y 6 pantallas al mismo tiempo es imposible de revisar. Mejor componentes primero (revisables uno por uno), después integración (revisable pantalla por pantalla).

## Componentes creados

10 componentes (la spec pedía 9; agregué `ChipButton` aparte de `Chip` como sugería la propia spec):

| Archivo | Tipo | Rol |
|---|---|---|
| `src/components/brand/BrandMark.tsx` | server | Ícono cuadrado de marca (SVG huella inline sobre sangre). Variantes default/muted, tamaños s/m/l. Prop `decorative` para usos donde el padre ya provee el nombre accesible. |
| `src/components/brand/BrandLockup.tsx` | server | BrandMark + "La Huella / del Caminante". Orientaciones horizontal/vertical. Opcional `href` para envolver en Link. |
| `src/components/events/DateTile.tsx` | server (async) | Bloque "JUN 07" reutilizable. Mes formateado con `Intl.DateTimeFormat` respetando locale. |
| `src/components/ui/Chip.tsx` | server | Pill estático para tags/badges. Accent brand/editorial/creator/neutral. |
| `src/components/ui/ChipButton.tsx` | client | Versión interactiva de Chip con onClick, focus ring, hover, aria-pressed cuando toggle. |
| `src/components/ui/Eyebrow.tsx` | server | Texto mono uppercase tracking ancho. Centraliza el estilo eyebrow. |
| `src/components/ui/SectionHeader.tsx` | server | Eyebrow + título h2 + slot de acción a la derecha. |
| `src/components/ui/FlyerImage.tsx` | **client** | Resuelve el problema de flyers Instagram mal renderizados. CldImage (publicId) → Image (src) → fallback de iniciales gigantes sobre gradient teñido. Es client porque CldImage requiere refs del browser. |
| `src/components/dashboard/StepCard.tsx` | server | Card numerada del onboarding del creator. |
| `src/components/dashboard/DashboardShell.tsx` | server (desktop only en v1) | Layout sidebar+main role-aware. Mobile drawer marcado como TODO para PR de integración. |

Plus:
- `src/components/types.ts` — tipos compartidos (`Accent`, `AccentBound`, `Size`, `SmallSize`).
- `src/components/ui/chip-styles.ts` — constantes compartidas entre Chip y ChipButton.

## Review interno (paso 3 del flujo)

Pasé el diff por `architecture-reviewer`. Resultado: **14 hallazgos** (2 ALTO, 6 MEDIO, 6 BAJO). Apliqué los críticos + los recomendados en commit `75aec99`:

**ALTO**
- ✅ `FlyerImage` agregada `"use client"` (CldImage requiere refs del browser; sin esto rompía el build al integrarse).
- ✅ Texto del fallback de FlyerImage pasa de `text-on-<accent>` a `text-fg-primary` (`on-editorial` quedaba invisible sobre el gradient dark).

**MEDIO**
- ✅ Extraída `chip-styles.ts` para eliminar duplicación entre Chip y ChipButton.
- ✅ Agregado `SmallSize` en `types.ts` y consumido desde DateTile/Chip/ChipButton.
- ✅ `text-body` → `text-body-l` en greeting de DashboardShell.
- ✅ Renombrada `locale` → `pathLocale` en DashboardShell para dejar claro que NO traduce labels.
- ✅ Cleanup de wrapping en BrandLockup (className al root real, sin `<span>` redundante).
- ✅ Exportadas `defaultDashboardNavItems` + `navItemClass` + `navItemActiveClass` para que el futuro MobileDrawer las reuse.
- ✅ `focus-visible:ring` en links del sidebar (consistencia con ChipButton).

**BAJO aplicados:**
- ✅ Prop `decorative` en BrandMark (resuelve la doble lectura de aria en BrandLockup).
- ✅ Sacados `font-extrabold`/`font-bold` redundantes que pisaban el peso del token tipográfico.
- ✅ JSDoc explicando uso de `Accent` (con neutral) en chips/eyebrow vs `AccentBound`.
- ✅ Nota en `types.ts` sobre convención "import directo, no barrels".
- ✅ DateTile JSDoc: explicita pasar `locale` en listings.

**BAJOS no aplicados (decisión explícita):**
- `inline-flex` en BrandMark queda como está (puede ir inline con texto, es correcto).

## Verificación pre-push

- 6 commits firmados (5 features + 1 fix del review).
- Diff vs main: **12 archivos nuevos, 0 modificados**.
- Ningún `page.tsx`, `Header.tsx`, `Footer.tsx`, ni archivo de pantalla fue tocado.
- Ningún cambio en `globals.css`, schema de Prisma, i18n, auth, middleware, `package.json`.

## Fuera de alcance

- Integración a pantallas (PR 4+).
- Mobile drawer del DashboardShell (PR de integración del dashboard).
- Blur-de-contención del FlyerImage para imágenes en ratio raro (iteración posterior).
- Reemplazo de los componentes shadcn que cumplen funciones similares (Button, Dialog, etc.) — eso es la épica "shadcn lo dejamos morir gradualmente".

## Test plan

- [ ] CI / CodeRabbit pasa sin errores.
- [ ] `npm run build` sin errores nuevos.
- [ ] El sitio sigue navegando como antes (ningún componente nuevo está integrado todavía).
- [ ] Validación visual de cada componente queda para el PR de integración (donde se monten en pantallas reales con datos).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brand identity: footprint mark icon and configurable lockup with two-line product text and horizontal/vertical layouts, optional link.
  * Dashboard: role-aware layout with desktop sidebar, role-specific navigation and active-route highlighting.
  * Onboarding: reusable step cards with number, description, preview and CTA.
  * UI library: chips (static & interactive), eyebrow, section headers, shared chip styles.
  * Events: locale-aware date tile and flexible flyer image renderer with fallbacks.
  * Shared types: centralized visual component type aliases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->