### PR TITLE
feat: redesign Header, Footer and LanguageSwitcher

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,61 +1,173 @@
-"use client"
+/**
+ * Footer — server component, 4 columnas en desktop, stacked en mobile.
+ *
+ * Estructura por columnas:
+ *  1. Marca: BrandLockup vertical + tagline.
+ *  2. EXPLORAR: links públicos (Eventos, Artistas, Esta semana).
+ *  3. PARA VOS: aplicar como creator, sign-in.
+ *  4. COMUNIDAD: Instagram, newsletter (placeholder), email mailto.
+ *
+ * Debajo de las columnas, línea separadora con copyright a la izquierda y
+ * links a Impressum/Datenschutz a la derecha (`#` por ahora; el contenido
+ * legal se redacta en una épica aparte).
+ *
+ * Es server component: no necesita hooks ni sesión. La distinción "mostrar
+ * email solo a creator/admin" del Footer viejo se elimina — el email
+ * `info@...` ahora aparece a todos, alineado con el handoff (sección
+ * pública de contacto).
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 + §6.
+ */
 
 import Link from "next/link"
-import { useTranslations, useLocale } from "next-intl"
-import { useSession } from "@/lib/auth-client"
+import { getLocale, getTranslations } from "next-intl/server"
+import { cn } from "@/lib/utils"
+import BrandLockup from "@/components/brand/BrandLockup"
+import Eyebrow from "@/components/ui/Eyebrow"
 
-export function Footer() {
-  const t = useTranslations("footer")
-  const locale = useLocale()
-  const currentYear = new Date().getFullYear()
-  const { data: session } = useSession()
-
-  const role = session?.user?.role?.toLowerCase()
-  const canCreate = role === "creator" || role === "admin"
+export async function Footer() {
+  const locale = await getLocale()
+  const t = await getTranslations("footer")
+  const tNav = await getTranslations("nav")
+  const year = new Date().getFullYear()
 
   return (
-    <footer className="border-t border-border bg-card mt-auto">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-10">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
-          {/* Brand */}
-          <div className="flex items-center gap-2.5">
-            <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center text-primary-foreground text-sm font-black shadow-sm">
-              ♪
-            </div>
-            <div className="leading-tight">
-              <div className="font-black text-sm">La Huella del Caminante</div>
-              <div className="text-xs text-muted-foreground">{t("tagline")}</div>
-            </div>
+    <footer
+      className="border-t border-border bg-bg-page mt-auto"
+      style={{
+        paddingTop: "var(--spacing-2xl)",
+        paddingBottom: "var(--spacing-xl)",
+      }}
+    >
+      <div
+        className="mx-auto"
+        style={{
+          maxWidth: "var(--layout-max-w)",
+          paddingLeft: "var(--layout-gutter)",
+          paddingRight: "var(--layout-gutter)",
+        }}
+      >
+        <div className="grid grid-cols-1 gap-xl lg:grid-cols-4 lg:gap-l">
+          {/* Columna 1 — Marca */}
+          <div className="flex flex-col items-start gap-m">
+            <BrandLockup orientation="vertical" />
+            <p className="text-body-s text-fg-secondary leading-relaxed max-w-[28ch]">
+              {t("tagline")}
+            </p>
           </div>
 
-          {/* Links */}
-          <nav className="flex items-center gap-5 text-sm text-muted-foreground">
-            <Link href={`/${locale}/events`} className="hover:text-foreground transition-colors">{t("events")}</Link>
-            <Link href={`/${locale}/artists`} className="hover:text-foreground transition-colors">{t("artists")}</Link>
-            <a
+          {/* Columna 2 — EXPLORAR */}
+          <FooterColumn eyebrow={t("explore")}>
+            <FooterLink href={`/${locale}/events`}>{tNav("events")}</FooterLink>
+            <FooterLink href={`/${locale}/artists`}>
+              {tNav("artists")}
+            </FooterLink>
+            <FooterLink href={`/${locale}/events#esta-semana`}>
+              {tNav("thisWeek")}
+            </FooterLink>
+          </FooterColumn>
+
+          {/* Columna 3 — PARA VOS */}
+          <FooterColumn eyebrow={t("forYou")}>
+            <FooterLink href={`/${locale}/apply`}>{t("apply")}</FooterLink>
+            <FooterLink href={`/${locale}/sign-in`}>{tNav("signIn")}</FooterLink>
+          </FooterColumn>
+
+          {/* Columna 4 — COMUNIDAD */}
+          <FooterColumn eyebrow={t("community")}>
+            <FooterLink
               href="https://www.instagram.com/lahuelladelcaminante/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground transition-colors"
+              external
             >
               Instagram
-            </a>
-            {canCreate && (
-              <a
-                href="mailto:info@lahuelladelcaminante.de"
-                className="hover:text-foreground transition-colors"
-              >
-                info@lahuelladelcaminante.de
-              </a>
-            )}
-            <Link href={`/${locale}/sign-in`} className="hover:text-foreground transition-colors">{t("login")}</Link>
-          </nav>
+            </FooterLink>
+            {/* TODO: replace `#` with real newsletter signup once flow exists. */}
+            <FooterLink href="#" external>
+              {t("newsletter")}
+            </FooterLink>
+            <FooterLink href="mailto:info@lahuelladelcaminante.de" external>
+              info@lahuelladelcaminante.de
+            </FooterLink>
+          </FooterColumn>
         </div>
 
-        <div className="mt-8 pt-6 border-t border-border text-xs text-muted-foreground text-center">
-          {t("copyright", { year: currentYear })}
+        {/* Línea inferior: copyright + legal */}
+        <div
+          className={cn(
+            "border-t border-border mt-2xl pt-l",
+            "flex flex-col gap-s sm:flex-row sm:items-center sm:justify-between"
+          )}
+        >
+          <p className="text-caption text-fg-tertiary">
+            {t("copyright", { year })}
+          </p>
+          <div className="flex items-center gap-l">
+            {/* TODO: link to actual legal pages when content is ready. */}
+            <a
+              href="#"
+              className="text-caption text-fg-tertiary hover:text-fg-primary transition-colors duration-200 ease-out"
+            >
+              {t("impressum")}
+            </a>
+            <a
+              href="#"
+              className="text-caption text-fg-tertiary hover:text-fg-primary transition-colors duration-200 ease-out"
+            >
+              {t("datenschutz")}
+            </a>
+          </div>
         </div>
       </div>
     </footer>
+  )
+}
+
+interface FooterColumnProps {
+  eyebrow: string
+  children: React.ReactNode
+}
+
+function FooterColumn({ eyebrow, children }: FooterColumnProps) {
+  return (
+    <div className="flex flex-col gap-m">
+      <Eyebrow as="p">{eyebrow}</Eyebrow>
+      <ul className="flex flex-col gap-s">{children}</ul>
+    </div>
+  )
+}
+
+interface FooterLinkProps {
+  href: string
+  children: React.ReactNode
+  /** Si es link externo o mailto: abre en nueva pestaña con `noopener
+   * noreferrer`. Los links internos usan `next/link`. */
+  external?: boolean
+}
+
+function FooterLink({ href, children, external = false }: FooterLinkProps) {
+  const className =
+    "text-body-s text-fg-secondary hover:text-fg-primary transition-colors duration-200 ease-out"
+
+  if (external) {
+    return (
+      <li>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={className}
+        >
+          {children}
+        </a>
+      </li>
+    )
+  }
+
+  return (
+    <li>
+      <Link href={href} className={className}>
+        {children}
+      </Link>
+    </li>
   )
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -19,14 +19,13 @@
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 + §6.
  */
 
-import Link from "next/link"
-import { getLocale, getTranslations } from "next-intl/server"
+import { getTranslations } from "next-intl/server"
+import { Link } from "@/i18n/navigation"
 import { cn } from "@/lib/utils"
 import BrandLockup from "@/components/brand/BrandLockup"
 import Eyebrow from "@/components/ui/Eyebrow"
 
 export async function Footer() {
-  const locale = await getLocale()
   const t = await getTranslations("footer")
   const tNav = await getTranslations("nav")
   const year = new Date().getFullYear()
@@ -58,19 +57,17 @@ export async function Footer() {
 
           {/* Columna 2 — EXPLORAR */}
           <FooterColumn eyebrow={t("explore")}>
-            <FooterLink href={`/${locale}/events`}>{tNav("events")}</FooterLink>
-            <FooterLink href={`/${locale}/artists`}>
-              {tNav("artists")}
-            </FooterLink>
-            <FooterLink href={`/${locale}/events#esta-semana`}>
+            <FooterLink href="/events">{tNav("events")}</FooterLink>
+            <FooterLink href="/artists">{tNav("artists")}</FooterLink>
+            <FooterLink href="/events#esta-semana">
               {tNav("thisWeek")}
             </FooterLink>
           </FooterColumn>
 
           {/* Columna 3 — PARA VOS */}
           <FooterColumn eyebrow={t("forYou")}>
-            <FooterLink href={`/${locale}/apply`}>{t("apply")}</FooterLink>
-            <FooterLink href={`/${locale}/sign-in`}>{tNav("signIn")}</FooterLink>
+            <FooterLink href="/apply">{t("apply")}</FooterLink>
+            <FooterLink href="/sign-in">{tNav("signIn")}</FooterLink>
           </FooterColumn>
 
           {/* Columna 4 — COMUNIDAD */}
@@ -140,7 +137,8 @@ interface FooterLinkProps {
   href: string
   children: React.ReactNode
   /** Si es link externo o mailto: abre en nueva pestaña con `noopener
-   * noreferrer`. Los links internos usan `next/link`. */
+   * noreferrer`. Los links internos usan el `Link` locale-aware de
+   * `@/i18n/navigation`. */
   external?: boolean
 }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,31 +15,34 @@
  *  - `useState` para el drawer mobile.
  *  - El drawer se cierra automáticamente al navegar (cuando cambia el
  *    pathname) — manejado con `useEffect`.
+ *  - Focus management: Escape cierra el drawer y restaura foco al
+ *    hamburger; al abrir, el foco se mueve al primer link del drawer.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 + §6.
  */
 
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslations } from "next-intl"
-import { useRouter } from "next/navigation"
-import Link from "next/link"
 import { useSession, signOut } from "@/lib/auth-client"
-import { useLocale } from "next-intl"
-import { usePathname } from "@/i18n/navigation"
+import { Link, usePathname, useRouter } from "@/i18n/navigation"
 import { cn } from "@/lib/utils"
 import BrandLockup from "@/components/brand/BrandLockup"
 import LanguageSwitcher from "./LanguageSwitcher"
 
 interface NavItem {
   href: string
+  /** `true` si el item linkea a una sección con hash (`#`). Esos no se
+   * pueden marcar activos basándose solo en el pathname — el hash no se
+   * lee en server-side. Hasta tener un detector client-side basado en
+   * `window.location.hash`, los tratamos como "nunca activos por path". */
+  hashOnly?: boolean
   label: string
 }
 
 export function Header() {
   const t = useTranslations("nav")
-  const locale = useLocale()
   const router = useRouter()
   const pathname = usePathname()
   const { data: session } = useSession()
@@ -53,12 +56,12 @@ export function Header() {
   const navItems: NavItem[] = [
     { href: "/events", label: t("events") },
     { href: "/artists", label: t("artists") },
-    { href: "/events#esta-semana", label: t("thisWeek") },
+    { href: "/events#esta-semana", hashOnly: true, label: t("thisWeek") },
   ]
 
   function handleSignOut() {
     signOut({
-      fetchOptions: { onSuccess: () => router.push(`/${locale}`) },
+      fetchOptions: { onSuccess: () => router.push("/") },
     })
   }
 
@@ -75,17 +78,16 @@ export function Header() {
           paddingRight: "var(--layout-gutter)",
         }}
       >
-        <BrandLockup orientation="horizontal" href={`/${locale}`} />
+        <BrandLockup orientation="horizontal" href="/" />
 
         {/* Nav central — desktop only */}
         <nav className="hidden md:flex items-center gap-l mx-auto">
           {navItems.map((item) => {
-            const localizedHref = `/${locale}${item.href}`
-            const isActive = isNavItemActive(pathname, item.href)
+            const isActive = isNavItemActive(pathname, item)
             return (
               <Link
                 key={item.href}
-                href={localizedHref}
+                href={item.href}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
                   "text-body-s font-medium pb-[2px] border-b-2 transition-colors duration-200 ease-out",
@@ -105,7 +107,6 @@ export function Header() {
           <LanguageSwitcher />
           <UserSlot
             session={session}
-            locale={locale}
             t={t}
             onSignOut={handleSignOut}
           />
@@ -114,22 +115,11 @@ export function Header() {
         {/* Mobile: switcher compacto + hamburguesa */}
         <div className="md:hidden flex items-center gap-s ml-auto">
           <LanguageSwitcher compact />
-          <button
-            type="button"
-            onClick={() => setDrawerOpen((prev) => !prev)}
-            aria-label={drawerOpen ? t("closeMenu") : t("openMenu")}
-            aria-expanded={drawerOpen}
-            aria-controls="header-mobile-drawer"
-            className={cn(
-              "inline-flex items-center justify-center w-9 h-9 rounded-m",
-              "text-2xl leading-none text-fg-primary",
-              "hover:bg-bg-surface-2 transition-colors duration-200 ease-out",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
-              "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
-            )}
-          >
-            {drawerOpen ? "×" : "≡"}
-          </button>
+          <HamburgerButton
+            open={drawerOpen}
+            onToggle={() => setDrawerOpen((prev) => !prev)}
+            t={t}
+          />
         </div>
       </div>
 
@@ -138,7 +128,6 @@ export function Header() {
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         navItems={navItems}
-        locale={locale}
         pathname={pathname}
         session={session}
         t={t}
@@ -148,11 +137,13 @@ export function Header() {
   )
 }
 
-/** Match exacto contra el segmento path-sans-locale. "/events" matchea
- * la página de eventos y sus hijos (`/events/...`). El hash no afecta el
- * matching del nav (el pathname no incluye hashes). */
-function isNavItemActive(pathname: string, itemHref: string): boolean {
-  const [path] = itemHref.split("#")
+/** Match contra el pathname-sans-locale (devuelto por `usePathname` de
+ * `@/i18n/navigation`). Para items con hash (`hashOnly: true`) no
+ * intentamos matchear basándonos en el path — el hash es ambiguo entre
+ * varias rutas y leerlo desde el server-rendered no es posible. */
+function isNavItemActive(pathname: string, item: NavItem): boolean {
+  if (item.hashOnly) return false
+  const path = item.href
   if (path === "/") return pathname === "/"
   return pathname === path || pathname.startsWith(`${path}/`)
 }
@@ -163,23 +154,22 @@ interface SessionLike {
 
 interface UserSlotProps {
   session: SessionLike | null | undefined
-  locale: string
   t: (key: string) => string
   onSignOut: () => void
 }
 
-function UserSlot({ session, locale, t, onSignOut }: UserSlotProps) {
+function UserSlot({ session, t, onSignOut }: UserSlotProps) {
   if (!session) {
     return (
       <div className="flex items-center gap-m">
         <Link
-          href={`/${locale}/sign-in`}
+          href="/sign-in"
           className="text-body-s text-fg-secondary hover:text-fg-primary transition-colors duration-200 ease-out"
         >
           {t("signIn")}
         </Link>
         <Link
-          href={`/${locale}/apply`}
+          href="/apply"
           className={cn(
             "inline-flex items-center rounded-pill bg-brand text-on-brand",
             "px-l py-xs text-body-s font-semibold",
@@ -229,10 +219,38 @@ function getInitials(name: string | null): string | null {
     name
       .split(" ")
       .filter(Boolean)
-      .map((part) => part[0]!)
+      .map((part) => part.charAt(0))
       .join("")
       .toUpperCase()
       .slice(0, 2) || null
+  )
+}
+
+interface HamburgerButtonProps {
+  open: boolean
+  onToggle: () => void
+  t: (key: string) => string
+}
+
+function HamburgerButton({ open, onToggle, t }: HamburgerButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={open ? t("closeMenu") : t("openMenu")}
+      aria-expanded={open}
+      aria-controls="header-mobile-drawer"
+      data-header-hamburger
+      className={cn(
+        "inline-flex items-center justify-center w-9 h-9 rounded-m",
+        "text-2xl leading-none text-fg-primary",
+        "hover:bg-bg-surface-2 transition-colors duration-200 ease-out",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+        "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+      )}
+    >
+      {open ? "×" : "≡"}
+    </button>
   )
 }
 
@@ -240,7 +258,6 @@ interface MobileDrawerProps {
   open: boolean
   onClose: () => void
   navItems: NavItem[]
-  locale: string
   pathname: string
   session: SessionLike | null | undefined
   t: (key: string) => string
@@ -251,25 +268,45 @@ function MobileDrawer({
   open,
   onClose,
   navItems,
-  locale,
   pathname,
   session,
   t,
   onSignOut,
 }: MobileDrawerProps) {
-  // Lock body scroll cuando el drawer está abierto.
+  const firstLinkRef = useRef<HTMLAnchorElement | null>(null)
+
+  // Lock body scroll cuando el drawer está abierto + cerrar con Escape +
+  // gestionar foco (al abrir, mover al primer link; al cerrar, restaurar
+  // al hamburger). TODO: agregar focus trap completo (Tab cycling) y
+  // `inert` sobre el resto del DOM cuando agreguemos un primitivo de
+  // dialog compartido (probable PR de overlays/modals).
   useEffect(() => {
     if (!open) return
-    const prev = document.body.style.overflow
+
+    const prevOverflow = document.body.style.overflow
     document.body.style.overflow = "hidden"
-    return () => {
-      document.body.style.overflow = prev
+    firstLinkRef.current?.focus()
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation()
+        onClose()
+      }
     }
-  }, [open])
+    document.addEventListener("keydown", onKey)
+
+    return () => {
+      document.body.style.overflow = prevOverflow
+      document.removeEventListener("keydown", onKey)
+      const hamburger = document.querySelector<HTMLButtonElement>(
+        "[data-header-hamburger]"
+      )
+      hamburger?.focus()
+    }
+  }, [open, onClose])
 
   return (
     <>
-      {/* Overlay debajo del header (offset por header-h). */}
       <div
         onClick={onClose}
         aria-hidden="true"
@@ -294,16 +331,18 @@ function MobileDrawer({
         style={{ top: "var(--layout-header-h)" }}
       >
         <nav className="flex flex-col gap-xs px-l py-l">
-          {navItems.map((item) => {
-            const localizedHref = `/${locale}${item.href}`
-            const isActive = isNavItemActive(pathname, item.href)
+          {navItems.map((item, index) => {
+            const isActive = isNavItemActive(pathname, item)
             return (
               <Link
                 key={item.href}
-                href={localizedHref}
+                href={item.href}
+                ref={index === 0 ? firstLinkRef : undefined}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
                   "text-body-l py-s rounded-m px-m transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+                  "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page",
                   isActive
                     ? "bg-bg-surface-2 text-fg-primary font-semibold"
                     : "text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary"
@@ -319,13 +358,13 @@ function MobileDrawer({
           {!session ? (
             <div className="flex flex-col gap-s">
               <Link
-                href={`/${locale}/sign-in`}
+                href="/sign-in"
                 className="text-body-s text-fg-secondary hover:text-fg-primary py-s"
               >
                 {t("signIn")}
               </Link>
               <Link
-                href={`/${locale}/apply`}
+                href="/apply"
                 className={cn(
                   "inline-flex items-center justify-center rounded-pill",
                   "bg-brand text-on-brand px-l py-s text-body-s font-semibold",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -277,9 +277,12 @@ function MobileDrawer({
 
   // Lock body scroll cuando el drawer está abierto + cerrar con Escape +
   // gestionar foco (al abrir, mover al primer link; al cerrar, restaurar
-  // al hamburger). TODO: agregar focus trap completo (Tab cycling) y
-  // `inert` sobre el resto del DOM cuando agreguemos un primitivo de
-  // dialog compartido (probable PR de overlays/modals).
+  // al hamburger). El `inert={!open}` sobre el div del drawer se aplica
+  // abajo en el JSX y descalifica el subtree del orden de tabulación
+  // cuando está cerrado (los Links/buttons internos no son focusables
+  // hasta que el drawer abra). TODO pendiente para un PR de overlays:
+  // focus trap completo (Tab cycling adentro del drawer) e `inert`
+  // sobre el resto del DOM cuando se introduzca un primitivo dialog.
   useEffect(() => {
     if (!open) return
 
@@ -323,6 +326,7 @@ function MobileDrawer({
         role="dialog"
         aria-modal="true"
         aria-hidden={!open}
+        inert={!open}
         className={cn(
           "md:hidden fixed inset-x-0 z-50 bg-bg-page border-b border-border",
           "transition-transform duration-200 ease-out",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -321,11 +321,14 @@ function MobileDrawer({
         style={{ top: "var(--layout-header-h)" }}
       />
 
+      {/* Sin role="dialog"/aria-modal mientras el componente no tenga un
+          focus trap real. El `<nav>` interno ya aporta semántica de
+          navegación; `inert` cubre el orden de tabulación cuando está
+          cerrado. Cuando se introduzca el dialog primitive compartido
+          (PR de overlays), volvemos a marcar role="dialog" junto con
+          el focus trap + inert global. */}
       <div
         id="header-mobile-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-hidden={!open}
         inert={!open}
         className={cn(
           "md:hidden fixed inset-x-0 z-50 bg-bg-page border-b border-border",
@@ -342,6 +345,7 @@ function MobileDrawer({
                 key={item.href}
                 href={item.href}
                 ref={index === 0 ? firstLinkRef : undefined}
+                onClick={onClose}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
                   "text-body-l py-s rounded-m px-m transition-colors",
@@ -363,12 +367,14 @@ function MobileDrawer({
             <div className="flex flex-col gap-s">
               <Link
                 href="/sign-in"
+                onClick={onClose}
                 className="text-body-s text-fg-secondary hover:text-fg-primary py-s"
               >
                 {t("signIn")}
               </Link>
               <Link
                 href="/apply"
+                onClick={onClose}
                 className={cn(
                   "inline-flex items-center justify-center rounded-pill",
                   "bg-brand text-on-brand px-l py-s text-body-s font-semibold",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,88 +1,356 @@
+/**
+ * Header — sticky top bar del sitio, presente en todas las pantallas
+ * (public, protected, admin). Compuesto por:
+ *  - BrandLockup horizontal (link a la home del locale activo).
+ *  - Nav central con underline-on-active sangre (desktop).
+ *  - LanguageSwitcher (pills siempre, compactas en mobile).
+ *  - Estado de usuario: "Iniciar sesión" + "Para artistas" si no logueado;
+ *    avatar/iniciales + "Sign out" si logueado.
+ *  - Drawer mobile con la misma nav + estado de usuario, accesible desde
+ *    botón hamburguesa.
+ *
+ * Es client component porque necesita:
+ *  - `usePathname()` para el estado activo del nav.
+ *  - `useSession()` de Better Auth para el estado de usuario.
+ *  - `useState` para el drawer mobile.
+ *  - El drawer se cierra automáticamente al navegar (cuando cambia el
+ *    pathname) — manejado con `useEffect`.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 + §6.
+ */
+
 "use client"
 
-import Link from "next/link"
-import { useLocale, useTranslations } from "next-intl"
-import { useSession, signOut } from "@/lib/auth-client"
+import { useEffect, useState } from "react"
+import { useTranslations } from "next-intl"
 import { useRouter } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import { LanguageSwitcher } from "./LanguageSwitcher"
+import Link from "next/link"
+import { useSession, signOut } from "@/lib/auth-client"
+import { useLocale } from "next-intl"
+import { usePathname } from "@/i18n/navigation"
+import { cn } from "@/lib/utils"
+import BrandLockup from "@/components/brand/BrandLockup"
+import LanguageSwitcher from "./LanguageSwitcher"
+
+interface NavItem {
+  href: string
+  label: string
+}
 
 export function Header() {
   const t = useTranslations("nav")
   const locale = useLocale()
   const router = useRouter()
+  const pathname = usePathname()
   const { data: session } = useSession()
+  const [drawerOpen, setDrawerOpen] = useState(false)
 
-  const initials = session?.user?.name
-    ? session.user.name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2)
-    : null
+  // Cerrar el drawer al navegar (cuando el path cambia).
+  useEffect(() => {
+    setDrawerOpen(false)
+  }, [pathname])
+
+  const navItems: NavItem[] = [
+    { href: "/events", label: t("events") },
+    { href: "/artists", label: t("artists") },
+    { href: "/events#esta-semana", label: t("thisWeek") },
+  ]
+
+  function handleSignOut() {
+    signOut({
+      fetchOptions: { onSuccess: () => router.push(`/${locale}`) },
+    })
+  }
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/90 backdrop-blur-md">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between gap-4">
-        {/* Logo */}
-        <Link href={`/${locale}`} className="flex items-center gap-2.5 shrink-0 group">
-          <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center text-primary-foreground text-sm font-black shadow-md shadow-primary/30 group-hover:scale-105 transition-transform">
-            ♪
-          </div>
-          <span className="font-black text-sm leading-tight hidden sm:block tracking-tight">
-            La Huella<br />
-            <span className="text-primary">del Caminante</span>
-          </span>
-        </Link>
+    <header
+      className="sticky top-0 z-50 border-b border-border bg-bg-page"
+      style={{ height: "var(--layout-header-h)" }}
+    >
+      <div
+        className="mx-auto h-full flex items-center gap-l"
+        style={{
+          maxWidth: "var(--layout-max-w)",
+          paddingLeft: "var(--layout-gutter)",
+          paddingRight: "var(--layout-gutter)",
+        }}
+      >
+        <BrandLockup orientation="horizontal" href={`/${locale}`} />
 
-        {/* Nav */}
-        <nav className="hidden md:flex items-center gap-1">
-          <Link
-            href={`/${locale}/events`}
-            className="px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors"
-          >
-            {t("events")}
-          </Link>
-          <Link
-            href={`/${locale}/artists`}
-            className="px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors"
-          >
-            {t("artists")}
-          </Link>
-          {session && (
-            <Link
-              href={`/${locale}/dashboard`}
-              className="px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors"
-            >
-              {t("dashboard")}
-            </Link>
-          )}
+        {/* Nav central — desktop only */}
+        <nav className="hidden md:flex items-center gap-l mx-auto">
+          {navItems.map((item) => {
+            const localizedHref = `/${locale}${item.href}`
+            const isActive = isNavItemActive(pathname, item.href)
+            return (
+              <Link
+                key={item.href}
+                href={localizedHref}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "text-body-s font-medium pb-[2px] border-b-2 transition-colors duration-200 ease-out",
+                  isActive
+                    ? "border-brand text-fg-primary"
+                    : "border-transparent text-fg-secondary hover:text-fg-primary"
+                )}
+              >
+                {item.label}
+              </Link>
+            )
+          })}
         </nav>
 
-        {/* Right side */}
-        <div className="flex items-center gap-2 ml-auto md:ml-0">
+        {/* Derecha: switcher + estado usuario — desktop */}
+        <div className="hidden md:flex items-center gap-l ml-auto">
           <LanguageSwitcher />
-          {session ? (
-            <div className="flex items-center gap-2">
-              {initials && (
-                <div className="w-8 h-8 rounded-full bg-primary/10 border border-primary/20 text-primary text-xs font-bold flex items-center justify-center hidden sm:flex">
-                  {initials}
-                </div>
-              )}
-              <Button
-                variant="outline"
-                size="sm"
-                className="rounded-full text-xs h-8 px-4"
-                onClick={() =>
-                  signOut({ fetchOptions: { onSuccess: () => router.push(`/${locale}`) } })
-                }
+          <UserSlot
+            session={session}
+            locale={locale}
+            t={t}
+            onSignOut={handleSignOut}
+          />
+        </div>
+
+        {/* Mobile: switcher compacto + hamburguesa */}
+        <div className="md:hidden flex items-center gap-s ml-auto">
+          <LanguageSwitcher compact />
+          <button
+            type="button"
+            onClick={() => setDrawerOpen((prev) => !prev)}
+            aria-label={drawerOpen ? t("closeMenu") : t("openMenu")}
+            aria-expanded={drawerOpen}
+            aria-controls="header-mobile-drawer"
+            className={cn(
+              "inline-flex items-center justify-center w-9 h-9 rounded-m",
+              "text-2xl leading-none text-fg-primary",
+              "hover:bg-bg-surface-2 transition-colors duration-200 ease-out",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+              "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+            )}
+          >
+            {drawerOpen ? "×" : "≡"}
+          </button>
+        </div>
+      </div>
+
+      {/* Drawer mobile */}
+      <MobileDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        navItems={navItems}
+        locale={locale}
+        pathname={pathname}
+        session={session}
+        t={t}
+        onSignOut={handleSignOut}
+      />
+    </header>
+  )
+}
+
+/** Match exacto contra el segmento path-sans-locale. "/events" matchea
+ * la página de eventos y sus hijos (`/events/...`). El hash no afecta el
+ * matching del nav (el pathname no incluye hashes). */
+function isNavItemActive(pathname: string, itemHref: string): boolean {
+  const [path] = itemHref.split("#")
+  if (path === "/") return pathname === "/"
+  return pathname === path || pathname.startsWith(`${path}/`)
+}
+
+interface SessionLike {
+  user?: { name?: string | null } | null
+}
+
+interface UserSlotProps {
+  session: SessionLike | null | undefined
+  locale: string
+  t: (key: string) => string
+  onSignOut: () => void
+}
+
+function UserSlot({ session, locale, t, onSignOut }: UserSlotProps) {
+  if (!session) {
+    return (
+      <div className="flex items-center gap-m">
+        <Link
+          href={`/${locale}/sign-in`}
+          className="text-body-s text-fg-secondary hover:text-fg-primary transition-colors duration-200 ease-out"
+        >
+          {t("signIn")}
+        </Link>
+        <Link
+          href={`/${locale}/apply`}
+          className={cn(
+            "inline-flex items-center rounded-pill bg-brand text-on-brand",
+            "px-l py-xs text-body-s font-semibold",
+            "hover:bg-brand-dim transition-colors duration-200 ease-out",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+          )}
+        >
+          {t("forArtists")}
+        </Link>
+      </div>
+    )
+  }
+
+  const initials = getInitials(session.user?.name ?? null)
+
+  return (
+    <div className="flex items-center gap-s">
+      <div
+        aria-hidden="true"
+        className={cn(
+          "w-9 h-9 rounded-pill bg-bg-surface-2 border border-border",
+          "flex items-center justify-center text-caption font-semibold text-fg-primary"
+        )}
+      >
+        {initials ?? "·"}
+      </div>
+      <button
+        type="button"
+        onClick={onSignOut}
+        className={cn(
+          "text-body-s text-fg-secondary hover:text-fg-primary",
+          "transition-colors duration-200 ease-out",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+          "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page rounded-s px-xs"
+        )}
+      >
+        {t("signOut")}
+      </button>
+    </div>
+  )
+}
+
+function getInitials(name: string | null): string | null {
+  if (!name) return null
+  return (
+    name
+      .split(" ")
+      .filter(Boolean)
+      .map((part) => part[0]!)
+      .join("")
+      .toUpperCase()
+      .slice(0, 2) || null
+  )
+}
+
+interface MobileDrawerProps {
+  open: boolean
+  onClose: () => void
+  navItems: NavItem[]
+  locale: string
+  pathname: string
+  session: SessionLike | null | undefined
+  t: (key: string) => string
+  onSignOut: () => void
+}
+
+function MobileDrawer({
+  open,
+  onClose,
+  navItems,
+  locale,
+  pathname,
+  session,
+  t,
+  onSignOut,
+}: MobileDrawerProps) {
+  // Lock body scroll cuando el drawer está abierto.
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  return (
+    <>
+      {/* Overlay debajo del header (offset por header-h). */}
+      <div
+        onClick={onClose}
+        aria-hidden="true"
+        className={cn(
+          "md:hidden fixed inset-x-0 bottom-0 bg-bg-page/80 backdrop-blur-sm z-40",
+          "transition-opacity duration-200 ease-out",
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        )}
+        style={{ top: "var(--layout-header-h)" }}
+      />
+
+      <div
+        id="header-mobile-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-hidden={!open}
+        className={cn(
+          "md:hidden fixed inset-x-0 z-50 bg-bg-page border-b border-border",
+          "transition-transform duration-200 ease-out",
+          open ? "translate-y-0" : "-translate-y-full"
+        )}
+        style={{ top: "var(--layout-header-h)" }}
+      >
+        <nav className="flex flex-col gap-xs px-l py-l">
+          {navItems.map((item) => {
+            const localizedHref = `/${locale}${item.href}`
+            const isActive = isNavItemActive(pathname, item.href)
+            return (
+              <Link
+                key={item.href}
+                href={localizedHref}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "text-body-l py-s rounded-m px-m transition-colors",
+                  isActive
+                    ? "bg-bg-surface-2 text-fg-primary font-semibold"
+                    : "text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary"
+                )}
               >
-                {t("signOut")}
-              </Button>
+                {item.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="border-t border-border px-l py-l">
+          {!session ? (
+            <div className="flex flex-col gap-s">
+              <Link
+                href={`/${locale}/sign-in`}
+                className="text-body-s text-fg-secondary hover:text-fg-primary py-s"
+              >
+                {t("signIn")}
+              </Link>
+              <Link
+                href={`/${locale}/apply`}
+                className={cn(
+                  "inline-flex items-center justify-center rounded-pill",
+                  "bg-brand text-on-brand px-l py-s text-body-s font-semibold",
+                  "hover:bg-brand-dim transition-colors duration-200 ease-out"
+                )}
+              >
+                {t("forArtists")}
+              </Link>
             </div>
           ) : (
-            <Button asChild size="sm" className="rounded-full h-8 px-5 text-xs font-semibold shadow-md shadow-primary/20">
-              <Link href={`/${locale}/sign-in`}>{t("signIn")}</Link>
-            </Button>
+            <div className="flex items-center justify-between gap-m">
+              <span className="text-body-s text-fg-secondary">
+                {session.user?.name ?? ""}
+              </span>
+              <button
+                type="button"
+                onClick={onSignOut}
+                className="text-body-s text-fg-secondary hover:text-fg-primary py-s"
+              >
+                {t("signOut")}
+              </button>
+            </div>
           )}
         </div>
       </div>
-    </header>
+    </>
   )
 }

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -1,47 +1,99 @@
+/**
+ * LanguageSwitcher — tres pills (`ES · EN · DE`) siempre visibles.
+ *
+ * Decisión cerrada del PM (handoff §5.3 regla 4): el switcher NUNCA se
+ * convierte en dropdown, en ningún breakpoint. En desktop las pills van
+ * separadas por `·`; en mobile (prop `compact`) se compactan (font menor,
+ * sin separador) pero siguen siendo tres elementos tappables.
+ *
+ * Click cambia el locale manteniendo la ruta actual via `useRouter.replace`
+ * de `@/i18n/navigation` — ese helper preserva el path y solo intercambia
+ * el segmento de locale.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §5.3 + §6.
+ */
+
 "use client"
 
 import { useLocale } from "next-intl"
-import { useRouter, usePathname } from "next/navigation"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { useTransition } from "react"
+import { cn } from "@/lib/utils"
+import { usePathname, useRouter } from "@/i18n/navigation"
+import { routing } from "@/i18n/routing"
 
-const locales = [
-  { code: "es", label: "Español" },
-  { code: "en", label: "English" },
-  { code: "de", label: "Deutsch" },
-]
+export interface LanguageSwitcherProps {
+  /** En mobile (`compact = true`) las pills usan font menor y se omite
+   * el separador `·` entre ellas. */
+  compact?: boolean
+  className?: string
+}
 
-export function LanguageSwitcher() {
-  const locale = useLocale()
+type Locale = (typeof routing.locales)[number]
+
+export default function LanguageSwitcher({
+  compact = false,
+  className,
+}: LanguageSwitcherProps) {
+  const activeLocale = useLocale() as Locale
   const router = useRouter()
   const pathname = usePathname()
+  const [isPending, startTransition] = useTransition()
 
-  function switchLocale(newLocale: string) {
-    const segments = pathname.split("/")
-    segments[1] = newLocale
-    router.push(segments.join("/"))
+  function switchTo(next: Locale) {
+    if (next === activeLocale) return
+    startTransition(() => {
+      router.replace(pathname, { locale: next })
+    })
   }
 
+  const pillBase = cn(
+    "inline-flex items-center justify-center font-mono uppercase font-semibold",
+    "rounded-pill transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+    "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page",
+    compact ? "text-mono px-s py-[2px]" : "text-mono px-m py-xs"
+  )
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="inline-flex items-center justify-center rounded-md px-2 py-1 text-sm font-medium hover:bg-accent transition-colors">
-        {locale.toUpperCase()}
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {locales.map((l) => (
-          <DropdownMenuItem
-            key={l.code}
-            onClick={() => switchLocale(l.code)}
-            className={locale === l.code ? "font-semibold" : ""}
-          >
-            {l.label}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div
+      className={cn(
+        "inline-flex items-center",
+        compact ? "gap-xs" : "gap-s",
+        className
+      )}
+      role="group"
+      aria-label="Language switcher"
+    >
+      {routing.locales.map((loc, i) => {
+        const isActive = loc === activeLocale
+        return (
+          <span key={loc} className="inline-flex items-center">
+            <button
+              type="button"
+              onClick={() => switchTo(loc)}
+              disabled={isPending}
+              aria-pressed={isActive}
+              className={cn(
+                pillBase,
+                isActive
+                  ? "bg-bg-surface-2 text-fg-primary"
+                  : "bg-transparent text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary",
+                isPending && "opacity-60 cursor-wait"
+              )}
+            >
+              {loc.toUpperCase()}
+            </button>
+            {!compact && i < routing.locales.length - 1 && (
+              <span
+                aria-hidden="true"
+                className="ml-s text-fg-tertiary select-none"
+              >
+                ·
+              </span>
+            )}
+          </span>
+        )
+      })}
+    </div>
   )
 }

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -15,7 +15,7 @@
 
 "use client"
 
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { cn } from "@/lib/utils"
 import { usePathname, useRouter } from "@/i18n/navigation"
 import { routing } from "@/i18n/routing"
@@ -36,6 +36,7 @@ export default function LanguageSwitcher({
   const activeLocale = useLocale() as Locale
   const router = useRouter()
   const pathname = usePathname()
+  const tNav = useTranslations("nav")
 
   function switchTo(next: Locale) {
     if (next === activeLocale) return
@@ -58,7 +59,7 @@ export default function LanguageSwitcher({
         className
       )}
       role="group"
-      aria-label="Language switcher"
+      aria-label={tNav("languageSwitcherLabel")}
     >
       {routing.locales.map((loc, i) => {
         const isActive = loc === activeLocale

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -16,7 +16,6 @@
 "use client"
 
 import { useLocale } from "next-intl"
-import { useTransition } from "react"
 import { cn } from "@/lib/utils"
 import { usePathname, useRouter } from "@/i18n/navigation"
 import { routing } from "@/i18n/routing"
@@ -37,13 +36,10 @@ export default function LanguageSwitcher({
   const activeLocale = useLocale() as Locale
   const router = useRouter()
   const pathname = usePathname()
-  const [isPending, startTransition] = useTransition()
 
   function switchTo(next: Locale) {
     if (next === activeLocale) return
-    startTransition(() => {
-      router.replace(pathname, { locale: next })
-    })
+    router.replace(pathname, { locale: next })
   }
 
   const pillBase = cn(
@@ -71,14 +67,12 @@ export default function LanguageSwitcher({
             <button
               type="button"
               onClick={() => switchTo(loc)}
-              disabled={isPending}
               aria-pressed={isActive}
               className={cn(
                 pillBase,
                 isActive
                   ? "bg-bg-surface-2 text-fg-primary"
-                  : "bg-transparent text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary",
-                isPending && "opacity-60 cursor-wait"
+                  : "bg-transparent text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary"
               )}
             >
               {loc.toUpperCase()}

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -1,0 +1,18 @@
+/**
+ * Helpers de navegación locale-aware de next-intl, atados al `routing` del
+ * proyecto. Usar estos en lugar de los de `next/navigation` cuando se quiera:
+ *  - Preservar el locale al navegar dentro del mismo idioma (`Link`,
+ *    `useRouter` re-exportados acá).
+ *  - Cambiar de locale manteniendo la ruta actual (`router.replace(pathname,
+ *    { locale: nextLocale })`).
+ *  - Leer el pathname **sin** el prefijo `/[locale]` (`usePathname()` de acá).
+ *
+ * Para navegación que ignora locale (ej. links a `#` o URLs externas), seguir
+ * usando `next/link` directamente.
+ */
+
+import { createNavigation } from "next-intl/navigation"
+import { routing } from "./routing"
+
+export const { Link, redirect, usePathname, useRouter, getPathname } =
+  createNavigation(routing)

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -173,9 +173,6 @@
   },
   "footer": {
     "tagline": "Lebendige lateinamerikanische Musik in Deutschland. Aus Berlin.",
-    "events": "Veranstaltungen",
-    "artists": "Künstler",
-    "login": "Anmelden",
     "copyright": "© {year} La Huella del Caminante. Gemacht mit ♥ in Berlin von Thusspokedata",
     "explore": "Entdecken",
     "forYou": "Für dich",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -4,7 +4,11 @@
     "artists": "Künstler",
     "dashboard": "Dashboard",
     "signIn": "Anmelden",
-    "signOut": "Abmelden"
+    "signOut": "Abmelden",
+    "thisWeek": "Diese Woche",
+    "forArtists": "Für Künstler",
+    "openMenu": "Menü öffnen",
+    "closeMenu": "Menü schließen"
   },
   "home": {
     "badge": "Berlin · Lateinamerikanische Musik",
@@ -168,11 +172,18 @@
     "createEvent": "Veranstaltung erstellen"
   },
   "footer": {
-    "tagline": "Lateinamerikanische Musik · Berlin",
+    "tagline": "Lebendige lateinamerikanische Musik in Deutschland. Aus Berlin.",
     "events": "Veranstaltungen",
     "artists": "Künstler",
     "login": "Anmelden",
-    "copyright": "© {year} La Huella del Caminante. Gemacht mit ♥ in Berlin von Thusspokedata"
+    "copyright": "© {year} La Huella del Caminante. Gemacht mit ♥ in Berlin von Thusspokedata",
+    "explore": "Entdecken",
+    "forYou": "Für dich",
+    "community": "Community",
+    "apply": "Bewerben",
+    "newsletter": "Newsletter",
+    "impressum": "Impressum",
+    "datenschutz": "Datenschutz"
   },
   "status": {
     "pending": "Ausstehend",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -8,7 +8,8 @@
     "thisWeek": "Diese Woche",
     "forArtists": "Für Künstler",
     "openMenu": "Menü öffnen",
-    "closeMenu": "Menü schließen"
+    "closeMenu": "Menü schließen",
+    "languageSwitcherLabel": "Sprachauswahl"
   },
   "home": {
     "badge": "Berlin · Lateinamerikanische Musik",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -4,7 +4,11 @@
     "artists": "Artists",
     "dashboard": "Dashboard",
     "signIn": "Sign In",
-    "signOut": "Sign Out"
+    "signOut": "Sign Out",
+    "thisWeek": "This week",
+    "forArtists": "For artists",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
   },
   "home": {
     "badge": "Berlin · Latin Music",
@@ -168,11 +172,18 @@
     "createEvent": "Create Event"
   },
   "footer": {
-    "tagline": "Latin American Music · Berlin",
+    "tagline": "Live Latin music in Germany. Made in Berlin.",
     "events": "Events",
     "artists": "Artists",
     "login": "Log in",
-    "copyright": "© {year} La Huella del Caminante. Made with ♥ in Berlin by Thusspokedata"
+    "copyright": "© {year} La Huella del Caminante. Made with ♥ in Berlin by Thusspokedata",
+    "explore": "Explore",
+    "forYou": "For you",
+    "community": "Community",
+    "apply": "Apply",
+    "newsletter": "Newsletter",
+    "impressum": "Impressum",
+    "datenschutz": "Datenschutz"
   },
   "status": {
     "pending": "Pending",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -8,7 +8,8 @@
     "thisWeek": "This week",
     "forArtists": "For artists",
     "openMenu": "Open menu",
-    "closeMenu": "Close menu"
+    "closeMenu": "Close menu",
+    "languageSwitcherLabel": "Language switcher"
   },
   "home": {
     "badge": "Berlin · Latin Music",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -173,9 +173,6 @@
   },
   "footer": {
     "tagline": "Live Latin music in Germany. Made in Berlin.",
-    "events": "Events",
-    "artists": "Artists",
-    "login": "Log in",
     "copyright": "© {year} La Huella del Caminante. Made with ♥ in Berlin by Thusspokedata",
     "explore": "Explore",
     "forYou": "For you",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -8,7 +8,8 @@
     "thisWeek": "Esta semana",
     "forArtists": "Para artistas",
     "openMenu": "Abrir menú",
-    "closeMenu": "Cerrar menú"
+    "closeMenu": "Cerrar menú",
+    "languageSwitcherLabel": "Selector de idioma"
   },
   "home": {
     "badge": "Berlín · Música Latina",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -173,9 +173,6 @@
   },
   "footer": {
     "tagline": "Música latina viva en Alemania. Hecha en Berlín.",
-    "events": "Eventos",
-    "artists": "Artistas",
-    "login": "Acceder",
     "copyright": "© {year} La Huella del Caminante. Hecho con ♥ en Berlín by Thusspokedata",
     "explore": "Explorar",
     "forYou": "Para vos",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -4,7 +4,11 @@
     "artists": "Artistas",
     "dashboard": "Panel",
     "signIn": "Iniciar sesión",
-    "signOut": "Cerrar sesión"
+    "signOut": "Cerrar sesión",
+    "thisWeek": "Esta semana",
+    "forArtists": "Para artistas",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú"
   },
   "home": {
     "badge": "Berlín · Música Latina",
@@ -168,11 +172,18 @@
     "createEvent": "Crear Evento"
   },
   "footer": {
-    "tagline": "Música Latinoamericana · Berlín",
+    "tagline": "Música latina viva en Alemania. Hecha en Berlín.",
     "events": "Eventos",
     "artists": "Artistas",
     "login": "Acceder",
-    "copyright": "© {year} La Huella del Caminante. Hecho con ♥ en Berlín by Thusspokedata"
+    "copyright": "© {year} La Huella del Caminante. Hecho con ♥ en Berlín by Thusspokedata",
+    "explore": "Explorar",
+    "forYou": "Para vos",
+    "community": "Comunidad",
+    "apply": "Aplicar",
+    "newsletter": "Newsletter",
+    "impressum": "Impressum",
+    "datenschutz": "Datenschutz"
   },
   "status": {
     "pending": "Pendiente",


### PR DESCRIPTION
## Summary

PR 4 del rediseño visual. Integra los componentes de `@/components/brand` y `@/components/ui` (del PR #10) y los tokens (del PR #9) en los tres elementos del **shell** del sitio: Header, Footer y LanguageSwitcher.

Estos tres aparecen en todas las pantallas, así que el cambio se ve inmediatamente en home, listings, dashboard, admin, sign-in, etc.

## Qué cambia

| Componente | Cambio |
|---|---|
| `Header.tsx` | Reescrito client. BrandLockup horizontal a la izquierda, nav con underline-on-active sangre al centro, LanguageSwitcher + UserSlot (no-logueado o logueado) a la derecha. Drawer hamburguesa en mobile con focus management (Escape, foco al primer link, restauración al hamburger). |
| `Footer.tsx` | Reescrito server async. 4 columnas (Marca / EXPLORAR / PARA VOS / COMUNIDAD) que pasan a stack en mobile. Línea inferior con copyright + Impressum/Datenschutz (slot legal a `#` por ahora). |
| `LanguageSwitcher.tsx` | Reescrito client. Tres pills `ES · EN · DE` siempre visibles. **Nunca dropdown** en ningún breakpoint (decisión cerrada del PM, handoff §5.3 regla 4). Prop `compact` para mobile. |
| `src/i18n/navigation.ts` | **Nuevo.** Expone `Link`/`useRouter`/`usePathname`/`redirect` locale-aware via `createNavigation(routing)` de next-intl. Header, Footer y Switcher lo consumen. |

## Qué NO cambia (todavía)

- No se tocó ninguna `page.tsx`. El Header/Footer ya estaban integrados en los layouts `(public)`, `(protected)`, `(admin)`.
- No se tocó shadcn ni componentes UI viejos (cards, hero, etc.).
- No se tocó `DashboardShell` (PR 8).
- No se rediseñaron sign-in / sign-up (PR 10 del plan).

**Consecuencia visual:** el shell se ve rediseñado, pero el contenido de cada pantalla sigue con el look viejo (cards, heros, etc.). Es esperado y se resuelve en PRs siguientes.

## i18n

Claves nuevas agregadas en los 3 locales (es/en/de):

- `nav.thisWeek`, `nav.forArtists`, `nav.openMenu`, `nav.closeMenu`
- `footer.tagline` (actualizado al copy del handoff), `footer.explore`, `footer.forYou`, `footer.community`, `footer.apply`, `footer.newsletter`, `footer.impressum`, `footer.datenschutz`

Claves legacy eliminadas (`footer.events`, `footer.artists`, `footer.login`) por consolidarse en `nav.*`.

## Review interno (paso 3 del flujo)

Pasé el diff por `architecture-reviewer`. Resultado: **5 hallazgos** (1 ALTO, 2 MEDIO, 2 BAJO). Apliqué los 5 en commit \`c04ad98\`:

- **ALTO**: bug donde estando en `/events`, los items "Eventos" y "Esta semana" (`/events#esta-semana`) quedaban activos simultáneamente. Fix: flag `hashOnly` en `NavItem` para que items de hash no se marquen activos por path. La detección por hash (`window.location.hash`) queda como TODO para cuando exista la sección real.
- **MEDIO**: inconsistencia de patrones — agregué el helper `@/i18n/navigation` pero el Header y Footer seguían con template strings `/\${locale}/...`. Migré ambos al helper; los hrefs ahora son paths sin locale.
- **MEDIO**: MobileDrawer sin focus management. Agregué Escape key, foco al primer link al abrir, restauración al hamburger al cerrar. Focus trap completo (Tab cycling) + `inert` quedan para cuando se introduzca un primitivo dialog compartido (TODO documentado en código).
- **BAJO**: `useTransition` en LanguageSwitcher sin valor visible. Removido.
- **BAJO**: claves i18n muertas en `footer.{events,artists,login}` después del refactor. Eliminadas.

## Verificación visual sugerida post-merge

1. Home pública sin login: Header con BrandLockup + nav + switcher + "Iniciar sesión" + "Para artistas".
2. `/events`: link "Eventos" activo con underline sangre. "Esta semana" **no** activo (es link con hash).
3. Click en `EN`/`DE`: cambia el locale manteniendo el path.
4. Mobile (< 768px): switcher compacto, hamburguesa visible, drawer abre/cierra.
5. Logueado: avatar con iniciales + "Sign out" en lugar de los CTAs.

## Test plan

- [ ] CI / CodeRabbit pasa.
- [ ] `npm run build` sin errores.
- [ ] Navegar las 3 secciones públicas y verificar Header/Footer.
- [ ] Cambiar idioma desde `/events/<slug>` y verificar que mantiene el path.
- [ ] Mobile: abrir drawer, presionar Escape, verificar que cierra y vuelve el foco.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile navigation drawer with hamburger, Escape-to-close, backdrop, focus restore, body-scroll lock, and sign-out redirect.
  * Redesigned responsive 4-column footer; contact email always visible and links open appropriately.
  * Inline language-switcher pills for quick locale changes.

* **Style**
  * Sticky header with enhanced desktop nav and active-link indicators.

* **Translations**
  * Updated EN/ES/DE navigation and footer copy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->