### PR TITLE
fix: tolerate stringified Date from next.js cache (RangeError on /events)

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -364,17 +364,27 @@ const LOCALE_MAP: Record<string, string> = {
   de: "de-DE",
 }
 
+/**
+ * Acepta `Date | string` en `from`/`to` porque `unstable_cache` de Next.js
+ * serializa los `Date` a string ISO al guardar y NO los re-hidrata al leer.
+ * `UpcomingStats.dateRange` viene del cache de `getUpcomingStats()`, así
+ * que después del primer hit los campos llegan como strings y `Intl.format()`
+ * sobre un string tira `RangeError: Invalid time value`. */
 function formatDateRange(
-  range: { from: Date | null; to: Date | null },
+  range: { from: Date | string | null; to: Date | string | null },
   locale: string
 ): string {
   if (!range.from || !range.to) return ""
+  const fromObj =
+    range.from instanceof Date ? range.from : new Date(range.from)
+  const toObj = range.to instanceof Date ? range.to : new Date(range.to)
+  if (isNaN(fromObj.getTime()) || isNaN(toObj.getTime())) return ""
   const intl = new Intl.DateTimeFormat(LOCALE_MAP[locale] ?? "es-ES", {
     day: "numeric",
     month: "short",
   })
-  const from = intl.format(range.from).replace(/\./g, "")
-  const to = intl.format(range.to).replace(/\./g, "")
+  const from = intl.format(fromObj).replace(/\./g, "")
+  const to = intl.format(toObj).replace(/\./g, "")
   if (from === to) return from
   return `${from} – ${to}`
 }

--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -365,11 +365,11 @@ const LOCALE_MAP: Record<string, string> = {
 }
 
 /**
- * Acepta `Date | string` en `from`/`to` porque `unstable_cache` de Next.js
- * serializa los `Date` a string ISO al guardar y NO los re-hidrata al leer.
- * `UpcomingStats.dateRange` viene del cache de `getUpcomingStats()`, así
- * que después del primer hit los campos llegan como strings y `Intl.format()`
- * sobre un string tira `RangeError: Invalid time value`. */
+ * Re-hidratación: a partir de este PR `getUpcomingStats()` rehidrata el
+ * `dateRange` antes de devolverlo (ver `src/lib/date.ts`), así que `from`
+ * y `to` vienen como `Date` real en uso normal. La signature `Date | string`
+ * y la conversión defensiva quedan como red de seguridad para callers que
+ * pudieran pasar ISO strings directamente. */
 function formatDateRange(
   range: { from: Date | string | null; to: Date | string | null },
   locale: string

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -136,11 +136,12 @@ export async function EventCard({
 /** "DOM 7 JUN · 19:30" (o equivalente por locale). Vacío si no hay date
  * o la date es inválida.
  *
- * IMPORTANTE: acepta `Date | string` porque `unstable_cache` de Next.js
- * serializa los `Date` a string ISO al guardar en cache y NO los re-hidrata
- * al leer. La declaración de `EventSummary.dates` como `Date[]` es honesta
- * en compile-time pero en runtime, después del primer cache hit, los items
- * vienen como strings. */
+ * Re-hidratación: a partir de este PR los services rehidratan `Date` post-
+ * cache (ver `src/lib/date.ts`), así que en uso normal `date` viene como
+ * `Date` real. La signature `Date | string` y la conversión defensiva
+ * quedan como red de seguridad para callers que pudieran pasar el ISO
+ * string directamente (ej. data de una API externa, fixtures de test,
+ * nuevos servicios que olviden el wrapper). */
 function formatEyebrow(
   date: Date | string | null,
   time: string | null,

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -133,19 +133,28 @@ export async function EventCard({
   )
 }
 
-/** "DOM 7 JUN · 19:30" (o equivalente por locale). Vacío si no hay date. */
+/** "DOM 7 JUN · 19:30" (o equivalente por locale). Vacío si no hay date
+ * o la date es inválida.
+ *
+ * IMPORTANTE: acepta `Date | string` porque `unstable_cache` de Next.js
+ * serializa los `Date` a string ISO al guardar en cache y NO los re-hidrata
+ * al leer. La declaración de `EventSummary.dates` como `Date[]` es honesta
+ * en compile-time pero en runtime, después del primer cache hit, los items
+ * vienen como strings. */
 function formatEyebrow(
-  date: Date | null,
+  date: Date | string | null,
   time: string | null,
   locale: string
 ): string {
   if (!date) return ""
+  const dateObj = date instanceof Date ? date : new Date(date)
+  if (isNaN(dateObj.getTime())) return ""
   const intl = new Intl.DateTimeFormat(MONTHS_BY_LOCALE[locale] ?? "es-ES", {
     weekday: "short",
     day: "numeric",
     month: "short",
   })
-  const label = intl.format(date).replace(/\./g, "").toUpperCase()
+  const label = intl.format(dateObj).replace(/\./g, "").toUpperCase()
   return time ? `${label} · ${time}` : label
 }
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,34 @@
+/**
+ * Helpers para re-hidratar `Date` después de pasar por `unstable_cache` de
+ * Next.js. La cache serializa a JSON al guardar y NO convierte los strings
+ * ISO de vuelta a `Date` al leer, así que cualquier valor `Date` declarado
+ * en el tipo del servicio llega como `string` tras un cache hit.
+ *
+ * Convención: los services cacheados aplican `rehydrateDate`/`rehydrateDates`
+ * en el wrapper post-cache para que los consumers reciban siempre `Date[]`
+ * reales y no tengan que defenderse uno por uno.
+ *
+ * Llamar `rehydrateDate(date)` es seguro sobre un `Date` ya vivo (no-op +
+ * validación) o sobre un `string` ISO (lo parsea); devuelve `null` para
+ * inputs vacíos o no parseables.
+ */
+
+export function rehydrateDate(
+  value: Date | string | null | undefined
+): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value
+  const d = new Date(value)
+  return isNaN(d.getTime()) ? null : d
+}
+
+export function rehydrateDates(
+  values: ReadonlyArray<Date | string | null | undefined>
+): Date[] {
+  const out: Date[] = []
+  for (const v of values) {
+    const d = rehydrateDate(v)
+    if (d) out.push(d)
+  }
+  return out
+}

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -2,8 +2,18 @@ import "server-only"
 
 import { unstable_cache, revalidateTag } from "next/cache"
 import { prisma } from "@/lib/prisma"
+import { rehydrateDate, rehydrateDates } from "@/lib/date"
 import { generateUniqueSlug } from "@/lib/slugify"
 import { deleteImages } from "./cloudinary"
+
+/**
+ * Re-hidrata los `Date` de un `EventSummary` por si vienen como string
+ * desde `unstable_cache`. Ver `src/lib/date.ts` para el porqué. Es un
+ * no-op cuando se llama sobre un objeto cuyas dates ya son Date reales
+ * (caso pre-cache dentro de un callback de `unstable_cache`). */
+function rehydrateEvent(e: EventSummary): EventSummary {
+  return { ...e, dates: rehydrateDates(e.dates) }
+}
 
 export interface EventSummary {
   id: string
@@ -176,7 +186,7 @@ export const getHeroVariant = unstable_cache(
  * futuras y los resultados se ordenan por la próxima fecha (no por
  * createdAt) — la card depende de `event.dates[0]` para mostrar "JUN 7".
  */
-export const getUpcomingEventsWithin = unstable_cache(
+const _getUpcomingEventsWithin = unstable_cache(
   async (days: number, limit?: number): Promise<EventSummary[]> => {
     const now = new Date()
     const until = new Date(now)
@@ -196,6 +206,13 @@ export const getUpcomingEventsWithin = unstable_cache(
   { revalidate: 300, tags: ["events"] }
 )
 
+export async function getUpcomingEventsWithin(
+  days: number,
+  limit?: number
+): Promise<EventSummary[]> {
+  return (await _getUpcomingEventsWithin(days, limit)).map(rehydrateEvent)
+}
+
 /**
  * Próximos 3-N eventos para la sección "Imperdibles" de la home. Por ahora
  * usamos un proxy: los próximos por fecha. TODO: cuando exista un flag
@@ -203,7 +220,7 @@ export const getUpcomingEventsWithin = unstable_cache(
  * filtra dates a futuras y los resultados se ordenan por la próxima fecha
  * (no por createdAt) para que la card muestre la fecha próxima real.
  */
-export const getFeaturedEvents = unstable_cache(
+const _getFeaturedEvents = unstable_cache(
   async (limit = 3): Promise<EventSummary[]> => {
     const now = new Date()
     const events = await prisma.event.findMany({
@@ -220,6 +237,10 @@ export const getFeaturedEvents = unstable_cache(
   { revalidate: 300, tags: ["events"] }
 )
 
+export async function getFeaturedEvents(limit = 3): Promise<EventSummary[]> {
+  return (await _getFeaturedEvents(limit)).map(rehydrateEvent)
+}
+
 export interface UpcomingStats {
   shows: number
   artists: number
@@ -232,7 +253,7 @@ export interface UpcomingStats {
  * cuántos artistas distintos, cuántas ciudades distintas y el rango de
  * fechas que cubren. Devuelve `dateRange.from/to = null` si no hay eventos.
  */
-export const getUpcomingStats = unstable_cache(
+const _getUpcomingStats = unstable_cache(
   async (): Promise<UpcomingStats> => {
     const now = new Date()
     const events = await prisma.event.findMany({
@@ -281,7 +302,18 @@ export const getUpcomingStats = unstable_cache(
   { revalidate: 300, tags: ["events"] }
 )
 
-export const getUpcomingEvents = unstable_cache(
+export async function getUpcomingStats(): Promise<UpcomingStats> {
+  const s = await _getUpcomingStats()
+  return {
+    ...s,
+    dateRange: {
+      from: rehydrateDate(s.dateRange.from),
+      to: rehydrateDate(s.dateRange.to),
+    },
+  }
+}
+
+const _getUpcomingEvents = unstable_cache(
   async (filters?: { genre?: string; city?: string }): Promise<EventSummary[]> => {
     const events = await prisma.event.findMany({
       where: {
@@ -300,7 +332,13 @@ export const getUpcomingEvents = unstable_cache(
   { revalidate: 300, tags: ["events"] }
 )
 
-export const getPastEvents = unstable_cache(
+export async function getUpcomingEvents(
+  filters?: { genre?: string; city?: string }
+): Promise<EventSummary[]> {
+  return (await _getUpcomingEvents(filters)).map(rehydrateEvent)
+}
+
+const _getPastEvents = unstable_cache(
   async (): Promise<EventSummary[]> => {
     const events = await prisma.event.findMany({
       where: {
@@ -315,6 +353,10 @@ export const getPastEvents = unstable_cache(
   ["past-events"],
   { revalidate: 600, tags: ["events"] }
 )
+
+export async function getPastEvents(): Promise<EventSummary[]> {
+  return (await _getPastEvents()).map(rehydrateEvent)
+}
 
 export async function getEventBySlug(slug: string): Promise<EventDetail | null> {
   const event = await prisma.event.findUnique({


### PR DESCRIPTION
## Summary

**Hotfix de bug de producción.** `GET /es/events` rompía con HTTP 500 + browser:
\`\`\`
Uncaught RangeError: Invalid time value
  at formatEyebrow (src/components/events/EventCard.tsx:148:22)
  at EventCard (src/components/events/EventCard.tsx:59:23)
  at EventsPage (src/app/[locale]/(public)/events/page.tsx:47:9)
\`\`\`

## Causa raíz

`unstable_cache` de Next.js **serializa los `Date` a string ISO al guardar y NO los re-hidrata al leer**. El tipo `EventSummary.dates: Date[]` es honesto en compile-time pero en runtime, después del primer cache hit, los items vienen como strings. Llamar `Intl.format()` sobre un string tira `RangeError: Invalid time value`.

`DateTile` ya manejaba este caso (agregado en PR #10). `formatEyebrow` y `formatDateRange` se introdujeron en PR #12 y quedaron sin el tratamiento.

## Fix en 2 capas

### Commit `f1b8b05` — defensa en los 2 consumers afectados (hotfix)
- `EventCard.tsx formatEyebrow`: acepta `Date | string`, convierte con `new Date()` si es string, valida con `isNaN(getTime())`.
- `(public)/page.tsx formatDateRange`: mismo tratamiento sobre `range.from/to` que vienen de `UpcomingStats.dateRange`.

Esto **destraba `/es/events` ya**. Pero el architecture-reviewer marcó como ALTO que dejaba la causa raíz viva: el próximo dev que confiara en el tipo `Date[]` iba a reintroducir el bug.

### Commit `23a26a5` — fix en origen (services)
- Nuevo helper `src/lib/date.ts`: `rehydrateDate` y `rehydrateDates`, idempotentes sobre `Date` reales, parsean strings ISO, validan con `isNaN`.
- 5 servicios cacheados ahora aplican re-hidratación post-cache via wrapper:
  - `getUpcomingEvents` / `getPastEvents` / `getUpcomingEventsWithin` / `getFeaturedEvents` → `.map(rehydrateEvent)` antes de devolver.
  - `getUpcomingStats` → `rehydrateDate(dateRange.from/to)` antes de devolver.
- Servicios NO cacheados (`getEventBySlug`, `getEventsByUser`, etc.) no se tocan: sus `Date` vienen frescos de Prisma.
- Las defensas del primer commit se mantienen como red de seguridad para callers que pudieran pasar ISO strings directos (APIs externas, fixtures, nuevos servicios que olviden el wrapper). Comentarios actualizados.

## Review interno (paso 3 del flujo)

Pasé el primer commit (`f1b8b05`) por `architecture-reviewer`. Resultado: 1 ALTO (el del fix en origen), 2 MEDIO, 1 BAJO. El ALTO se cierra con `23a26a5`. Los MEDIO restantes:
- **`sortByNextDate` asume Date reales**: ahora siempre se cumple porque está dentro del cache callback + el wrapper re-hidrata después. Cerrado de hecho.
- **Duplicación de helpers de formateo locale-aware (4 variantes)**: deuda preexistente, fuera del scope del hotfix. Sugerido para refactor aparte.
- **BAJO firma propagada**: se cierra de hecho con el fix en origen.

## Test plan

- [ ] `GET /es/events` devuelve 200 (no más 500).
- [ ] Home con cache caliente muestra fechas correctas en cards y en stats strip.
- [ ] CI / CodeRabbit pasa.

## Notas operacionales

- Tu WIP en main (los 9 modificados + `BackButton.tsx`) sigue intacto. Este fix no lo toca.
- El conflict pendiente de `ArtistCard.tsx` en main no se resuelve acá — sigue como UU en tu WT local para que vos decidas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date handling and formatting consistency across the app, particularly for cached data. Dates are now properly converted and validated to ensure reliable display and formatting throughout the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->