### PR TITLE
fix: drop gravity=auto when crop=pad in FlyerImage (cloudinary warning)

### DIFF
--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -105,13 +105,19 @@ export default function FlyerImage({
     const { width, height } = ASPECT_DIMENSIONS[aspectRatio]
     return (
       <div className={containerClass}>
+        {/* No usamos `gravity` con `crop="pad"`: Cloudinary solo respeta
+            gravity con crops que recortan (`fill`, `thumb`, etc.). `pad`
+            rellena con bandas, así que la gravity es irrelevante y
+            agregarla dispara un warning ("Auto gravity can only be used
+            with crop modes: auto, crop, fill, lfill, fill_pad, thumb").
+            Si en algún momento se vuelve a `crop="fill"` o `fill_pad`,
+            re-agregar `gravity="auto"`. */}
         <CldImage
           src={publicId}
           alt={alt}
           width={width}
           height={height}
           crop="pad"
-          gravity="auto"
           format="auto"
           quality="auto"
           priority={priority}

--- a/src/components/ui/FlyerImage.tsx
+++ b/src/components/ui/FlyerImage.tsx
@@ -4,8 +4,9 @@
  * en ratio Instagram (4:5 o 1:1), no en landscape, y no deben recortarse.
  *
  * Comportamiento por orden de prioridad:
- *  1. Si hay `publicId`: usa `<CldImage>` (Cloudinary) con `crop="pad"` +
- *     `gravity="auto"` y format/quality automáticos.
+ *  1. Si hay `publicId`: usa `<CldImage>` (Cloudinary) con `crop="pad"` y
+ *     format/quality automáticos. NO se pasa `gravity` porque `pad` no
+ *     recorta (Cloudinary la ignoraría y avisaría en consola).
  *  2. Si hay `src` pero no `publicId`: usa `<Image>` de Next con object-contain.
  *  3. Si no hay ninguno: renderiza fallback de iniciales gigantes sobre un
  *     fondo con radial gradient del color accent (estilo "MS / WP / FC" del


### PR DESCRIPTION
## Summary

Fix de un warning de Cloudinary visible en cada render de `EventCard`/`ArtistCard`:

> Auto gravity can only be used with crop modes: auto, crop, fill, lfill, fill_pad, thumb. Not applying gravity.

## Causa

En el PR #10 cambiamos `crop="fill"` por `crop="pad"` (handoff §1.4: nunca recortar texto del flyer) pero dejamos huérfana la prop `gravity="auto"`. Cloudinary solo respeta `gravity` con crops que recortan (`fill`, `thumb`, `fill_pad`, etc.); `pad` rellena con bandas y la `gravity` es irrelevante ahí.

## Fix

Una línea: eliminar `gravity="auto"` del `<CldImage>`. Comportamiento visual no cambia (la imagen sigue contenida con padding sobre `bg-bg-surface-2`). Agrego comentario para que si en el futuro se vuelve a `fill` o `fill_pad`, se re-agregue la gravity junto con el crop.

## Test plan

- [ ] Recargar `/es/artists` y `/es/artists/<slug>` en el browser.
- [ ] Verificar consola: el warning ya no aparece.
- [ ] Visualmente: las cards e imágenes se ven igual que antes.
- [ ] CI / CodeRabbit pasa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a spurious image-provider warning when displaying flyer images; no visual changes to image sizing, containment, or fallback flows.
  * Internal notes updated to reflect the new behavior and avoid triggering console warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->