### PR TITLE
feat: BackButton component + auth back-home link + detail page polish

### DIFF
--- a/src/app/[locale]/(auth)/sign-in/page.tsx
+++ b/src/app/[locale]/(auth)/sign-in/page.tsx
@@ -81,6 +81,12 @@ export default function SignInPage() {
               {t("signUp")}
             </Link>
           </p>
+
+          <div className="text-center">
+            <Link href={`/${locale}`} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              ← {t("backHome")}
+            </Link>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/app/[locale]/(auth)/sign-up/page.tsx
+++ b/src/app/[locale]/(auth)/sign-up/page.tsx
@@ -80,6 +80,12 @@ export default function SignUpPage() {
               {t("signIn")}
             </Link>
           </p>
+
+          <div className="text-center">
+            <Link href={`/${locale}`} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              ← {t("backHome")}
+            </Link>
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/app/[locale]/(public)/artists/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/artists/[slug]/page.tsx
@@ -1,12 +1,11 @@
 import { notFound } from "next/navigation"
 import Image from "next/image"
-import Link from "next/link"
 import { getArtistBySlug } from "@/services/artists"
 import { getEventsByArtist } from "@/services/events"
 import { EventList } from "@/components/events/EventList"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { ArrowLeft, ExternalLink } from "lucide-react"
+import { BackButton } from "@/components/ui/BackButton"
+import { ExternalLink } from "lucide-react"
 
 export default async function ArtistDetailPage({
   params,
@@ -31,6 +30,7 @@ export default async function ArtistDetailPage({
             src={images[0].url}
             alt={artist.name}
             fill
+            sizes="100vw"
             className="object-cover"
             priority
           />
@@ -41,12 +41,7 @@ export default async function ArtistDetailPage({
       </div>
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 pb-16 -mt-10 relative">
-        <Button variant="ghost" asChild className="mb-4 text-muted-foreground hover:text-foreground rounded-full -ml-2">
-          <Link href={`/${locale}/artists`}>
-            <ArrowLeft className="w-4 h-4 mr-1.5" />
-            Artistas
-          </Link>
-        </Button>
+        <BackButton label="Artistas" />
 
         {/* Name + meta */}
         <div className="mb-8">
@@ -151,7 +146,7 @@ export default async function ArtistDetailPage({
         {/* Events */}
         {events.length > 0 && (
           <section>
-            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">Próximos eventos</p>
+            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">Próximas fechas</p>
             <EventList events={events} />
           </section>
         )}

--- a/src/app/[locale]/(public)/artists/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/artists/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation"
 import Image from "next/image"
+import { getTranslations } from "next-intl/server"
 import { getArtistBySlug } from "@/services/artists"
 import { getEventsByArtist } from "@/services/events"
 import { EventList } from "@/components/events/EventList"
@@ -13,6 +14,7 @@ export default async function ArtistDetailPage({
   params: Promise<{ locale: string; slug: string }>
 }) {
   const { locale, slug } = await params
+  const t = await getTranslations({ locale, namespace: "artists" })
   const artist = await getArtistBySlug(slug)
 
   if (!artist) notFound()
@@ -41,7 +43,7 @@ export default async function ArtistDetailPage({
       </div>
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 pb-16 -mt-10 relative">
-        <BackButton label="Artistas" />
+        <BackButton label={t("title")} />
 
         {/* Name + meta */}
         <div className="mb-8">
@@ -121,7 +123,7 @@ export default async function ArtistDetailPage({
         {/* Photo gallery (all images) */}
         {images.length > 1 && (
           <section className="mb-12">
-            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">Fotos</p>
+            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">{t("photosLabel")}</p>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {images.map((img, i) => (
                 <div
@@ -146,7 +148,7 @@ export default async function ArtistDetailPage({
         {/* Events */}
         {events.length > 0 && (
           <section>
-            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">Próximas fechas</p>
+            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">{t("upcomingDatesLabel")}</p>
             <EventList events={events} />
           </section>
         )}

--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -29,6 +29,7 @@ export default async function EventDetailPage({
             src={event.coverImage}
             alt={event.title}
             fill
+            sizes="100vw"
             className="object-cover"
             priority
           />

--- a/src/components/ui/BackButton.tsx
+++ b/src/components/ui/BackButton.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { ArrowLeft } from "lucide-react"
+
+interface BackButtonProps {
+  label: string
+}
+
+export function BackButton({ label }: BackButtonProps) {
+  const router = useRouter()
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={() => router.back()}
+      className="mb-4 text-muted-foreground hover:text-foreground rounded-full -ml-2"
+    >
+      <ArrowLeft className="w-4 h-4 mr-1.5" />
+      {label}
+    </Button>
+  )
+}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -94,7 +94,9 @@
     "title": "Künstler",
     "search": "Künstler suchen...",
     "noArtists": "Keine Künstler gefunden",
-    "createArtist": "Künstler erstellen"
+    "createArtist": "Künstler erstellen",
+    "photosLabel": "Fotos",
+    "upcomingDatesLabel": "Kommende Termine"
   },
   "dashboard": {
     "title": "Mein Dashboard",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -221,7 +221,8 @@
     "blockedTitle": "Konto gesperrt",
     "blockedDescription": "Ihr Konto wurde gesperrt. Kontaktieren Sie den Administrator.",
     "noAccount": "Noch kein Konto?",
-    "haveAccount": "Schon ein Konto?"
+    "haveAccount": "Schon ein Konto?",
+    "backHome": "Zur Startseite"
   },
   "common": {
     "save": "Speichern",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -221,7 +221,8 @@
     "blockedTitle": "Account suspended",
     "blockedDescription": "Your account has been suspended. Contact the administrator.",
     "noAccount": "Don't have an account?",
-    "haveAccount": "Already have an account?"
+    "haveAccount": "Already have an account?",
+    "backHome": "Back to home"
   },
   "common": {
     "save": "Save",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -94,7 +94,9 @@
     "title": "Artists",
     "search": "Search artist...",
     "noArtists": "No artists found",
-    "createArtist": "Create Artist"
+    "createArtist": "Create Artist",
+    "photosLabel": "Photos",
+    "upcomingDatesLabel": "Upcoming dates"
   },
   "dashboard": {
     "title": "My Dashboard",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -94,7 +94,9 @@
     "title": "Artistas",
     "search": "Buscar artista...",
     "noArtists": "No se encontraron artistas",
-    "createArtist": "Crear Artista"
+    "createArtist": "Crear Artista",
+    "photosLabel": "Fotos",
+    "upcomingDatesLabel": "Próximas fechas"
   },
   "dashboard": {
     "title": "Mi Panel",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -221,7 +221,8 @@
     "blockedTitle": "Cuenta suspendida",
     "blockedDescription": "Tu cuenta ha sido suspendida. Contacta al administrador.",
     "noAccount": "¿No tienes cuenta?",
-    "haveAccount": "¿Ya tienes cuenta?"
+    "haveAccount": "¿Ya tienes cuenta?",
+    "backHome": "Volver al inicio"
   },
   "common": {
     "save": "Guardar",


### PR DESCRIPTION
## Summary

Rescate de partes útiles del WIP viejo que quedaron sueltas tras el merge de los PRs de rediseño (#11, #12, #13).

- **`BackButton` component** (`src/components/ui/BackButton.tsx`): botón ghost chico con `ArrowLeft` + label que dispara `router.back()`. Tiene `type="button"` explícito (sugerencia que CR había dejado en PR #11 cuando este mismo componente se coló por error). Usado en páginas de detalle para no hardcodear la URL de vuelta y preservar filtros/scroll del listado de origen.
- **Auth back-home link**: link "← Volver al inicio" debajo del form en sign-in y sign-up, con traducciones `auth.backHome` en es/en/de. UX para salir del flujo sin tener que usar el back del browser.
- **`artists/[slug]`**: reemplaza el `<Button asChild><Link href="/artists">` ad-hoc por `<BackButton label="Artistas" />`. Cambia el header del bloque inferior de "Próximos eventos" a "Próximas fechas" para alinear con la terminología del nuevo home.
- **`artists/[slug]` y `events/[slug]`**: agrega `sizes="100vw"` al `<Image fill>` del hero, silencia el warning de `next/image` y mejora la selección de tamaño.

## Test plan

- [ ] `/es/sign-in` y `/es/sign-up` muestran el link "← Volver al inicio" y navega a `/es`
- [ ] Verificar los strings en `/en/sign-in` ("Back to home") y `/de/sign-in` ("Zur Startseite")
- [ ] `/es/artists/<slug>` muestra el botón `BackButton` arriba y `router.back()` funciona desde distintos orígenes (listado, home, deeplink)
- [ ] Header inferior del detalle de artista dice "Próximas fechas"
- [ ] No hay warning de `next/image` sobre `sizes` en consola al abrir `/es/artists/<slug>` y `/es/events/<slug>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "back home" navigation links (arrow icon) on sign-in and sign-up pages and a reusable back button for pages.

* **Improvements**
  * Replaced hardcoded labels with localized strings on artist pages.
  * Improved responsive image sizing for artist and event hero images.

* **Localization**
  * Added translation keys for photos, upcoming dates, and "back home" in English, German, and Spanish.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->