### PR TITLE
fix: add max-width and container scale to @theme to restore Tailwind v4 max-w-* utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,6 +116,48 @@
   --spacing-2xl: 64px;
   --spacing-3xl: 96px;
 
+  /* ── Container & max-width scale ─────────────────────────────
+     Restore Tailwind v4 default sizes overridden por los
+     `--spacing-*` tokens del proyecto. La resolución de
+     `max-w-{name}` en Tailwind v4 es:
+       1. --max-width-{name}   ← lo que definimos acá abajo
+       2. --spacing-{name}     ← acá colisiona con nuestro design system
+       3. --container-{name}   ← fallback
+     Sin estos `--max-width-*`, `max-w-2xl` resolvía a
+     `var(--spacing-2xl)` = 64px en lugar de 42rem (672px),
+     rompiendo cualquier contenedor de texto largo. Los
+     `--container-*` se mantienen porque también los usan
+     `@container` queries y son fallback para `w-*` / `min-w-*`.
+     Valores: defaults de Tailwind v4
+     (`node_modules/tailwindcss/theme.css`). */
+  --max-width-3xs: 16rem;
+  --max-width-2xs: 18rem;
+  --max-width-xs: 20rem;
+  --max-width-sm: 24rem;
+  --max-width-md: 28rem;
+  --max-width-lg: 32rem;
+  --max-width-xl: 36rem;
+  --max-width-2xl: 42rem;
+  --max-width-3xl: 48rem;
+  --max-width-4xl: 56rem;
+  --max-width-5xl: 64rem;
+  --max-width-6xl: 72rem;
+  --max-width-7xl: 80rem;
+
+  --container-3xs: 16rem;
+  --container-2xs: 18rem;
+  --container-xs: 20rem;
+  --container-sm: 24rem;
+  --container-md: 28rem;
+  --container-lg: 32rem;
+  --container-xl: 36rem;
+  --container-2xl: 42rem;
+  --container-3xl: 48rem;
+  --container-4xl: 56rem;
+  --container-5xl: 64rem;
+  --container-6xl: 72rem;
+  --container-7xl: 80rem;
+
   /* ── Radius ───────────────────────────────────────────────── */
   --radius-s: 4px;
   --radius-m: 8px;


### PR DESCRIPTION
## Summary

Bug arquitectónico preexistente desde el PR de tokens del rediseño. En Tailwind v4.2.2 la resolución de `max-w-{name}` es, en orden de prioridad:

1. `--max-width-{name}`
2. `--spacing-{name}`
3. `--container-{name}`

El proyecto definía `--spacing-{xs,xl,2xl,3xl}` en `@theme inline` (para el sistema de p/m/gap del design system), pero no definía `--max-width-*` ni `--container-*`. Resultado: cualquier `max-w-{tshirt}` que colisionara con un key de spacing devolvía el valor de spacing en lugar del default.

**Caso concreto que motivó el fix**: el bio del detalle de artista (`<p className="... max-w-2xl">`) renderizaba en una columna de **64px** (= `--spacing-2xl`) en lugar de **42rem / 672px**, partiendo cada palabra en su propia línea.

## Cambio

Agregar `--max-width-{3xs..7xl}` y `--container-{3xs..7xl}` con los defaults oficiales de Tailwind v4 (verificados contra `node_modules/tailwindcss/theme.css`). Sin tocar `--spacing-*` ni ningún componente.

- `--max-width-*` gana en la cascada y arregla `max-w-*` directamente.
- `--container-*` queda como fallback para `w-*` / `min-w-*` futuros y para `@container` queries.

## Alcance

- 21 ocurrencias de `max-w-{tshirt}` en `src/` se arreglan automáticamente.
- Cero cambios en componentes, pages o lógica de aplicación.
- Es **prerrequisito** del PR 7 en curso (rediseño detail pages) — sin esto el bio rediseñado se rompe igual.

## Observación a tener en cuenta en QA visual

`max-w-7xl` (8 ocurrencias en `(public)/page.tsx`, `(public)/events/page.tsx`, `(public)/artists/page.tsx`, `(public)/apply/page.tsx`, `(protected)/layout.tsx`) **antes no aplicaba ningún tope** porque ni `--spacing-7xl` ni `--container-7xl` existían. Después del fix pasa a `80rem (1280px)`. Eso significa que **en pantallas anchas (>1280px) van a aparecer márgenes laterales que antes no estaban**. Comportamiento correcto según el diseño con `mx-auto`, pero visible.

## Test plan

- [ ] DevTools sobre el bio del detalle de artista: `max-width` computed = `672px` (antes `64px`).
- [ ] Build pasa: `pnpm build`.
- [ ] QA visual rápido en monitor grande (≥1440px): home, listados de events y artists, página apply, layout dashboard — confirmar que se ven centrados con márgenes (esperado), no rotos.
- [ ] QA visual mobile/tablet: sin cambios visibles (el `max-w-*` ya estaba por encima del viewport).
- [ ] Después del merge: rebasear branch `feat/redesign-detail-pages` (PR 7) contra `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CSS design tokens for width and container sizing to ensure proper resolution and prevent naming conflicts within the design system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->