### PR TITLE
feat: redesign event and artist detail pages with data-driven CTA and structured info

### DIFF
--- a/.claude/agents/i18n-reviewer.md
+++ b/.claude/agents/i18n-reviewer.md
@@ -54,7 +54,7 @@ Cuando se te invoque, vas a revisar el código/diff que el dev te indique buscan
 - Longitud relativa: traducciones DE son ~15-30% más largas que ES, EN suele ser ~10-20% más cortas. Outliers (DE 3x más largo, EN igual de largo que ES) suelen ser síntoma de traducción literal o uso de palabras incorrectas.
 - Terminología compartida: si "evento" se traduce a "event" en un lugar y "show" en otro, decidir y unificar.
 - Tono coherente: si ES dice "Conseguí tus entradas", EN no debe decir formal "Please obtain your tickets". DE no debe pasar a "Sie".
-- Mismo símbolo/puntuación: si ES usa `· ` (middle dot espaciado) como separador, EN y DE deberían usar lo mismo o un equivalente cultural acordado.
+- Mismo símbolo/puntuación: si ES usa `·` (middle dot, separado del texto con espacios) como separador, EN y DE deberían usar lo mismo o un equivalente cultural acordado.
 
 ### 3. Estructura de keys y namespaces
 

--- a/.claude/agents/i18n-reviewer.md
+++ b/.claude/agents/i18n-reviewer.md
@@ -1,0 +1,157 @@
+---
+name: i18n-reviewer
+description: Revisor de internacionalización (ES/EN/DE) y de uso correcto de next-intl en La Huella del Caminante. Invocar on-demand cuando un PR agrega/edita claves de traducción, crea componentes o páginas con strings, o cuando se quiere verificar naturalidad y consistencia entre los tres locales antes de mergear. Solo reporta hallazgos, nunca modifica código.
+tools: Read, Grep, Glob, Bash
+---
+
+# i18n Reviewer — La Huella del Caminante
+
+Sos un agente especializado en internacionalización de aplicaciones web, con foco en español rioplatense, inglés americano coloquial y alemán estándar. Tu trabajo es revisar las traducciones de "La Huella del Caminante" (portal de eventos de música latinoamericana en Alemania) y reportar hallazgos. **No modificás código bajo ninguna circunstancia.** Solo leés, analizás y reportás.
+
+Este agente se complementa con `architecture-reviewer` (que NO mira i18n) y `security-reviewer`. Cuando un PR toca strings visibles al usuario, este agente es el code review específico de traducciones.
+
+## Contexto del proyecto
+
+- **Audiencia:** comunidad latinoamericana en Berlín, Múnich, Hamburgo. Visitantes ocasionales hispanohablantes, residentes que mezclan ES/EN/DE, y un creciente público alemán curioso por la cultura latina. **Tono cálido, cercano, con identidad cultural** — no corporate, no neutro plano.
+- **Locales soportados:** `es`, `en`, `de`. **ES es el canónico** (el dev escribe primero en español rioplatense). EN y DE son traducciones derivadas.
+- **Librería i18n:** `next-intl` (server + client). Archivos en `src/messages/{es,en,de}.json`. Namespaces top-level por dominio (`nav`, `home`, `events`, `artists`, `eventDetail`, `artistDetail`, `dashboard`, `admin`, `forms`, `footer`, `status`, `auth`, `common`).
+- **Patrones de uso:**
+  - Server components: `getTranslations({ locale, namespace })` desde `next-intl/server`.
+  - Client components: `useTranslations(namespace)`.
+  - Navegación locale-aware: `Link`/`useRouter`/`usePathname` desde `@/i18n/navigation`, no de `next/navigation`.
+- **Equipo:** un único dev full-stack hispanohablante. El alemán del dev es básico — las traducciones DE son las que más necesitan revisión profesional.
+
+## Alcance de la revisión
+
+Cuando se te invoque, vas a revisar el código/diff que el dev te indique buscando hallazgos en estas categorías.
+
+### 1. Calidad lingüística por locale
+
+**Español (ES)** — base canónica:
+- Naturalidad del registro: el proyecto usa **voseo / informal cercano** ("seguinos en redes", "consultá al organizador"). Reportar usos formales con "tú" o registros corporate que no peguen.
+- Castellano neutro vs rioplatense: aceptamos rioplatense, pero verificar que no se cuele jerga muy local que aliene a hispanohablantes de otras regiones.
+- Errores ortográficos, tildes faltantes, mayúsculas mal usadas.
+- Strings que son traducciones literales del inglés y suenan forzadas en castellano.
+
+**Inglés (EN)** — inglés americano coloquial:
+- Ritmo y naturalidad: ¿suena escrito por nativo o traducido por máquina? Reportar frases "traducidas".
+- Capitalización de títulos: el proyecto usa **sentence case** ("Get tickets") no Title Case ("Get Tickets"). Reportar inconsistencias.
+- Concisión vs claridad: el inglés acepta menos palabras que el castellano. Strings EN que copien estructura ES suelen quedar largos.
+- Modismos que no funcionan transatlánticos (UK vs US): preferir US salvo que se acuerde otra cosa.
+
+**Alemán (DE)** — alemán estándar de Alemania:
+- Capitalización de sustantivos: regla básica del alemán, sustantivos comunes y propios capitalizados. **Reportar TODO sustantivo en minúscula** que no sea verbo/adjetivo.
+- Casos (Nominativo/Acusativo/Dativo/Genitivo): verificar que coincidan con la preposición o verbo regente.
+- Conjugaciones de "du" vs "Sie": el proyecto usa **"du" informal** (consistente con el tono ES informal). Reportar mezclas "Sie + du" en el mismo namespace.
+- Composiciones (Komposita): el alemán arma palabras largas (`Spendenbasis`, `Veranstaltungsdetails`). Verificar que las usadas existan y sean naturales, no inventadas.
+- Anglicismos: cuando hay alternativa nativa razonable, preferirla ("Spende" sobre "donation"). Excepción: brand names ("Instagram", "Spotify") y términos consolidados ("Live", "Booking").
+- Strings que el dev escribió con su alemán básico y suenan a Google Translate. **Importante: este es el locale que más vigilancia necesita.**
+
+### 2. Consistencia entre locales
+
+- Mismo string ES con dos traducciones EN distintas en el mismo archivo: reportar.
+- Plurales: si un namespace tiene `events.upcoming` y `events.upcomingSingle`, los tres locales deben tener ambas keys.
+- Longitud relativa: traducciones DE son ~15-30% más largas que ES, EN suele ser ~10-20% más cortas. Outliers (DE 3x más largo, EN igual de largo que ES) suelen ser síntoma de traducción literal o uso de palabras incorrectas.
+- Terminología compartida: si "evento" se traduce a "event" en un lugar y "show" en otro, decidir y unificar.
+- Tono coherente: si ES dice "Conseguí tus entradas", EN no debe decir formal "Please obtain your tickets". DE no debe pasar a "Sie".
+- Mismo símbolo/puntuación: si ES usa `· ` (middle dot espaciado) como separador, EN y DE deberían usar lo mismo o un equivalente cultural acordado.
+
+### 3. Estructura de keys y namespaces
+
+- Naming de keys: `camelCase` para keys, `dot.notation` para namespaces anidados (ej. `eventDetail.access.tickets`).
+- Keys huérfanas: claves en uno o dos locales que no están en el tercero. Cualquier asimetría es bug latente (`MISSING_MESSAGE` en runtime).
+- Keys repetidas: misma string definida en múltiples namespaces sin razón clara. Reportar para considerar consolidación en `common`.
+- Keys mal ubicadas: ej. una key específica de `/events/[slug]` puesta en `events` en vez de `eventDetail`. Decidir según el scope de uso.
+- Namespaces que crecen sin orden: si `dashboard` tiene 60 keys, sugerir partición.
+
+### 4. Uso correcto de next-intl
+
+- **Strings hardcodeados** en componentes o pages dentro de `src/app/[locale]/` o `src/components/`. Excepción válida: brand names ("Instagram", "Spotify"), JSDoc internos, mensajes de error de desarrollo (no visibles al usuario).
+- Uso de strings literales en `<title>`, `description`, `Metadata.title`, `Metadata.description` de `generateMetadata`. Estos también van por i18n.
+- Mezcla de `getTranslations` (server) con `useTranslations` (client) en el mismo árbol sin claridad.
+- Falta de `locale` explícito en `getTranslations({ namespace })` cuando se está en server async fuera del request context (puede caer al locale default sin avisar).
+- Interpolaciones `{name}`: verificar que las variables estén consistentes en los 3 locales (mismas keys de interpolación).
+- ICU plurals/select: si se usa, verificar sintaxis correcta y consistencia entre locales.
+- Strings dinámicos construidos por concatenación (`t("hello") + " " + userName`): preferir interpolación.
+
+### 5. Cultural & dominio musical/eventos
+
+- Términos del dominio musical/eventos: "lineup", "set", "venue", "booking", "tour", "gira", "show", "presentación", "función", "fecha". Verificar que la traducción no pierda matiz.
+- Géneros musicales: nombres propios (Tango, Folklore, Cumbia, Bossa Nova) generalmente NO se traducen. Reportar si alguien intentó traducirlos.
+- Términos de acceso a evento: "Aporte voluntario" / "Pay what you can" / "Spendenbasis". Verificar que el modo "voluntary" esté correctamente expresado en los 3 locales — es un concepto cultural común en la escena alternativa que tiene términos consagrados.
+- Términos burocráticos alemanes que se traducen mal: "Anmeldung", "Abendkasse", "Vorverkauf", "Veranstalter". Si aparecen, verificar uso.
+- Nombres propios de lugares (Berlín / Berlin / Berlin): mantener consistencia por locale (`Berlín` en ES, `Berlin` en EN/DE).
+- Formato de fechas: si se hardcodea formato (`day/month` vs `month/day`), verificar coherencia con `Intl.DateTimeFormat` por locale.
+
+### 6. Accesibilidad de i18n
+
+- `aria-label`, `alt` text, `title` de elementos también deben ser i18n. Reportar `aria-label="Cerrar"` literal en un componente que vive en `[locale]`.
+- Strings de screen reader-only (`sr-only`) traducidos.
+- `<html lang>` correcto por locale (verificar `src/app/[locale]/layout.tsx` o el root).
+
+## Lo que NO tenés que reportar
+
+- Hallazgos de arquitectura, server/client, data fetching, Prisma. Es `architecture-reviewer`.
+- Hallazgos de seguridad, GDPR, auth. Es `security-reviewer`.
+- Accesibilidad visual (contraste, jerarquía visual). Sí reportá la accesibilidad de i18n (aria, alt, sr-only).
+- Performance del bundle de mensajes. Conocido, fuera de alcance.
+- Decisiones de producto ("¿por qué soportamos alemán?"). No es tu tema.
+- Estilo de código JS/TS de los archivos i18n (formateo). Solo si rompe el JSON.
+
+## Cómo hacer la revisión
+
+1. Pedile al dev (si no te lo dio) qué querés revisar: ¿un PR específico, un diff de mensajes, un componente, o el repo completo?
+2. Leé los archivos relevantes con `Read`, `Grep`, `Glob`. Para diff de strings: `Bash` con `git diff main -- src/messages/` o equivalente. Para detectar hardcodes: `grep -rE "[áéíóúñÁÉÍÓÚÑ]" src/app src/components` (caracteres acentuados ES en código suelen indicar hardcode).
+3. Para cada hallazgo, identificá archivo, línea, key específica, y el string problemático.
+4. Si el string tiene una propuesta de mejora obvia, sugerila — pero **no escribas el código del JSON**. Texto del string entre comillas alcanza.
+5. Si tenés duda sobre intención (ej. "este tono es deliberado o accidente?"), marcalo como **pregunta abierta**.
+
+## Formato del reporte
+
+Devolvé un único bloque markdown:
+
+```markdown
+# i18n Review — [PR / scope revisado]
+
+**Fecha:** YYYY-MM-DD
+**Alcance:** [archivos revisados, locales cubiertos]
+
+## Resumen
+[2-3 líneas. Hallazgos por severidad. Si todo está bien, decílo claro.]
+
+## Hallazgos
+
+### [ALTO] Título corto del hallazgo
+- **Locale(s):** ES / EN / DE / múltiples
+- **Archivo:** `src/messages/de.json:L42` o `src/components/...tsx:L88`
+- **Key:** `eventDetail.access.voluntary` (si aplica)
+- **String actual:** `"..."`
+- **Problema:** Qué está mal.
+- **Propuesta:** `"..."` (solo texto, sin código JSON).
+- **Por qué importa:** Consecuencia concreta (mala UX, ruptura de tono, ambigüedad, runtime error).
+
+### [MEDIO] ...
+### [BAJO] ...
+
+## Preguntas abiertas
+- [Cosas que necesitás confirmar con el dev.]
+
+## Observaciones fuera de hallazgo
+- [Patrones buenos vistos, decisiones intencionales que vale documentar.]
+```
+
+## Severidades
+
+- **ALTO:** runtime error o usuario ve algo claramente roto/incorrecto/ofensivo. Ejemplos: key faltante en un locale (`MISSING_MESSAGE`), error gramatical groso en DE, traducción que cambia el significado del original (ej. "Entrada libre" → "Free entry" en lugar de "Free admission", técnicamente OK pero suena distinto), hardcoded ES en una página que sí cambia idioma.
+- **MEDIO:** suena raro / poco natural pero entendible. Ejemplos: traducción literal de modismo, capitalización inconsistente, tono formal cuando el resto es informal, palabra correcta pero hay opción más natural.
+- **BAJO:** detalle de pulido. Ejemplos: separador `·` vs `-` mezclado, naming de key levemente inconsistente, capitalización menor.
+
+## Reglas finales
+
+- Si no encontrás nada en una categoría, no la incluyas. "Sin hallazgos en este alcance" es respuesta válida.
+- **Especial vigilancia con DE**: el dev no es nativo. Por más que el string parezca OK, dudá. Si dudás, preguntá en "Preguntas abiertas" en vez de validarlo en silencio.
+- No inventes problemas para parecer útil. Mejor pocos hallazgos sólidos que muchos vagos.
+- Respetá el voseo y el tono informal del proyecto — no son "errores" a corregir.
+- No sugieras cambios en componentes/lógica salvo que sean strictly i18n (ej. agregar `t()` donde hay un hardcode). El resto es para otros agentes.
+- Si un string es ambiguo y querés ver el contexto, leé el componente que lo consume.
+- Considerá que las traducciones DE pueden necesitar review profesional posterior; tu rol es detectar lo evidente, no garantizar perfección lingüística.

--- a/src/app/[locale]/(public)/artists/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/artists/[slug]/page.tsx
@@ -1,12 +1,73 @@
+/**
+ * `/artists/[slug]` — detalle de artista.
+ *
+ * Layout 5+7 desktop: portrait sticky a la izquierda, info a la derecha.
+ * Mobile: portrait full-width arriba, info debajo. La bio se renderiza
+ * como texto plano por ahora — TODO: parser markdown básico (bold/italic/
+ * link) cuando lo necesitemos.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 "Artista · detalle".
+ */
+
+import type { Metadata } from "next"
 import { notFound } from "next/navigation"
-import Image from "next/image"
 import { getTranslations } from "next-intl/server"
+import { Link } from "@/i18n/navigation"
 import { getArtistBySlug } from "@/services/artists"
-import { getEventsByArtist } from "@/services/events"
-import { EventList } from "@/components/events/EventList"
-import { Badge } from "@/components/ui/badge"
-import { BackButton } from "@/components/ui/BackButton"
-import { ExternalLink } from "lucide-react"
+import { getUpcomingEventsByArtist } from "@/services/events"
+import { genreAccent } from "@/lib/genre-accent"
+import { getCloudinaryUrl } from "@/lib/cloudinary-url"
+import { ArrowLeft } from "lucide-react"
+import Chip from "@/components/ui/Chip"
+import Eyebrow from "@/components/ui/Eyebrow"
+import FlyerImage from "@/components/ui/FlyerImage"
+import SocialLinks from "@/components/artists/SocialLinks"
+import { EventCard } from "@/components/events/EventCard"
+
+function originEyebrow(genres: string[], origin: string | null): string | null {
+  const parts: string[] = []
+  if (genres[0]) parts.push(genres[0].toUpperCase())
+  if (origin) parts.push(origin.toUpperCase())
+  return parts.length > 0 ? parts.join(" · ") : null
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>
+}): Promise<Metadata> {
+  const { locale, slug } = await params
+  const tCommon = await getTranslations({ locale, namespace: "common" })
+  const artist = await getArtistBySlug(slug)
+  if (!artist) {
+    return { title: `${tCommon("notFound")} · La Huella del Caminante` }
+  }
+
+  const description = [
+    artist.name,
+    artist.origin,
+    artist.genres.length > 0 ? artist.genres.join(", ") : null,
+  ]
+    .filter(Boolean)
+    .join(" — ")
+
+  // Cascada de fallback: Cloudinary → URL plana → sin imagen. Ver
+  // comentario equivalente en `/events/[slug]/page.tsx`.
+  const ogUrl =
+    (artist.coverImagePublicId && getCloudinaryUrl(artist.coverImagePublicId)) ??
+    artist.coverImage
+  const images = ogUrl ? [{ url: ogUrl }] : []
+
+  return {
+    title: `${artist.name} · La Huella del Caminante`,
+    description,
+    openGraph: {
+      title: artist.name,
+      description: artist.bio?.slice(0, 160) ?? description,
+      images,
+    },
+  }
+}
 
 export default async function ArtistDetailPage({
   params,
@@ -14,144 +75,93 @@ export default async function ArtistDetailPage({
   params: Promise<{ locale: string; slug: string }>
 }) {
   const { locale, slug } = await params
-  const t = await getTranslations({ locale, namespace: "artists" })
   const artist = await getArtistBySlug(slug)
-
   if (!artist) notFound()
 
-  const events = await getEventsByArtist(artist.id)
-  const social = artist.socialMedia as Record<string, string> | null
-  const images = artist.images ?? []
+  const t = await getTranslations({ locale, namespace: "artistDetail" })
+  const upcomingEvents = await getUpcomingEventsByArtist(artist.id)
+
+  const accent = genreAccent(artist.genres[0])
+  const fallbackAccent = accent === "neutral" ? "creator" : accent
+  const eyebrowText = originEyebrow(artist.genres, artist.origin)
+  const resolvedLocale = locale
 
   return (
-    <div>
-      {/* Hero image (first photo, full bleed) */}
-      <div className="relative w-full h-64 sm:h-80 bg-gradient-to-br from-primary/20 via-accent/10 to-background overflow-hidden">
-        {images[0] ? (
-          <Image
-            src={images[0].url}
-            alt={artist.name}
-            fill
-            sizes="100vw"
-            className="object-cover"
-            priority
-          />
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-8xl opacity-10 select-none">🎵</div>
-        )}
-        <div className="absolute inset-0 bg-gradient-to-t from-background via-background/30 to-transparent" />
-      </div>
+    <div className="max-w-7xl mx-auto px-m sm:px-l py-l lg:py-xl">
+      {/* Breadcrumb */}
+      <Link
+        href="/artists"
+        className="inline-flex items-center gap-xs text-body-s text-fg-secondary hover:text-fg-primary transition-colors mb-l"
+      >
+        <ArrowLeft className="w-4 h-4" aria-hidden />
+        <span>{t("backToArtists")}</span>
+      </Link>
 
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 pb-16 -mt-10 relative">
-        <BackButton label={t("title")} />
-
-        {/* Name + meta */}
-        <div className="mb-8">
-          <h1 className="text-4xl sm:text-5xl font-black leading-tight mb-2">{artist.name}</h1>
-          {artist.origin && (
-            <p className="text-muted-foreground text-lg mb-3">{artist.origin}</p>
-          )}
-          <div className="flex flex-wrap gap-2 mb-4">
-            {artist.genres.map((g) => (
-              <Badge key={g} variant="secondary" className="rounded-full px-3">{g}</Badge>
-            ))}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-xl">
+        {/* Portrait sticky */}
+        <div className="lg:col-span-5">
+          <div className="lg:sticky lg:top-[calc(var(--layout-header-h)+24px)]">
+            <FlyerImage
+              publicId={artist.coverImagePublicId ?? undefined}
+              src={artist.coverImage ?? undefined}
+              alt={artist.coverImageAlt ?? artist.name}
+              aspectRatio="4:5"
+              fallbackAccent={fallbackAccent}
+              priority
+            />
           </div>
-          {/* Social links */}
-          {social && (
-            <div className="flex flex-wrap gap-3">
-              {social.instagram && (
-                <a
-                  href={social.instagram}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="w-4 h-4" /> Instagram
-                </a>
-              )}
-              {social.spotify && (
-                <a
-                  href={social.spotify}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="w-4 h-4" /> Spotify
-                </a>
-              )}
-              {social.youtube && (
-                <a
-                  href={social.youtube}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="w-4 h-4" /> YouTube
-                </a>
-              )}
-              {social.tiktok && (
-                <a
-                  href={social.tiktok}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="w-4 h-4" /> TikTok
-                </a>
-              )}
-              {social.website && (
-                <a
-                  href={social.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="w-4 h-4" /> Web
-                </a>
-              )}
-            </div>
-          )}
         </div>
 
-        {/* Bio */}
-        {artist.bio && (
-          <p className="text-muted-foreground leading-relaxed text-base mb-10 max-w-2xl">
-            {artist.bio}
-          </p>
-        )}
+        {/* Info */}
+        <div className="lg:col-span-7 flex flex-col gap-l">
+          {eyebrowText ? <Eyebrow>{eyebrowText}</Eyebrow> : null}
 
-        {/* Photo gallery (all images) */}
-        {images.length > 1 && (
-          <section className="mb-12">
-            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">{t("photosLabel")}</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {images.map((img, i) => (
-                <div
-                  key={img.id}
-                  className={`relative overflow-hidden rounded-xl bg-muted ${
-                    i === 0 ? "col-span-2 sm:col-span-1 aspect-square" : "aspect-square"
-                  }`}
-                >
-                  <Image
-                    src={img.url}
-                    alt={img.alt ?? artist.name}
-                    fill
-                    sizes="(max-width: 640px) 50vw, 33vw"
-                    className="object-cover hover:scale-105 transition-transform duration-500"
-                  />
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
+          <h1 className="text-heading-l sm:text-display-m font-display text-fg-primary leading-tight">
+            {artist.name}
+          </h1>
 
-        {/* Events */}
-        {events.length > 0 && (
-          <section>
-            <p className="text-xs font-bold text-primary uppercase tracking-[0.15em] mb-4">{t("upcomingDatesLabel")}</p>
-            <EventList events={events} />
+          {/* Bio (texto plano por ahora — TODO: markdown básico bold/italic/link) */}
+          {artist.bio ? (
+            <p className="text-body-l text-fg-primary leading-relaxed whitespace-pre-line max-w-2xl">
+              {artist.bio}
+            </p>
+          ) : null}
+
+          {/* Géneros */}
+          {artist.genres.length > 0 ? (
+            <ul className="flex flex-wrap gap-xs">
+              {artist.genres.map((g) => {
+                const a = genreAccent(g)
+                return (
+                  <li key={g}>
+                    <Chip accent={a === "neutral" ? "creator" : a} active size="s">
+                      {g}
+                    </Chip>
+                  </li>
+                )
+              })}
+            </ul>
+          ) : null}
+
+          {/* Redes sociales */}
+          <SocialLinks socialMedia={artist.socialMedia} />
+
+          {/* Próximas fechas */}
+          <section className="flex flex-col gap-m">
+            <Eyebrow as="h2">{t("upcomingShows")}</Eyebrow>
+            {upcomingEvents.length > 0 ? (
+              <ul className="grid grid-cols-1 sm:grid-cols-2 gap-m">
+                {upcomingEvents.map((ev) => (
+                  <li key={ev.id}>
+                    <EventCard event={ev} locale={resolvedLocale} />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-body text-fg-secondary">{t("noUpcomingShows")}</p>
+            )}
           </section>
-        )}
+        </div>
       </div>
     </div>
   )

--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -228,20 +228,24 @@ export default async function EventDetailPage({
             <FactGrid
               items={[
                 {
+                  id: "when",
                   label: t("facts.when"),
                   value: nextDate
                     ? formatEventDateLong(nextDate, event.time, resolvedLocale)
                     : null,
                 },
                 {
+                  id: "timing",
                   label: t("facts.timing"),
                   value: timeRange,
                 },
                 {
+                  id: "where",
                   label: t("facts.where"),
                   value: event.location,
                 },
                 {
+                  id: "address",
                   label: t("facts.address"),
                   value: event.address,
                 },

--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -135,13 +135,24 @@ export default async function EventDetailPage({
   const otherDates = event.dates.slice(1)
   const timeRange = extractTimeRange(event.time)
 
-  // Eyebrow "live" si la próxima fecha cae en los próximos 7 días. Calculado
-  // acá para no agregar otra dependencia de cache — la decision es trivial
-  // y solo afecta el chip visual.
+  // Eyebrow "live" si la próxima fecha cae en los próximos 7 días.
+  // Comparamos contra **bounds de día calendario** (todayStart 00:00 →
+  // in7End 23:59:59.999), no contra timestamps exactos: si un evento es
+  // hoy a las 21:00 y son las 22:00 del día anterior + 1 minuto (00:01),
+  // sigue siendo "hoy" para nosotros — no debe salir del rango EN VIVO
+  // por la hora del clock. La decisión es visual, no necesita más precisión.
   const now = new Date()
-  const in7 = new Date(now)
-  in7.setDate(in7.getDate() + 7)
-  const isLive = nextDate ? nextDate >= now && nextDate <= in7 : false
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const in7End = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 7,
+    23,
+    59,
+    59,
+    999
+  )
+  const isLive = nextDate ? nextDate >= todayStart && nextDate <= in7End : false
 
   return (
     <>

--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -1,11 +1,115 @@
+/**
+ * `/events/[slug]` — detalle de evento.
+ *
+ * Layout 5+7 desktop (flyer sticky a la izquierda, info a la derecha) y
+ * stack vertical en mobile con `EventAccessCTA` adicional fijado al fondo
+ * vía `StickyCTABar`. Estructura del bloque de info: breadcrumb, eyebrow
+ * con chips, h1, artista vinculado, fact grid 2×2, CTA contextual, bloque
+ * "sobre el show", más fechas (si hay), otros shows del artista (si hay).
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 "Evento · detalle".
+ */
+
+import type { Metadata } from "next"
 import { notFound } from "next/navigation"
-import Image from "next/image"
-import Link from "next/link"
 import { getTranslations } from "next-intl/server"
-import { getEventBySlug } from "@/services/events"
-import { formatDate } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { CalendarDays, MapPin, Clock, Ticket, Users, ArrowLeft, Navigation } from "lucide-react"
+import { Link } from "@/i18n/navigation"
+import { getEventBySlug, getOtherEventsByArtist } from "@/services/events"
+import { genreAccent } from "@/lib/genre-accent"
+import { getCloudinaryUrl } from "@/lib/cloudinary-url"
+import { ArrowLeft } from "lucide-react"
+import Chip from "@/components/ui/Chip"
+import Eyebrow from "@/components/ui/Eyebrow"
+import FactGrid from "@/components/ui/FactGrid"
+import FlyerImage from "@/components/ui/FlyerImage"
+import StickyCTABar from "@/components/ui/StickyCTABar"
+import { EventCard } from "@/components/events/EventCard"
+import EventAccessCTA from "@/components/events/EventAccessCTA"
+
+/** Formatea "Lun 7 jun · 19:30" (o equivalente por locale). Vacío si no hay
+ * date o la date es inválida. Replica el patrón de `EventCard` para
+ * consistencia visual entre la card y el detalle. */
+const LOCALE_MAP: Record<string, string> = {
+  es: "es-ES",
+  en: "en-US",
+  de: "de-DE",
+}
+
+function formatEventDateLong(
+  date: Date | null,
+  time: string | null,
+  locale: string
+): string {
+  if (!date) return ""
+  const intl = new Intl.DateTimeFormat(LOCALE_MAP[locale] ?? "es-ES", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  })
+  const label = intl.format(date).replace(/\./g, "")
+  return time ? `${label} · ${time}` : label
+}
+
+/** "19:30 — 23:00" si tenemos campo `time` con rango; null si solo hay hora
+ * de inicio o nada. Por ahora `Event.time` es string libre — si el creator
+ * escribe "19:30 - 23:00" lo mostramos tal cual; si escribe solo "19:30",
+ * `null` (el dato ya va en el fact "CUÁNDO" como sufijo). */
+function extractTimeRange(time: string | null): string | null {
+  if (!time) return null
+  const trimmed = time.trim()
+  return /[-—–]/.test(trimmed) ? trimmed : null
+}
+
+function extractCity(location: string): string {
+  const parts = location.split(",").map((s) => s.trim())
+  return parts[parts.length - 1] ?? location
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>
+}): Promise<Metadata> {
+  const { locale, slug } = await params
+  const tCommon = await getTranslations({ locale, namespace: "common" })
+  const event = await getEventBySlug(slug)
+  if (!event) {
+    return { title: `${tCommon("notFound")} · La Huella del Caminante` }
+  }
+
+  const nextDate = event.dates[0] ?? null
+  const description = [
+    event.title,
+    extractCity(event.location),
+    nextDate
+      ? new Intl.DateTimeFormat(LOCALE_MAP[locale] ?? "es-ES", {
+          day: "numeric",
+          month: "long",
+        }).format(nextDate)
+      : null,
+    event.location,
+  ]
+    .filter(Boolean)
+    .join(" · ")
+
+  // Cascada de fallback: Cloudinary (transformaciones OG) → URL plana del
+  // cover → sin imagen. Si el cloud name no está configurado o no hay
+  // publicId, todavía podemos usar la URL plana en `event.coverImage`.
+  const ogUrl =
+    (event.coverImagePublicId && getCloudinaryUrl(event.coverImagePublicId)) ??
+    event.coverImage
+  const images = ogUrl ? [{ url: ogUrl }] : []
+
+  return {
+    title: `${event.title} · La Huella del Caminante`,
+    description,
+    openGraph: {
+      title: event.title,
+      description: event.description?.slice(0, 160) ?? description,
+      images,
+    },
+  }
+}
 
 export default async function EventDetailPage({
   params,
@@ -13,155 +117,178 @@ export default async function EventDetailPage({
   params: Promise<{ locale: string; slug: string }>
 }) {
   const { locale, slug } = await params
-  const t = await getTranslations({ locale, namespace: "events" })
-  const tCommon = await getTranslations({ locale, namespace: "common" })
-  const tForms = await getTranslations({ locale, namespace: "forms" })
   const event = await getEventBySlug(slug)
-
   if (!event) notFound()
 
+  const t = await getTranslations({ locale, namespace: "eventDetail" })
+
+  const otherEvents = event.artist
+    ? await getOtherEventsByArtist(event.artist.id, event.id, 3)
+    : []
+
+  const accent = genreAccent(event.genre)
+  const chipAccent = accent === "neutral" ? "brand" : accent
+  const fallbackAccent = accent === "neutral" ? "brand" : accent
+  const resolvedLocale = locale
+
+  const nextDate = event.dates[0] ?? null
+  const otherDates = event.dates.slice(1)
+  const timeRange = extractTimeRange(event.time)
+
+  // Eyebrow "live" si la próxima fecha cae en los próximos 7 días. Calculado
+  // acá para no agregar otra dependencia de cache — la decision es trivial
+  // y solo afecta el chip visual.
+  const now = new Date()
+  const in7 = new Date(now)
+  in7.setDate(in7.getDate() + 7)
+  const isLive = nextDate ? nextDate >= now && nextDate <= in7 : false
+
   return (
-    <div>
-      {/* Hero image */}
-      <div className="relative w-full h-72 sm:h-96 bg-gradient-to-br from-primary/20 via-accent/10 to-background overflow-hidden">
-        {event.coverImage ? (
-          <Image
-            src={event.coverImage}
-            alt={event.title}
-            fill
-            sizes="100vw"
-            className="object-cover"
-            priority
-          />
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-8xl opacity-10 select-none">
-            🎶
+    <>
+      <div className="max-w-7xl mx-auto px-m sm:px-l py-l lg:py-xl">
+        {/* Breadcrumb */}
+        <Link
+          href="/events"
+          className="inline-flex items-center gap-xs text-body-s text-fg-secondary hover:text-fg-primary transition-colors mb-l"
+        >
+          <ArrowLeft className="w-4 h-4" aria-hidden />
+          <span>{t("backToEvents")}</span>
+        </Link>
+
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-xl">
+          {/* Columna izquierda: flyer sticky */}
+          <div className="lg:col-span-5">
+            <div className="lg:sticky lg:top-[calc(var(--layout-header-h)+24px)]">
+              <FlyerImage
+                publicId={event.coverImagePublicId ?? undefined}
+                src={event.coverImage ?? undefined}
+                alt={event.coverImageAlt ?? event.title}
+                aspectRatio="4:5"
+                fallbackAccent={fallbackAccent}
+                priority
+              />
+            </div>
           </div>
-        )}
-        <div className="absolute inset-0 bg-gradient-to-t from-background via-background/20 to-transparent" />
 
-        {/* Genre badge */}
-        {event.genre && (
-          <div className="absolute top-5 right-5 bg-primary text-primary-foreground text-sm font-bold px-4 py-1.5 rounded-full shadow-lg">
-            {event.genre}
-          </div>
-        )}
-      </div>
+          {/* Columna derecha: info */}
+          <div className="lg:col-span-7 flex flex-col gap-l pb-[calc(env(safe-area-inset-bottom)+96px)] lg:pb-0">
+            {/* Eyebrow con chips */}
+            <div className="flex flex-wrap items-center gap-xs">
+              {isLive ? (
+                <Chip accent="brand" active size="s">
+                  {t("eyebrow.live")}
+                </Chip>
+              ) : null}
+              {event.genre ? (
+                <Chip accent={chipAccent} active size="s">
+                  {event.genre}
+                </Chip>
+              ) : null}
+            </div>
 
-      {/* Content */}
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 pb-16 -mt-8 relative">
-        <Button variant="ghost" asChild className="mb-6 text-muted-foreground hover:text-foreground rounded-full -ml-2">
-          <Link href={`/${locale}/events`}>
-            <ArrowLeft className="w-4 h-4 mr-1.5" />
-            {tCommon("back")}
-          </Link>
-        </Button>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* Main */}
-          <div className="lg:col-span-2 space-y-6">
-            <h1 className="text-4xl sm:text-5xl font-black leading-tight">{event.title}</h1>
-
-            {event.description && (
-              <p className="text-muted-foreground leading-relaxed text-base">{event.description}</p>
-            )}
-
-            {/* Artist card */}
-            {event.artist && (
-              <div className="rounded-2xl border border-border bg-card p-5 flex items-center gap-4 shadow-sm">
-                <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-                  <Users className="w-5 h-5 text-primary" />
-                </div>
-                <div>
-                  <p className="text-xs font-bold text-muted-foreground uppercase tracking-wide">{tForms("artistField")}</p>
+            {/* Título + artista vinculado */}
+            <header className="flex flex-col gap-s">
+              <h1 className="text-heading-l sm:text-display-m font-display text-fg-primary leading-tight">
+                {event.title}
+              </h1>
+              {event.artist ? (
+                <p className="text-body-l text-fg-secondary">
                   <Link
-                    href={`/${locale}/artists/${event.artist.slug}`}
-                    className="text-lg font-bold hover:text-primary transition-colors"
+                    href={`/artists/${event.artist.slug}`}
+                    className="hover:text-fg-primary transition-colors font-medium"
                   >
                     {event.artist.name}
                   </Link>
-                  {event.artist.origin && (
-                    <p className="text-sm text-muted-foreground">{event.artist.origin}</p>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
+                  {event.artist.origin ? (
+                    <span className="text-fg-tertiary">
+                      {" "}
+                      · {event.artist.origin}
+                    </span>
+                  ) : null}
+                </p>
+              ) : event.artistName ? (
+                <p className="text-body-l text-fg-secondary font-medium">
+                  {event.artistName}
+                </p>
+              ) : null}
+            </header>
 
-          {/* Sidebar */}
-          <div className="space-y-3">
-            <div className="rounded-2xl border border-border bg-card p-5 space-y-4 shadow-sm">
-              {/* Dates */}
-              <div className="flex gap-3">
-                <CalendarDays className="w-5 h-5 text-primary shrink-0 mt-0.5" />
-                <div>
-                  <p className="text-xs font-bold text-muted-foreground uppercase tracking-wide mb-1">
-                    {event.dates.length > 1 ? t("dates") : t("date")}
-                  </p>
-                  <div className="space-y-0.5">
-                    {event.dates.map((d, i) => (
-                      <p key={i} className="text-sm font-medium">{formatDate(d, locale)}</p>
-                    ))}
-                  </div>
-                </div>
-              </div>
+            {/* Fact grid 2×2 */}
+            <FactGrid
+              items={[
+                {
+                  label: t("facts.when"),
+                  value: nextDate
+                    ? formatEventDateLong(nextDate, event.time, resolvedLocale)
+                    : null,
+                },
+                {
+                  label: t("facts.timing"),
+                  value: timeRange,
+                },
+                {
+                  label: t("facts.where"),
+                  value: event.location,
+                },
+                {
+                  label: t("facts.address"),
+                  value: event.address,
+                },
+              ]}
+            />
 
-              {event.time && (
-                <div className="flex gap-3">
-                  <Clock className="w-5 h-5 text-primary shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-xs font-bold text-muted-foreground uppercase tracking-wide mb-1">{tForms("time")}</p>
-                    <p className="text-sm font-medium">{event.time}</p>
-                  </div>
-                </div>
-              )}
+            {/* CTA principal */}
+            <EventAccessCTA price={event.price} locale={resolvedLocale} />
 
-              <div className="flex gap-3">
-                <MapPin className="w-5 h-5 text-primary shrink-0 mt-0.5" />
-                <div>
-                  <p className="text-xs font-bold text-muted-foreground uppercase tracking-wide mb-1">{tForms("venue")}</p>
-                  <p className="text-sm font-medium">{event.location}</p>
-                  {event.address && (
-                    <p className="text-sm text-muted-foreground mt-0.5">{event.address}</p>
-                  )}
-                </div>
-              </div>
+            {/* About */}
+            {event.description ? (
+              <section className="flex flex-col gap-s">
+                <Eyebrow as="h2">{t("about")}</Eyebrow>
+                <p className="text-body text-fg-primary leading-relaxed whitespace-pre-line">
+                  {event.description}
+                </p>
+              </section>
+            ) : null}
 
-              {event.address && (
-                <a
-                  href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.address)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 w-full justify-center bg-primary/8 hover:bg-primary/15 border border-primary/20 text-primary text-sm font-semibold px-4 py-2.5 rounded-xl transition-colors"
-                >
-                  <Navigation className="w-4 h-4" />
-                  Abrir en Google Maps
-                </a>
-              )}
+            {/* Más fechas del mismo evento */}
+            {otherDates.length > 0 ? (
+              <section className="flex flex-col gap-s">
+                <Eyebrow as="h2">{t("moreDates")}</Eyebrow>
+                <ul className="flex flex-col gap-xs">
+                  {otherDates.map((d, i) => (
+                    <li key={i} className="text-body text-fg-secondary">
+                      {formatEventDateLong(d, event.time, resolvedLocale)}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
 
-              {event.price && (
-                <div className="flex gap-3">
-                  <Ticket className="w-5 h-5 text-primary shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-xs font-bold text-muted-foreground uppercase tracking-wide mb-1">{tForms("price")}</p>
-                    <p className="text-sm font-medium">{event.price}</p>
-                  </div>
-                </div>
-              )}
-
-              {event.organizer && (
-                <div className="flex gap-3">
-                  <Users className="w-5 h-5 text-primary shrink-0 mt-0.5" />
-                  <div>
-                    <p className="text-xs font-bold text-muted-foreground uppercase tracking-wide mb-1">{tForms("organizer")}</p>
-                    <p className="text-sm font-medium">{event.organizer}</p>
-                  </div>
-                </div>
-              )}
-            </div>
+            {/* Otros shows del artista */}
+            {otherEvents.length > 0 ? (
+              <section className="flex flex-col gap-m">
+                <Eyebrow as="h2">{t("otherEvents")}</Eyebrow>
+                <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-m">
+                  {otherEvents.map((ev) => (
+                    <li key={ev.id}>
+                      <EventCard event={ev} locale={resolvedLocale} />
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
           </div>
         </div>
       </div>
-    </div>
+
+      {/* Sticky CTA mobile */}
+      <StickyCTABar>
+        <EventAccessCTA
+          price={event.price}
+          locale={resolvedLocale}
+          variant="compact"
+        />
+      </StickyCTABar>
+    </>
   )
 }

--- a/src/components/artists/SocialLinks.tsx
+++ b/src/components/artists/SocialLinks.tsx
@@ -13,6 +13,7 @@
 
 import { ExternalLink, Globe } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { isSafeHttpUrl } from "@/lib/safe-url"
 
 /**
  * Whitelist de plataformas para resolver el label visible. Solo el "website"
@@ -55,9 +56,11 @@ function capitalize(s: string): string {
 export default function SocialLinks({ socialMedia, className }: SocialLinksProps) {
   if (!isStringRecord(socialMedia)) return null
 
+  // Validamos scheme `http:`/`https:` para que un `javascript:` o `data:`
+  // que entre via formulario del creator no ejecute código al hacer click.
   const entries = Object.entries(socialMedia).filter(
     (entry): entry is [string, string] =>
-      typeof entry[1] === "string" && entry[1].trim() !== ""
+      typeof entry[1] === "string" && isSafeHttpUrl(entry[1])
   )
 
   if (entries.length === 0) return null

--- a/src/components/artists/SocialLinks.tsx
+++ b/src/components/artists/SocialLinks.tsx
@@ -1,0 +1,87 @@
+/**
+ * SocialLinks — bloque de enlaces a redes sociales de un artista. Recibe el
+ * JSON `Artist.socialMedia` (campo flexible donde cada key es la plataforma
+ * y el value la URL completa) y renderiza un botón por cada plataforma que
+ * tenga URL no vacía. Las plataformas sin URL se omiten — la lista no
+ * "cuela" vacíos.
+ *
+ * No usa nombres como labels visibles (Instagram, Spotify, etc) son brand
+ * names — no se traducen. Los iconos vienen de lucide-react para las
+ * comunes; para plataformas raras o sin icono específico usamos el genérico
+ * `ExternalLink`.
+ */
+
+import { ExternalLink, Globe } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+/**
+ * Whitelist de plataformas para resolver el label visible. Solo el "website"
+ * usa un icono distinto (`Globe`) para diferenciarlo visualmente como
+ * "el sitio propio del artista" frente a "una red social externa". Todas
+ * las redes usan `ExternalLink` — uniforme + honesto ("te llevamos
+ * afuera").
+ *
+ * TODO: cuando lucide-react actualice a v1.10+ o se decida sumar
+ * `simple-icons`, cambiar a iconos de marca por plataforma.
+ */
+const PLATFORM_META: Record<
+  string,
+  { label: string; Icon: React.ComponentType<{ className?: string }> }
+> = {
+  instagram: { label: "Instagram", Icon: ExternalLink },
+  youtube: { label: "YouTube", Icon: ExternalLink },
+  spotify: { label: "Spotify", Icon: ExternalLink },
+  bandcamp: { label: "Bandcamp", Icon: ExternalLink },
+  soundcloud: { label: "SoundCloud", Icon: ExternalLink },
+  tiktok: { label: "TikTok", Icon: ExternalLink },
+  facebook: { label: "Facebook", Icon: ExternalLink },
+  website: { label: "Web", Icon: Globe },
+}
+
+export interface SocialLinksProps {
+  /** El JSON `Artist.socialMedia` directo. Espera shape `Record<string, string>`. */
+  socialMedia: unknown
+  className?: string
+}
+
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export default function SocialLinks({ socialMedia, className }: SocialLinksProps) {
+  if (!isStringRecord(socialMedia)) return null
+
+  const entries = Object.entries(socialMedia).filter(
+    (entry): entry is [string, string] =>
+      typeof entry[1] === "string" && entry[1].trim() !== ""
+  )
+
+  if (entries.length === 0) return null
+
+  return (
+    <ul className={cn("flex flex-wrap gap-s", className)}>
+      {entries.map(([key, url]) => {
+        const meta = PLATFORM_META[key.toLowerCase()]
+        const label = meta?.label ?? capitalize(key)
+        const Icon = meta?.Icon ?? ExternalLink
+        return (
+          <li key={key}>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-xs px-m py-s rounded-pill border border-border bg-bg-surface text-fg-primary text-body-s font-medium transition-colors duration-200 ease-out hover:border-border-hi hover:bg-bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+            >
+              <Icon className="w-4 h-4" />
+              <span>{label}</span>
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/components/events/EventAccessCTA.tsx
+++ b/src/components/events/EventAccessCTA.tsx
@@ -1,0 +1,117 @@
+/**
+ * EventAccessCTA — renderiza el CTA de acceso al evento según el modo
+ * interpretado por `getEventAccessMode` del `Event.price`. Server async
+ * (consume `getTranslations`). Reutilizado por el bloque principal del
+ * detalle y por el `StickyCTABar` mobile.
+ *
+ * 5 modos visuales:
+ *  - `tickets`   → botón sangre grande con link externo. Precio (`priceText`)
+ *                  como subtítulo si está disponible.
+ *  - `voluntary` → etiqueta no-clickeable sobre `bg-surface-2`. Texto chico
+ *                  explicativo debajo ("lo que cada uno pueda...").
+ *  - `free`      → etiqueta no-clickeable. Nota "no requiere reserva".
+ *  - `door`      → etiqueta no-clickeable. Si hay precio, lo muestra.
+ *  - `unknown`   → bloque chico con el texto original del creator + nota
+ *                  "consultá al organizador".
+ *
+ * Layout: variantes `compact` (sticky bar mobile) y `default` (bloque
+ * principal). En `compact`, el botón y la etiqueta usan tamaño chico para
+ * caber en el bar; el subtítulo se omite.
+ */
+
+import { getTranslations } from "next-intl/server"
+import { ArrowUpRight } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { getEventAccessMode } from "@/lib/event-access"
+
+export interface EventAccessCTAProps {
+  /** Texto libre del campo `Event.price`. */
+  price: string | null
+  /** Locale resuelto del request. */
+  locale: string
+  /** `default` = bloque grande del body. `compact` = sticky bar mobile. */
+  variant?: "default" | "compact"
+  className?: string
+}
+
+export default async function EventAccessCTA({
+  price,
+  locale,
+  variant = "default",
+  className,
+}: EventAccessCTAProps) {
+  const t = await getTranslations({ locale, namespace: "eventDetail.access" })
+  const access = getEventAccessMode(price)
+  const isCompact = variant === "compact"
+
+  if (access.mode === "tickets" && access.ticketUrl) {
+    return (
+      <div className={cn("flex flex-col gap-xs", className)}>
+        <a
+          href={access.ticketUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "inline-flex items-center justify-center gap-s rounded-pill bg-brand text-on-brand font-semibold transition-all duration-200 ease-out hover:bg-brand-dim focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page",
+            isCompact ? "px-l py-s text-body" : "px-xl py-m text-body-l"
+          )}
+        >
+          <span>{t("tickets")}</span>
+          <ArrowUpRight className={isCompact ? "w-4 h-4" : "w-5 h-5"} aria-hidden />
+        </a>
+        {!isCompact && access.priceText ? (
+          <p className="text-body-s text-fg-secondary">{access.priceText}</p>
+        ) : null}
+      </div>
+    )
+  }
+
+  // Las 4 variantes no-clickeables comparten el mismo skeleton: bloque
+  // sobre surface-2 con título grande + nota chica. Cambia el texto.
+  const labelByMode: Record<typeof access.mode, string> = {
+    tickets: t("tickets"), // unreachable acá (ya manejado arriba) pero satisface el tipo
+    voluntary: t("voluntary"),
+    free: t("free"),
+    door: t("door"),
+    unknown: access.priceText ?? "",
+  }
+  const noteByMode: Record<typeof access.mode, string | null> = {
+    tickets: null,
+    voluntary: t("voluntaryNote"),
+    free: t("freeNote"),
+    door: null,
+    unknown: t("unknownNote"),
+  }
+
+  const label = labelByMode[access.mode]
+  const note = noteByMode[access.mode]
+  const secondaryText =
+    access.mode === "door" ? access.priceText : null
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-xs rounded-l bg-bg-surface-2 border border-border",
+        isCompact ? "px-l py-s" : "px-l py-m",
+        className
+      )}
+    >
+      <p
+        className={cn(
+          "font-semibold text-fg-primary leading-tight",
+          isCompact ? "text-body" : "text-body-l"
+        )}
+      >
+        {label}
+        {secondaryText ? (
+          <span className="ml-s text-fg-secondary font-normal">
+            · {secondaryText}
+          </span>
+        ) : null}
+      </p>
+      {!isCompact && note ? (
+        <p className="text-body-s text-fg-secondary">{note}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/events/EventAccessCTA.tsx
+++ b/src/components/events/EventAccessCTA.tsx
@@ -23,6 +23,7 @@ import { getTranslations } from "next-intl/server"
 import { ArrowUpRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getEventAccessMode } from "@/lib/event-access"
+import { isSafeHttpUrl } from "@/lib/safe-url"
 
 export interface EventAccessCTAProps {
   /** Texto libre del campo `Event.price`. */
@@ -44,7 +45,11 @@ export default async function EventAccessCTA({
   const access = getEventAccessMode(price)
   const isCompact = variant === "compact"
 
-  if (access.mode === "tickets" && access.ticketUrl) {
+  // Validar scheme antes de emitir el anchor externo: `Event.price` es texto
+  // libre del creator y podría contener `javascript:` o `data:`. Si no es
+  // http/https, caemos al render no-clickeable de abajo con el texto literal
+  // (`unknown`-style) en lugar de generar un link inseguro.
+  if (access.mode === "tickets" && isSafeHttpUrl(access.ticketUrl)) {
     return (
       <div className={cn("flex flex-col gap-xs", className)}>
         <a
@@ -68,12 +73,18 @@ export default async function EventAccessCTA({
 
   // Las 4 variantes no-clickeables comparten el mismo skeleton: bloque
   // sobre surface-2 con título grande + nota chica. Cambia el texto.
-  const labelByMode: Record<typeof access.mode, string> = {
+  // El caso `unknown` tiene dos sub-casos:
+  //   - hay `priceText` (el creator escribió algo que no matcheó ninguna
+  //     heurística): mostramos el texto literal como label + nota genérica.
+  //   - no hay `priceText` (price era null/empty, o ticketUrl inválida): NO
+  //     renderizamos label vacío; solo la nota como bloque informativo
+  //     standalone.
+  const labelByMode: Record<typeof access.mode, string | null> = {
     tickets: t("tickets"), // unreachable acá (ya manejado arriba) pero satisface el tipo
     voluntary: t("voluntary"),
     free: t("free"),
     door: t("door"),
-    unknown: access.priceText ?? "",
+    unknown: access.priceText ?? null,
   }
   const noteByMode: Record<typeof access.mode, string | null> = {
     tickets: null,
@@ -96,19 +107,21 @@ export default async function EventAccessCTA({
         className
       )}
     >
-      <p
-        className={cn(
-          "font-semibold text-fg-primary leading-tight",
-          isCompact ? "text-body" : "text-body-l"
-        )}
-      >
-        {label}
-        {secondaryText ? (
-          <span className="ml-s text-fg-secondary font-normal">
-            · {secondaryText}
-          </span>
-        ) : null}
-      </p>
+      {label ? (
+        <p
+          className={cn(
+            "font-semibold text-fg-primary leading-tight",
+            isCompact ? "text-body" : "text-body-l"
+          )}
+        >
+          {label}
+          {secondaryText ? (
+            <span className="ml-s text-fg-secondary font-normal">
+              · {secondaryText}
+            </span>
+          ) : null}
+        </p>
+      ) : null}
       {!isCompact && note ? (
         <p className="text-body-s text-fg-secondary">{note}</p>
       ) : null}

--- a/src/components/ui/Eyebrow.tsx
+++ b/src/components/ui/Eyebrow.tsx
@@ -20,7 +20,7 @@ export interface EyebrowProps {
   children: React.ReactNode
   accent?: Accent
   className?: string
-  as?: "span" | "p" | "div"
+  as?: "span" | "p" | "div" | "h2" | "h3" | "h4" | "dt"
 }
 
 const ACCENT_COLOR: Record<Accent, string> = {

--- a/src/components/ui/FactGrid.tsx
+++ b/src/components/ui/FactGrid.tsx
@@ -14,6 +14,14 @@ import { cn } from "@/lib/utils"
 import Eyebrow from "@/components/ui/Eyebrow"
 
 export interface FactGridItem {
+  /**
+   * Identificador estable para el `key` de React. Requerido porque
+   * los `label` pueden colisionar (dos celdas con el mismo eyebrow no
+   * son inválidas) o cambiar por i18n entre renders — confiar en label
+   * para el key arriesga bugs de reconciliación. Usar slugs como `"when"`,
+   * `"timing"`, etc.
+   */
+  id: string
   /** Label corto del eyebrow (ej. "CUÁNDO"). */
   label: string
   /**
@@ -37,7 +45,7 @@ export default function FactGrid({ items, className }: FactGridProps) {
       {visible.map((item) => (
         // `<div>` agrupando `<dt>/<dd>` es permitido por HTML5 dentro de `<dl>`
         // y mantiene la asociación semántica de termino → valor.
-        <div key={item.label} className="flex flex-col gap-xs">
+        <div key={item.id} className="flex flex-col gap-xs">
           <Eyebrow as="dt">{item.label}</Eyebrow>
           <dd className="text-body text-fg-primary leading-snug">{item.value}</dd>
         </div>

--- a/src/components/ui/FactGrid.tsx
+++ b/src/components/ui/FactGrid.tsx
@@ -1,0 +1,47 @@
+/**
+ * FactGrid — bloque de info estructurada para detalle de evento.
+ *
+ * Cada celda: `Eyebrow` (label corto en mono mayúsculas) + valor (texto en
+ * `fg-primary`). Layout 1 col mobile, 2 cols desktop (≥sm). Las celdas se
+ * pueden omitir pasando `value` undefined/null — la grilla colapsa esos
+ * espacios manteniendo el orden.
+ *
+ * Usado en `/events/[slug]` para el bloque CUÁNDO / HORARIO / DÓNDE /
+ * DIRECCIÓN del fact grid 2×2 del handoff §3 — "Evento · detalle".
+ */
+
+import { cn } from "@/lib/utils"
+import Eyebrow from "@/components/ui/Eyebrow"
+
+export interface FactGridItem {
+  /** Label corto del eyebrow (ej. "CUÁNDO"). */
+  label: string
+  /**
+   * Valor a mostrar. Puede ser nodo React (links, spans con estilo, etc).
+   * Si es `null`/`undefined`, la celda se omite — no se renderiza.
+   */
+  value: React.ReactNode | null | undefined
+}
+
+export interface FactGridProps {
+  items: FactGridItem[]
+  className?: string
+}
+
+export default function FactGrid({ items, className }: FactGridProps) {
+  const visible = items.filter((it) => it.value != null && it.value !== "")
+  if (visible.length === 0) return null
+
+  return (
+    <dl className={cn("grid grid-cols-1 sm:grid-cols-2 gap-l", className)}>
+      {visible.map((item) => (
+        // `<div>` agrupando `<dt>/<dd>` es permitido por HTML5 dentro de `<dl>`
+        // y mantiene la asociación semántica de termino → valor.
+        <div key={item.label} className="flex flex-col gap-xs">
+          <Eyebrow as="dt">{item.label}</Eyebrow>
+          <dd className="text-body text-fg-primary leading-snug">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/components/ui/StickyCTABar.tsx
+++ b/src/components/ui/StickyCTABar.tsx
@@ -1,0 +1,39 @@
+/**
+ * StickyCTABar — wrapper que fija un CTA al fondo del viewport en mobile y
+ * lo oculta en desktop (donde el CTA del body principal ya es visible).
+ *
+ * No es client en sí — solo aplica utilities. Lo dejamos como server
+ * component minimalista para que pueda envolver children async (ej.
+ * `EventAccessCTA` que es async server). El sticky es puro CSS (`fixed`
+ * con `bottom-0`) y no necesita JS.
+ *
+ * Visual: barra full-width con borde superior + backdrop blur sutil, para
+ * separarla del contenido scrolleado. Se oculta en ≥lg (1024px) porque a
+ * partir de ese breakpoint la columna derecha del detalle ya tiene el CTA
+ * principal visible sin scroll.
+ */
+
+import { cn } from "@/lib/utils"
+
+export interface StickyCTABarProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export default function StickyCTABar({ children, className }: StickyCTABarProps) {
+  return (
+    <div
+      className={cn(
+        // `z-30` queda explícitamente por debajo del drawer/backdrop del
+        // Header (`z-50`/`z-40`) para evitar clash visual cuando el menú
+        // mobile está abierto.
+        "fixed bottom-0 inset-x-0 z-30 lg:hidden",
+        "bg-bg-page/95 backdrop-blur border-t border-border",
+        "px-m py-s pb-[max(env(safe-area-inset-bottom),0.5rem)]",
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/lib/cloudinary-url.ts
+++ b/src/lib/cloudinary-url.ts
@@ -1,0 +1,47 @@
+/**
+ * Construye una URL pública de Cloudinary a partir de un `publicId`. La
+ * usamos donde no podemos renderizar `<CldImage>` — por ejemplo, en
+ * `generateMetadata` para Open Graph (`og:image`), donde Next.js necesita
+ * la URL ya resuelta a la hora de generar el `<meta>` server-side.
+ *
+ * Aplicamos transformaciones por defecto pensadas para previews sociales:
+ *  - `f_auto`  → formato óptimo según el cliente (WebP / AVIF / JPG).
+ *  - `q_auto`  → calidad automática.
+ *  - `w_1200,h_630,c_fill,g_auto` → ratio 1.91:1 recomendado por OG, con
+ *    crop inteligente. Cloudinary intenta no cortar caras o elementos
+ *    importantes. Mejor que `c_pad` acá porque las plataformas sociales
+ *    sí recortan, y un letterbox previo se ve raro.
+ */
+
+const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME
+
+export interface CloudinaryUrlOptions {
+  /** Ancho en px. Default 1200 (OG-friendly). */
+  width?: number
+  /** Alto en px. Default 630 (OG-friendly). */
+  height?: number
+  /**
+   * Crop mode. `fill` rellena el frame respetando el aspect target (default,
+   * óptimo para OG). `pad` agrega bandas, mejor para flyers verticales si en
+   * el futuro hace falta. */
+  crop?: "fill" | "pad"
+}
+
+export function getCloudinaryUrl(
+  publicId: string,
+  options: CloudinaryUrlOptions = {}
+): string | null {
+  if (!CLOUD_NAME) return null
+  const { width = 1200, height = 630, crop = "fill" } = options
+  const transformations = [
+    "f_auto",
+    "q_auto",
+    `w_${width}`,
+    `h_${height}`,
+    `c_${crop}`,
+    crop === "fill" ? "g_auto" : null,
+  ]
+    .filter(Boolean)
+    .join(",")
+  return `https://res.cloudinary.com/${CLOUD_NAME}/image/upload/${transformations}/${publicId}`
+}

--- a/src/lib/event-access.ts
+++ b/src/lib/event-access.ts
@@ -44,8 +44,13 @@ export interface EventAccessInfo {
 }
 
 const URL_RE = /(https?:\/\/[^\s)]+)/i
-// "€15", "$ 20", "15€", "12,50", "10.5" — número opcional con símbolo de moneda
-const PRICE_ONLY_RE = /^[€$£]?\s*\d+([.,]\d+)?\s*[€$£]?$/
+// Precio "solo número" en formatos comunes de Berlín/Hamburgo/Múnich:
+//   - símbolo prefijo o sufijo: "€15", "15€", "$ 20", "£10"
+//   - decimales: "12,50", "10.5"
+//   - notación DE sin decimales: "15,-" (15 euros exactos)
+//   - código de moneda 3 letras: "EUR 15", "15 EUR", "USD 20"
+const PRICE_ONLY_RE =
+  /^(?:[€$£]\s*\d+(?:[.,]\d+|,-)?|\d+(?:[.,]\d+|,-)?\s*[€$£]?|(?:EUR|USD|GBP)\s*\d+(?:[.,]\d+|,-)?|\d+(?:[.,]\d+|,-)?\s*(?:EUR|USD|GBP))$/i
 
 export function getEventAccessMode(price: string | null | undefined): EventAccessInfo {
   const raw = price?.trim() ?? ""

--- a/src/lib/event-access.ts
+++ b/src/lib/event-access.ts
@@ -1,0 +1,104 @@
+/**
+ * `getEventAccessMode` interpreta el campo libre `Event.price` (string que
+ * llena el creator del evento) y lo clasifica en 5 modos de acceso. El
+ * componente que renderiza el CTA decide cómo mostrar cada modo (texto,
+ * estilo, traducción). Acá solo categorizamos y extraemos data útil.
+ *
+ *  - `tickets`   → hay URL externa (compra de entradas). `ticketUrl` se
+ *                  extrae; `priceText` contiene el resto del string sin URL.
+ *  - `voluntary` → "aporte"/"voluntario"/"spende"/"donation" en el texto.
+ *  - `free`      → "libre"/"gratis"/"free"/"frei"/"kostenlos" en el texto.
+ *  - `door`      → "puerta"/"door"/"abendkasse"/"kasse"/"tür" en el texto,
+ *                  o número solo (precio sin URL).
+ *  - `unknown`   → no matchea ninguna heurística. El componente debería
+ *                  mostrar el `priceText` literal (texto original del creator)
+ *                  + nota genérica "consultá al organizador".
+ *
+ * Reglas:
+ *  - Matching case-insensitive sobre el string trimmed.
+ *  - Las heurísticas se evalúan en orden: `voluntary` → `free` → `door`
+ *    → número-solo → `unknown`. El orden importa para casos como "Eintritt
+ *    frei an der Abendkasse" (alemán: entrada libre en la puerta), donde
+ *    queremos `free` (lo más permisivo) antes que `door`.
+ *  - URL gana sobre todo lo demás: aunque diga "aporte voluntario http://...",
+ *    es `tickets` con `ticketUrl`. La intención de tener un link de compra
+ *    pesa más que la categoría textual.
+ *  - `priceText` cuando se devuelve es texto-as-is del creator (no se
+ *    traduce). El componente lo muestra crudo.
+ */
+
+export type EventAccessMode = "tickets" | "voluntary" | "free" | "door" | "unknown"
+
+export interface EventAccessInfo {
+  mode: EventAccessMode
+  /** URL externa de tickets. Solo presente cuando `mode === "tickets"`. */
+  ticketUrl?: string
+  /**
+   * Texto a mostrar como precio o info adicional:
+   *  - `tickets`: resto del string sin la URL.
+   *  - `door`:    el número/precio escrito por el creator (ej. "€15").
+   *  - `unknown`: el string completo original del creator.
+   * No definido para `voluntary` / `free` — esos modos no necesitan precio.
+   */
+  priceText?: string
+}
+
+const URL_RE = /(https?:\/\/[^\s)]+)/i
+// "€15", "$ 20", "15€", "12,50", "10.5" — número opcional con símbolo de moneda
+const PRICE_ONLY_RE = /^[€$£]?\s*\d+([.,]\d+)?\s*[€$£]?$/
+
+export function getEventAccessMode(price: string | null | undefined): EventAccessInfo {
+  const raw = price?.trim() ?? ""
+  if (raw === "") return { mode: "unknown" }
+
+  const lower = raw.toLowerCase()
+
+  // URL gana primero: la intención de venta de tickets externa es la señal
+  // más fuerte. El priceText (resto del string sin URL) puede contener el
+  // precio que el creator quiera mostrar al lado del botón.
+  const urlMatch = raw.match(URL_RE)
+  if (urlMatch) {
+    const url = urlMatch[1]
+    const rest = raw.replace(url, "").trim().replace(/^[-—–·:|]+\s*|\s*[-—–·:|]+$/g, "").trim()
+    return {
+      mode: "tickets",
+      ticketUrl: url,
+      priceText: rest || undefined,
+    }
+  }
+
+  if (
+    lower.includes("aporte") ||
+    lower.includes("voluntari") || // voluntario / voluntary / voluntär
+    lower.includes("spende") || // spendenbasis / spende
+    lower.includes("donation") ||
+    lower.includes("donativo")
+  ) {
+    return { mode: "voluntary" }
+  }
+  if (
+    lower.includes("libre") ||
+    lower.includes("gratis") ||
+    lower.includes("kostenlos") ||
+    /\bfree\b/.test(lower) ||
+    /\bfrei\b/.test(lower) // alemán "frei" como palabra completa
+  ) {
+    return { mode: "free" }
+  }
+  if (
+    lower.includes("puerta") ||
+    lower.includes("abendkasse") ||
+    /\bkasse\b/.test(lower) ||
+    /\bdoor\b/.test(lower) ||
+    /\btür\b/.test(lower)
+  ) {
+    return { mode: "door", priceText: raw }
+  }
+  if (PRICE_ONLY_RE.test(raw)) {
+    return { mode: "door", priceText: raw }
+  }
+
+  // No matcheó nada: dejamos el texto original para que el componente lo
+  // muestre como bloque informativo + nota genérica al lado.
+  return { mode: "unknown", priceText: raw }
+}

--- a/src/lib/safe-url.ts
+++ b/src/lib/safe-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Validador de URLs externas. Los campos `Event.price` (puede contener
+ * URL de tickets) y `Artist.socialMedia` (objeto plataforma→URL) los llena
+ * el creator como texto libre — si entra `javascript:alert(1)` o
+ * `data:text/html,...`, renderizarlo crudo en un `<a href>` ejecuta el
+ * payload. Acotamos a `http:` / `https:` como única opción aceptable
+ * para anclas externas.
+ *
+ * Devuelve `true` solo si la URL parsea Y su protocolo es http/https.
+ * Cualquier otro caso (string vacío, malformado, schemes peligrosos)
+ * devuelve `false`. El consumidor decide qué hacer con un `false`
+ * (típicamente: omitir el link entero).
+ */
+
+export function isSafeHttpUrl(url: string | null | undefined): boolean {
+  if (!url || typeof url !== "string") return false
+  try {
+    const parsed = new URL(url.trim())
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -98,6 +98,41 @@
     "photosLabel": "Fotos",
     "upcomingDatesLabel": "Kommende Termine"
   },
+  "eventDetail": {
+    "eyebrow": {
+      "live": "LIVE",
+      "featured": "★ EMPFEHLUNG"
+    },
+    "facts": {
+      "when": "WANN",
+      "timing": "UHRZEIT",
+      "where": "WO",
+      "address": "ADRESSE"
+    },
+    "access": {
+      "tickets": "Tickets holen",
+      "voluntary": "Spendenbasis",
+      "voluntaryNote": "Zahl, was du kannst. Tickets auch an der Abendkasse.",
+      "free": "Eintritt frei",
+      "freeNote": "Keine Reservierung nötig.",
+      "door": "Abendkasse",
+      "unknownNote": "Wende dich an den Veranstalter für mehr Infos."
+    },
+    "about": "Über die Show",
+    "moreDates": "Weitere Termine dieser Show",
+    "otherEvents": "Weitere Shows von diesem Künstler",
+    "share": "Teilen",
+    "calendar": "Zum Kalender",
+    "save": "Speichern",
+    "backToEvents": "Veranstaltungen"
+  },
+  "artistDetail": {
+    "upcomingShows": "Kommende Termine",
+    "noUpcomingShows": "Aktuell keine Shows geplant. Folge uns auf Social Media, um nichts zu verpassen.",
+    "bioShowMore": "Mehr anzeigen",
+    "bioShowLess": "Weniger anzeigen",
+    "backToArtists": "Künstler"
+  },
   "dashboard": {
     "title": "Mein Dashboard",
     "myEvents": "Meine Veranstaltungen",
@@ -245,6 +280,7 @@
     "eventCreated": "Veranstaltung erstellt",
     "artistUpdated": "Künstler aktualisiert",
     "artistCreated": "Künstler erstellt",
-    "eventDeleted": "Veranstaltung gelöscht"
+    "eventDeleted": "Veranstaltung gelöscht",
+    "notFound": "Nicht gefunden"
   }
 }

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -101,7 +101,7 @@
   "eventDetail": {
     "eyebrow": {
       "live": "LIVE",
-      "featured": "★ EMPFEHLUNG"
+      "featured": "★ HIGHLIGHT"
     },
     "facts": {
       "when": "WANN",
@@ -112,7 +112,7 @@
     "access": {
       "tickets": "Tickets holen",
       "voluntary": "Spendenbasis",
-      "voluntaryNote": "Zahl, was du kannst. Tickets auch an der Abendkasse.",
+      "voluntaryNote": "Zahl, was du kannst. Tickets an der Abendkasse.",
       "free": "Eintritt frei",
       "freeNote": "Keine Reservierung nötig.",
       "door": "Abendkasse",
@@ -124,14 +124,14 @@
     "share": "Teilen",
     "calendar": "Zum Kalender",
     "save": "Speichern",
-    "backToEvents": "Veranstaltungen"
+    "backToEvents": "Zu den Veranstaltungen"
   },
   "artistDetail": {
     "upcomingShows": "Kommende Termine",
     "noUpcomingShows": "Aktuell keine Shows geplant. Folge uns auf Social Media, um nichts zu verpassen.",
     "bioShowMore": "Mehr anzeigen",
     "bioShowLess": "Weniger anzeigen",
-    "backToArtists": "Künstler"
+    "backToArtists": "Zu den Künstlern"
   },
   "dashboard": {
     "title": "Mein Dashboard",
@@ -281,6 +281,6 @@
     "artistUpdated": "Künstler aktualisiert",
     "artistCreated": "Künstler erstellt",
     "eventDeleted": "Veranstaltung gelöscht",
-    "notFound": "Nicht gefunden"
+    "notFound": "Seite nicht gefunden"
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -112,7 +112,7 @@
     "access": {
       "tickets": "Get tickets",
       "voluntary": "Pay what you can",
-      "voluntaryNote": "Whatever you can contribute. Available at the door.",
+      "voluntaryNote": "Whatever you can contribute. Pay at the door.",
       "free": "Free entry",
       "freeNote": "No booking required.",
       "door": "Pay at the door",
@@ -281,6 +281,6 @@
     "artistUpdated": "Artist updated",
     "artistCreated": "Artist created",
     "eventDeleted": "Event deleted",
-    "notFound": "Not found"
+    "notFound": "Page not found"
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -98,6 +98,41 @@
     "photosLabel": "Photos",
     "upcomingDatesLabel": "Upcoming dates"
   },
+  "eventDetail": {
+    "eyebrow": {
+      "live": "LIVE",
+      "featured": "★ FEATURED"
+    },
+    "facts": {
+      "when": "WHEN",
+      "timing": "TIME",
+      "where": "WHERE",
+      "address": "ADDRESS"
+    },
+    "access": {
+      "tickets": "Get tickets",
+      "voluntary": "Pay what you can",
+      "voluntaryNote": "Whatever you can contribute. Available at the door.",
+      "free": "Free entry",
+      "freeNote": "No booking required.",
+      "door": "Pay at the door",
+      "unknownNote": "Reach out to the organizer for more info."
+    },
+    "about": "About the show",
+    "moreDates": "More dates for this show",
+    "otherEvents": "Other shows by this artist",
+    "share": "Share",
+    "calendar": "Add to calendar",
+    "save": "Save",
+    "backToEvents": "Events"
+  },
+  "artistDetail": {
+    "upcomingShows": "Upcoming dates",
+    "noUpcomingShows": "No upcoming shows for now. Follow us on socials to stay tuned.",
+    "bioShowMore": "Show more",
+    "bioShowLess": "Show less",
+    "backToArtists": "Artists"
+  },
   "dashboard": {
     "title": "My Dashboard",
     "myEvents": "My Events",
@@ -245,6 +280,7 @@
     "eventCreated": "Event created",
     "artistUpdated": "Artist updated",
     "artistCreated": "Artist created",
-    "eventDeleted": "Event deleted"
+    "eventDeleted": "Event deleted",
+    "notFound": "Not found"
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -115,7 +115,7 @@
       "voluntaryNote": "Lo que cada uno pueda. Tickets disponibles en la puerta.",
       "free": "Entrada libre",
       "freeNote": "No requiere reserva.",
-      "door": "Entrada en puerta",
+      "door": "Se paga en la puerta",
       "unknownNote": "Consultá al organizador para más info."
     },
     "about": "Sobre el show",
@@ -281,6 +281,6 @@
     "artistUpdated": "Artista actualizado",
     "artistCreated": "Artista creado",
     "eventDeleted": "Evento eliminado",
-    "notFound": "No encontrado"
+    "notFound": "Página no encontrada"
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -98,6 +98,41 @@
     "photosLabel": "Fotos",
     "upcomingDatesLabel": "Próximas fechas"
   },
+  "eventDetail": {
+    "eyebrow": {
+      "live": "EN VIVO",
+      "featured": "★ DESTACADO"
+    },
+    "facts": {
+      "when": "CUÁNDO",
+      "timing": "HORARIO",
+      "where": "DÓNDE",
+      "address": "DIRECCIÓN"
+    },
+    "access": {
+      "tickets": "Conseguir entradas",
+      "voluntary": "Aporte voluntario",
+      "voluntaryNote": "Lo que cada uno pueda. Tickets disponibles en la puerta.",
+      "free": "Entrada libre",
+      "freeNote": "No requiere reserva.",
+      "door": "Entrada en puerta",
+      "unknownNote": "Consultá al organizador para más info."
+    },
+    "about": "Sobre el show",
+    "moreDates": "Más fechas de este show",
+    "otherEvents": "Otros shows de este artista",
+    "share": "Compartir",
+    "calendar": "Agendar",
+    "save": "Guardar",
+    "backToEvents": "Eventos"
+  },
+  "artistDetail": {
+    "upcomingShows": "Próximas fechas",
+    "noUpcomingShows": "Por ahora no hay shows próximos. Seguinos en redes para enterarte.",
+    "bioShowMore": "Mostrar más",
+    "bioShowLess": "Mostrar menos",
+    "backToArtists": "Artistas"
+  },
   "dashboard": {
     "title": "Mi Panel",
     "myEvents": "Mis Eventos",
@@ -245,6 +280,7 @@
     "eventCreated": "Evento creado",
     "artistUpdated": "Artista actualizado",
     "artistCreated": "Artista creado",
-    "eventDeleted": "Evento eliminado"
+    "eventDeleted": "Evento eliminado",
+    "notFound": "No encontrado"
   }
 }

--- a/src/services/artists.ts
+++ b/src/services/artists.ts
@@ -1,5 +1,6 @@
 import "server-only"
 
+import { cache } from "react"
 import { unstable_cache, revalidateTag } from "next/cache"
 import { prisma } from "@/lib/prisma"
 import { generateUniqueSlug } from "@/lib/slugify"
@@ -133,7 +134,15 @@ export async function getPastArtists(): Promise<ArtistSummary[]> {
   return artists.map(mapToSummary)
 }
 
-export async function getArtistBySlug(slug: string): Promise<ArtistDetail | null> {
+/**
+ * Wrapeado con `cache()` de React para dedupe **dentro del mismo request**:
+ * `generateMetadata` y el `page` default del detalle de artista llaman a
+ * `getArtistBySlug(slug)` por separado. Sin este wrapper, dos queries
+ * Prisma idénticas con includes. `cache()` reusa el resultado.
+ */
+export const getArtistBySlug = cache(_getArtistBySlugImpl)
+
+async function _getArtistBySlugImpl(slug: string): Promise<ArtistDetail | null> {
   const artist = await prisma.artist.findUnique({
     where: { slug },
     include: {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -1,5 +1,6 @@
 import "server-only"
 
+import { cache } from "react"
 import { unstable_cache, revalidateTag } from "next/cache"
 import { prisma } from "@/lib/prisma"
 import { rehydrateDate, rehydrateDates } from "@/lib/date"
@@ -358,7 +359,21 @@ export async function getPastEvents(): Promise<EventSummary[]> {
   return (await _getPastEvents()).map(rehydrateEvent)
 }
 
-export async function getEventBySlug(slug: string): Promise<EventDetail | null> {
+/**
+ * Wrapeado con `cache()` de React para dedupe **dentro del mismo request**:
+ * `generateMetadata` y el `page` default llaman a `getEventBySlug(slug)`
+ * por separado en el render del detalle. Sin este wrapper, son dos queries
+ * a Prisma con includes pesados. `cache()` hace que la segunda llamada
+ * con el mismo arg reuse el resultado de la primera.
+ *
+ * No usamos `unstable_cache` porque la invalidación de events ya se hace
+ * por tag desde `updateEvent`/`softDeleteEvent`, y la frecuencia de hits
+ * al detalle no justifica el overhead de cache de Next; el dedupe
+ * request-scoped es suficiente para evitar el bug obvio.
+ */
+export const getEventBySlug = cache(_getEventBySlugImpl)
+
+async function _getEventBySlugImpl(slug: string): Promise<EventDetail | null> {
   const event = await prisma.event.findUnique({
     where: { slug, isDeleted: false },
     include: {
@@ -453,6 +468,78 @@ export async function getEventsByArtist(artistId: string): Promise<EventSummary[
     orderBy: { createdAt: "desc" },
   })
   return events.map(mapToSummary)
+}
+
+/**
+ * Próximos eventos de un artista, ordenados por la próxima fecha (más
+ * cercana primero). Usado por el detalle de artista para la sección
+ * "Próximas fechas". Solo trae la próxima fecha futura del evento (no
+ * todas las fechas pasadas), igual que `getUpcomingEventsWithin`.
+ */
+const _getUpcomingEventsByArtist = unstable_cache(
+  async (artistId: string, limit?: number): Promise<EventSummary[]> => {
+    const now = new Date()
+    const events = await prisma.event.findMany({
+      where: {
+        artistId,
+        isDeleted: false,
+        isActive: true,
+        dates: { some: { date: { gte: now } } },
+      },
+      include: futureEventInclude(now),
+    })
+    const ordered = sortByNextDate(events.map(mapToSummary))
+    return limit ? ordered.slice(0, limit) : ordered
+  },
+  ["upcoming-events-by-artist"],
+  { revalidate: 300, tags: ["events"] }
+)
+
+export async function getUpcomingEventsByArtist(
+  artistId: string,
+  limit?: number
+): Promise<EventSummary[]> {
+  return (await _getUpcomingEventsByArtist(artistId, limit)).map(rehydrateEvent)
+}
+
+/**
+ * Otros próximos eventos de un artista, excluyendo uno específico. Usado
+ * por el detalle de evento para la sección "Otros shows de este artista".
+ * Ordena por próxima fecha. Reusa la lógica de `_getUpcomingEventsByArtist`
+ * porque el filtro adicional es solo `excludeEventId`.
+ */
+const _getOtherEventsByArtist = unstable_cache(
+  async (
+    artistId: string,
+    excludeEventId: string,
+    limit?: number
+  ): Promise<EventSummary[]> => {
+    const now = new Date()
+    const events = await prisma.event.findMany({
+      where: {
+        artistId,
+        isDeleted: false,
+        isActive: true,
+        id: { not: excludeEventId },
+        dates: { some: { date: { gte: now } } },
+      },
+      include: futureEventInclude(now),
+    })
+    const ordered = sortByNextDate(events.map(mapToSummary))
+    return limit ? ordered.slice(0, limit) : ordered
+  },
+  ["other-events-by-artist"],
+  { revalidate: 300, tags: ["events"] }
+)
+
+export async function getOtherEventsByArtist(
+  artistId: string,
+  excludeEventId: string,
+  limit?: number
+): Promise<EventSummary[]> {
+  return (await _getOtherEventsByArtist(artistId, excludeEventId, limit)).map(
+    rehydrateEvent
+  )
 }
 
 export async function getEventsByUser(userId: string): Promise<EventSummary[]> {


### PR DESCRIPTION
## Summary

Rediseño completo de las páginas `/events/[slug]` y `/artists/[slug]` siguiendo §3 del handoff (`docs/design/DESIGN_HANDOFF_OUTPUT.md`). Cierra el frente de páginas públicas del rediseño (home + listados ya estaban).

## Pantallas rediseñadas

**`/events/[slug]`** — detalle de evento
- Layout 5+7 desktop (FlyerImage sticky izq, info derecha) · mobile stack vertical + CTA sticky bottom
- Eyebrow con chips "EN VIVO" (si la próxima fecha es en ≤7 días) + género con accent
- H1 + artista vinculado con origen
- `FactGrid` 2×2: CUÁNDO, HORARIO, DÓNDE, DIRECCIÓN
- `EventAccessCTA` data-driven según `Event.price` (ver helper abajo)
- Bloque "Sobre el show" con descripción
- "Más fechas de este show" si el evento tiene varias funciones
- "Otros shows de este artista" — `EventCard` reutilizadas

**`/artists/[slug]`** — detalle de artista
- Layout 5+7 desktop (portrait sticky izq, info derecha)
- Eyebrow con género + origen
- H1 + bio (texto plano por ahora — TODO markdown básico declarado en código)
- Chips de géneros con accent
- `SocialLinks` desde JSON `Artist.socialMedia`
- Sección "Próximas fechas" o empty state

## Helper de CTA data-driven

`src/lib/event-access.ts` interpreta el campo libre `Event.price` y lo clasifica en 5 modos. El componente decide la presentación; el helper solo categoriza.

| Modo | Heurística | CTA |
|---|---|---|
| `tickets` | contiene URL | botón sangre con link externo + precio como subtítulo |
| `voluntary` | aporte / voluntari / spende / donation / donativo | etiqueta sobre surface-2, no clickeable |
| `free` | libre / gratis / free / frei / kostenlos | etiqueta + nota "no requiere reserva" |
| `door` | puerta / door / abendkasse / kasse / tür · o número solo | etiqueta + precio si lo hay |
| `unknown` | nada matchea | texto original del creator + nota "consultá al organizador" |

Keywords cubren ES/EN/DE. URL siempre gana sobre keywords textuales.

## Modelo de datos

**No se toca el schema de Prisma.** El campo `Event.price` sigue siendo string libre; el helper lo interpreta sin requerir migración. Normalización a enum queda para otro PR.

## SEO

`generateMetadata` exportado en ambas páginas con title, description y Open Graph (`og:image` resuelta vía nuevo helper `getCloudinaryUrl` con cascada de fallback Cloudinary → URL plana → omisión limpia). Strings de fallback (artista/evento no encontrado) ahora pasan por `getTranslations` — no más castellano hardcodeado.

**Out of scope (decisión cerrada de la épica):** `og:image` con template del flyer + branding queda como backlog.

## Componentes nuevos

| Path | Notas |
|---|---|
| `src/lib/event-access.ts` | `getEventAccessMode(price)` — 5 modos |
| `src/lib/cloudinary-url.ts` | URL pública con transformaciones OG |
| `src/components/ui/FactGrid.tsx` | `<dl>` con celdas eyebrow + valor |
| `src/components/ui/StickyCTABar.tsx` | wrapper `fixed bottom-0` mobile-only |
| `src/components/events/EventAccessCTA.tsx` | server async, 5 modos visuales |
| `src/components/artists/SocialLinks.tsx` | redes desde JSON socialMedia |

## Cambios menores

- `Eyebrow` (`src/components/ui/Eyebrow.tsx`): el prop `as` ahora acepta `h2 | h3 | h4 | dt` además de `span/p/div` (necesario para semántica de secciones del detalle y `<dt>` de FactGrid).
- `getEventBySlug` / `getArtistBySlug` envueltos con `React.cache()` para dedupe request-scoped: antes `generateMetadata` + `page` ejecutaban dos queries idénticas a Prisma por request.

## i18n

Nuevos namespaces `eventDetail` y `artistDetail` en es/en/de + `common.notFound`. Strings DE escritos directamente; conviene revisar en un PR de pasada con agente i18n dedicado.

## Architecture review

Pasé el `architecture-reviewer` interno sobre el diff completo antes de commitear. Encontró 1 HIGH (metadata i18n hardcodeado), 4 MEDIUM (dedupe queries, OG fallback, keywords i18n del helper, semántica `<dl>`), 4 LOW (role/aria, JSDoc, iconos SocialLinks, z-index StickyCTABar). **Todos aplicados antes del primer commit.**

## i18n review

Creé y corrí el `i18n-reviewer` interno (nuevo agente persistente en `.claude/agents/i18n-reviewer.md`) sobre las 38 keys nuevas en es/en/de. Encontró 2 MEDIUM (DE `voluntaryNote` con `auch` que insinuaba pre-venta inexistente, EN `voluntaryNote` ambiguo) y 4 LOW (DE `EMPFEHLUNG` vs `HIGHLIGHT` para consistencia con `home`, ES `door` muy formal, DE breadcrumbs poco naturales, `common.notFound` muy genérico). **Todos aplicados en commits aparte.** Además extendí `PRICE_ONLY_RE` del helper para cubrir formatos alemanes (`15,-`, `EUR 15`) que antes caían en `unknown`.

### Keys scaffolded (declaradas pero todavía no consumidas)

Las siguientes 6 keys están en los 3 locales pero no se renderizan todavía. Quedan listas para próximas iteraciones del rediseño y se documentan acá para que CR / futuros reviewers no las flaggeen como muertas:

- `eventDetail.eyebrow.featured` — chip "★ HIGHLIGHT" cuando el modelo `Event` tenga flag `featured`.
- `eventDetail.share`, `.calendar`, `.save` — botones secundarios del detalle (compartir, agendar, guardar).
- `artistDetail.bioShowMore`, `.bioShowLess` — toggle de bio cuando se implemente el truncado a ~5 líneas.

## Test plan

- [ ] `/es/events/<slug>` desktop: layout dos columnas, flyer sticky, fact grid 2×2, CTA correcto para el `price` del evento
- [ ] Probar con eventos de distintos `price`: URL externa (`tickets`), "Aporte voluntario" (`voluntary`), "Libre"/"Eintritt frei" (`free`), número solo `€15` (`door`), vacío o raro (`unknown`)
- [ ] `/es/events/<slug>` mobile: flyer arriba, CTA sticky bottom funciona, padding inferior previene tape
- [ ] `/es/artists/<slug>` desktop: portrait sticky, bio legible, redes sociales, próximas fechas
- [ ] `/es/artists/<slug>` mobile: stack vertical, bio respeta ancho (que el bug del `max-w-2xl` del PR previo no reaparezca)
- [ ] Cambio de idioma desde un detalle (ES → EN → DE): URL mantiene slug, contenido y CTA cambian
- [ ] Slug que no existe → 404 limpio con title traducido del browser tab
- [ ] Open Graph: inspeccionar `<meta>` de OG con `view-source:` o un debugger social
- [ ] Sin errores en consola del browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned artist and event detail pages: responsive two-column/grid layouts, sticky images, genre chips, structured facts, upcoming/other events lists, localized SEO/OpenGraph metadata, and improved social links.
  * Event access CTA with safer ticket-link handling and a mobile sticky CTA.

* **UI**
  * New FactGrid, expanded Eyebrow variants, StickyCTABar, and dedicated SocialLinks component.

* **Localization**
  * Added en/es/de strings for event and artist detail views (including notFound).

* **Documentation**
  * New i18n reviewer guidance.

* **Chores**
  * Safer URL validation and cached service lookups for artists/events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
