### PR TITLE
fix(home): restore vertical padding on hero and stats sections

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -103,7 +103,6 @@ async function HeroSection({ variant, locale }: HeroSectionProps) {
   return (
     <section
       className={cn("relative overflow-hidden border-b border-border", SECTION_GAP_CLASS)}
-      style={{ paddingTop: "var(--space-3xl)", paddingBottom: "var(--space-3xl)" }}
     >
       <div
         className="mx-auto grid grid-cols-1 gap-xl lg:grid-cols-[1.4fr_1fr] lg:items-end"
@@ -149,7 +148,7 @@ async function StatsSection({ stats, locale }: StatsSectionProps) {
   ]
 
   return (
-    <section className="border-b border-border" style={{ paddingTop: "var(--space-xl)", paddingBottom: "var(--space-xl)" }}>
+    <section className="border-b border-border py-l">
       <div className="mx-auto grid grid-cols-2 gap-l lg:grid-cols-4" style={CONTAINER_STYLE}>
         {items.map((item) => (
           <div key={item.label} className="flex flex-col gap-xs">


### PR DESCRIPTION
## Summary

Bug visual preexistente en la home. Las secciones `HeroSection` y `StatsSection` usaban `style={{ paddingTop: "var(--space-3xl)" }}` (y `--space-xl` para stats), pero **esos tokens no existen** en el proyecto — los reales son `--spacing-*`. Las CSS vars resolvían a vacío → padding = 0 → contenido pegado a los bordes de la sección (especialmente notorio en stats, donde los números grandes tocaban la línea divisoria).

## Cambios

- **`HeroSection`**: borrar el `style` inline duplicado. El `className` ya incluye `SECTION_GAP_CLASS = "py-3xl"`, así que la sección sigue con su padding correcto (96px arriba y abajo).
- **`StatsSection`**: reemplazar el `style` por `py-l` (24px) en el `className`. Alineado con la referencia de Claude Design — la versión original (`py-xl` = 40px) habría sido el doble de alto del que pide el diseño.

Total: 1 línea agregada, 2 líneas eliminadas. Cero impacto fuera de la home.

## Patrón a futuro

Preferir utilities Tailwind (`py-*`, `px-*`) que consumen `--spacing-*` directamente, en lugar de inline `style` con CSS vars del namespace incorrecto. Vale chequear si hay otros usos de `var(--space-*)` que estén silenciosamente rotos.

## Test plan

- [ ] `/es` y `/en` y `/de`: el hero respira como antes (`py-3xl` ya estaba aplicado por className, solo se sacó duplicación)
- [ ] `/es`: la franja de stats (`12 shows próximos · 7 artistas · 3 ciudades · 7-21 jun`) tiene aire arriba y abajo de los números — ya no están pegados a las líneas divisorias
- [ ] Coincide razonablemente con la franja de Claude Design (no más alta de lo necesario)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated section padding for Hero and Stats components using a refreshed styling approach for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->