### PR TITLE
feat: add /contact page and remove exposed email from footer

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,25 @@
+DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+BETTER_AUTH_SECRET=tu_secreto_aleatorio_minimo_32_caracteres_aqui
+BETTER_AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Google OAuth (opcional)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Cloudinary
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=
+NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+
+# Resend
+RESEND_API_KEY=
+
+# Email destino de los mensajes que llegan desde /contact (form de contacto
+# público). Si no se define, cae a info@lahuelladelcaminante.de (mismo
+# destino que las notificaciones de /apply).
+CONTACT_RECIPIENT_EMAIL=info@example.com
+
+# Trigger.dev
+TRIGGER_SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# Example env files SI se trackean (sin secretos, sirven de docs para
+# nuevos devs). Si se agrega `.env.example` también, sumarlo acá.
+!.env.local.example
 
 # vercel
 .vercel

--- a/src/app/[locale]/(public)/contact/page.tsx
+++ b/src/app/[locale]/(public)/contact/page.tsx
@@ -1,0 +1,101 @@
+/**
+ * `/contact` — pantalla pública para enviar mensajes al founder.
+ *
+ * Reemplaza el `mailto:info@lahuelladelcaminante.de` que vivía en el
+ * footer y exponía el email a scrapers. El form va a un route handler
+ * que dispara un email pre-clasificado por tipo de consulta.
+ *
+ * Layout simple centrado (un form no necesita 1280px). Bloque de
+ * alternativas debajo: Instagram externo + link al flujo `/apply` para
+ * artistas (no mezclar tracks).
+ *
+ * Server async — la i18n se resuelve acá; el form interno es client.
+ */
+
+import type { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
+import { ExternalLink } from "lucide-react"
+import { Link } from "@/i18n/navigation"
+import Eyebrow from "@/components/ui/Eyebrow"
+import ContactForm from "@/components/contact/ContactForm"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "contact" })
+  return {
+    title: `${t("metaTitle")} · La Huella del Caminante`,
+    description: t("metaDescription"),
+  }
+}
+
+export default async function ContactPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "contact" })
+
+  return (
+    <div className="max-w-2xl mx-auto px-m sm:px-l py-l lg:py-xl flex flex-col gap-2xl">
+      <header className="flex flex-col gap-m">
+        <Eyebrow accent="brand">{t("eyebrow")}</Eyebrow>
+        <h1 className="text-display-m sm:text-display-l font-display text-fg-primary leading-[0.95]">
+          {t("title")}
+        </h1>
+        <p className="text-body-l text-fg-secondary leading-relaxed">
+          {t.rich("body", {
+            applyLink: (chunks) => (
+              <Link
+                href="/apply"
+                className="font-semibold text-brand hover:text-brand-dim transition-colors"
+              >
+                {chunks}
+              </Link>
+            ),
+          })}
+        </p>
+      </header>
+
+      <ContactForm />
+
+      <section
+        aria-labelledby="alternatives-heading"
+        className="flex flex-col gap-m border-t border-border pt-l"
+      >
+        <Eyebrow as="h2" className="block" >
+          <span id="alternatives-heading">{t("alternatives.title")}</span>
+        </Eyebrow>
+        <ul className="flex flex-col gap-s text-body text-fg-secondary">
+          <li>
+            <a
+              href="https://www.instagram.com/lahuelladelcaminante/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-xs font-medium text-fg-primary hover:underline"
+            >
+              {t("alternatives.instagramLabel")}
+              <ExternalLink className="w-4 h-4" aria-hidden />
+            </a>
+          </li>
+          <li>
+            {t.rich("alternatives.artist", {
+              applyLink: (chunks) => (
+                <Link
+                  href="/apply"
+                  className="font-semibold text-brand hover:text-brand-dim transition-colors"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,73 @@
+/**
+ * POST `/api/contact` — recibe el form de `/contact`, valida con el
+ * schema compartido y dispara el email al founder via Resend.
+ *
+ * No persiste en DB (decisión de producto — los mensajes se manejan
+ * desde la inbox del founder, no hay sistema de "tickets" interno).
+ *
+ * El label legible del tipo (`typeLabel`, que termina en el subject
+ * del email) se resuelve del namespace i18n `contact.form.types.*`
+ * usando el locale del request. Esto evita que el founder reciba mails
+ * con keys técnicas como `[Contacto · event_suggestion]`.
+ */
+
+import { NextResponse } from "next/server"
+import { getTranslations } from "next-intl/server"
+import { env } from "@/lib/env"
+import {
+  contactSchema,
+  CONTACT_TYPE_I18N_KEY,
+  type ContactType,
+} from "@/lib/validators/contact"
+import { triggerContactNotification } from "@/lib/trigger"
+
+async function resolveTypeLabel(type: ContactType, locale: string): Promise<string> {
+  const t = await getTranslations({ locale, namespace: "contact.form.types" })
+  return t(CONTACT_TYPE_I18N_KEY[type])
+}
+
+function pickLocale(headerValue: string | null): string {
+  // El cliente manda `x-locale` con el locale activo del request (es/en/de).
+  // Fallback `es` (locale canónico del proyecto) si el header no llega o no
+  // matchea — no afecta la entrega, solo el idioma del label que aparece
+  // en el subject.
+  const fallback = "es"
+  if (!headerValue) return fallback
+  return ["es", "en", "de"].includes(headerValue) ? headerValue : fallback
+}
+
+export async function POST(request: Request) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 })
+  }
+
+  const result = contactSchema.safeParse(body)
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "validation_error", issues: result.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const locale = pickLocale(request.headers.get("x-locale"))
+  const typeLabel = await resolveTypeLabel(result.data.type, locale)
+
+  // Fire-and-forget igual que `/apply` — si Resend falla, no queremos
+  // bloquear al user con un 500. El catch silencioso es deuda conocida
+  // del patrón existente; cuando se agregue logging estructurado, atar
+  // acá también.
+  triggerContactNotification({
+    to: env.CONTACT_RECIPIENT_EMAIL,
+    name: result.data.name,
+    email: result.data.email,
+    type: result.data.type,
+    typeLabel,
+    message: result.data.message,
+    locale,
+  }).catch(() => {})
+
+  return NextResponse.json({ data: { success: true } })
+}

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -135,8 +135,17 @@ export async function POST(request: Request) {
       locale,
     })
   } catch (error) {
+    // Whitelist explícito de campos del error — NO serializamos el objeto
+    // crudo porque `error.message` / `error.cause` pueden traer eco del
+    // payload del user (snippets del body que falló al enviar). Solo
+    // logueamos `name` (clase del error: TypeError, NetworkError, etc),
+    // que es info diagnóstica sin PII.
+    const safeError =
+      error instanceof Error
+        ? { errorName: error.name }
+        : { errorType: typeof error }
     console.error("contact_notification_failed", {
-      error,
+      ...safeError,
       recipient: env.CONTACT_RECIPIENT_EMAIL,
       type: result.data.type,
       locale,

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -27,7 +27,7 @@ import { NextResponse } from "next/server"
 import { getTranslations } from "next-intl/server"
 import { env } from "@/lib/env"
 import {
-  contactSchema,
+  contactRequestSchema,
   CONTACT_TYPE_I18N_KEY,
   type ContactType,
 } from "@/lib/validators/contact"
@@ -98,7 +98,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "invalid_json" }, { status: 400 })
   }
 
-  const result = contactSchema.safeParse(body)
+  const result = contactRequestSchema.safeParse(body)
   if (!result.success) {
     return NextResponse.json(
       { error: "validation_error", issues: result.error.issues },
@@ -114,19 +114,38 @@ export async function POST(request: Request) {
   const locale = pickLocale(request.headers.get("x-locale"))
   const typeLabel = await resolveTypeLabel(result.data.type, locale)
 
-  // Fire-and-forget igual que `/apply` — si Resend falla, no queremos
-  // bloquear al user con un 500. El catch silencioso es deuda conocida
-  // del patrón existente; cuando se agregue logging estructurado, atar
-  // acá también.
-  triggerContactNotification({
-    to: env.CONTACT_RECIPIENT_EMAIL,
-    name: result.data.name,
-    email: result.data.email,
-    type: result.data.type,
-    typeLabel,
-    message: result.data.message,
-    locale,
-  }).catch(() => {})
+  // Await el envío del email — si Resend falla, queremos saberlo antes
+  // de devolver 200 al cliente. El catch loggea estructurado para que
+  // se pueda diagnosticar sin filtrar PII al log (no logueamos `name`,
+  // `email` ni `message` — solo metadata mínima para correlacionar con
+  // el dashboard de Resend).
+  //
+  // Trade-off: el user espera el roundtrip de Resend (~200-400ms extra)
+  // antes de ver el toast de éxito. Aceptable para este formulario de
+  // baja frecuencia; si en el futuro hay carga, mover a queue (Trigger.dev
+  // job real) y devolver 202 con tracking id.
+  try {
+    await triggerContactNotification({
+      to: env.CONTACT_RECIPIENT_EMAIL,
+      name: result.data.name,
+      email: result.data.email,
+      type: result.data.type,
+      typeLabel,
+      message: result.data.message,
+      locale,
+    })
+  } catch (error) {
+    console.error("contact_notification_failed", {
+      error,
+      recipient: env.CONTACT_RECIPIENT_EMAIL,
+      type: result.data.type,
+      locale,
+    })
+    return NextResponse.json(
+      { error: "notification_failed" },
+      { status: 502 }
+    )
+  }
 
   return NextResponse.json({ data: { success: true } })
 }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -9,6 +9,18 @@
  * del email) se resuelve del namespace i18n `contact.form.types.*`
  * usando el locale del request. Esto evita que el founder reciba mails
  * con keys técnicas como `[Contacto · event_suggestion]`.
+ *
+ * Defensas anti-abuse acotadas (decisión de producto: sin captcha):
+ *  - Honeypot field `website` en el schema. Si llega no-vacío,
+ *    descartamos silenciosamente con 200 fake (no le damos pista al
+ *    bot).
+ *  - Origin/Referer check contra `NEXT_PUBLIC_APP_URL` para cortar el
+ *    vector "sitio tercero hace fetch cross-origin desde browser".
+ *    Defense parcial — un atacante con backend propio sin browser la
+ *    evita, pero corta el caso bot-on-third-party-site.
+ *
+ * Falta (registrado en BACKLOG como deuda ALTA): rate limit IP-based,
+ * GDPR consent + Datenschutzerklärung, security headers globales.
  */
 
 import { NextResponse } from "next/server"
@@ -36,7 +48,49 @@ function pickLocale(headerValue: string | null): string {
   return ["es", "en", "de"].includes(headerValue) ? headerValue : fallback
 }
 
+/**
+ * Chequea que el POST venga del mismo origen del sitio. Cierra el
+ * vector "browser de un tercero hace fetch cross-origin a /api/contact"
+ * que de otra forma habilitaría a bots distribuidos sin infra propia.
+ * No es defensa completa (un atacante con backend la evita), pero corta
+ * el path browser-based con cero costo.
+ */
+function isAllowedOrigin(request: Request): boolean {
+  const expected = env.NEXT_PUBLIC_APP_URL
+  if (!expected) return true // sin app URL configurada → no podemos comparar
+  const origin = request.headers.get("origin")
+  if (origin) {
+    try {
+      return new URL(origin).origin === new URL(expected).origin
+    } catch {
+      return false
+    }
+  }
+  // Si no hay Origin (algunos clientes), probar con Referer como fallback.
+  const referer = request.headers.get("referer")
+  if (referer) {
+    try {
+      return new URL(referer).origin === new URL(expected).origin
+    } catch {
+      return false
+    }
+  }
+  // Sin Origin ni Referer: rechazar conservadoramente (browsers reales
+  // mandan al menos uno en POSTs).
+  return false
+}
+
+/** "200 fake" para honeypot trips: respondemos como si todo OK pero NO
+ * disparamos el email. Sin pista para el bot. */
+function fakeOk() {
+  return NextResponse.json({ data: { success: true } })
+}
+
 export async function POST(request: Request) {
+  if (!isAllowedOrigin(request)) {
+    return NextResponse.json({ error: "forbidden_origin" }, { status: 403 })
+  }
+
   let body: unknown
   try {
     body = await request.json()
@@ -50,6 +104,11 @@ export async function POST(request: Request) {
       { error: "validation_error", issues: result.error.issues },
       { status: 400 }
     )
+  }
+
+  // Honeypot trip: bot completó el campo invisible. Fake 200, sin email.
+  if (result.data.website && result.data.website.trim() !== "") {
+    return fakeOk()
   }
 
   const locale = pickLocale(request.headers.get("x-locale"))

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,0 +1,295 @@
+"use client"
+
+/**
+ * ContactForm — form de `/contact`. Client component porque maneja
+ * estado de submit + success state inline + reset.
+ *
+ * Validación: schema zod compartido (`@/lib/validators/contact`). En
+ * cliente lo usamos para feedback inmediato antes del POST; el route
+ * handler `/api/contact` re-aplica el mismo schema (no confiamos en
+ * la validación del cliente). HTML `required` / `minLength` quedan
+ * como red de seguridad — bloquean submit en browsers sin JS.
+ *
+ * UX:
+ *  - Errores de validación de campo se muestran inline debajo del input.
+ *  - Errores de network/server se muestran como `toast` (sonner).
+ *  - Submit exitoso → render inline de la confirmación (no navega).
+ *  - Botón "Enviar otro mensaje" en la confirmación → reset full del state.
+ */
+
+import { useState, useTransition } from "react"
+import { useTranslations, useLocale } from "next-intl"
+import { Link } from "@/i18n/navigation"
+import { toast } from "sonner"
+import { CheckCircle2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import Eyebrow from "@/components/ui/Eyebrow"
+import {
+  contactSchema,
+  CONTACT_TYPES,
+  CONTACT_TYPE_I18N_KEY,
+  type ContactType,
+  type ContactInput,
+} from "@/lib/validators/contact"
+
+type FieldErrors = Partial<Record<keyof ContactInput, string>>
+
+const INITIAL_STATE: ContactInput = {
+  name: "",
+  email: "",
+  type: "event_suggestion",
+  message: "",
+}
+
+/** Códigos de error definidos en el schema. Cualquier código no listado
+ * acá cae al label `generic` del namespace i18n. */
+const KNOWN_ERROR_CODES = new Set<string>([
+  "name_too_short",
+  "name_too_long",
+  "email_invalid",
+  "email_too_long",
+  "type_invalid",
+  "message_too_short",
+  "message_too_long",
+])
+
+export default function ContactForm() {
+  const tForm = useTranslations("contact.form")
+  const tTypes = useTranslations("contact.form.types")
+  const tErrors = useTranslations("contact.form.errors")
+  const tSuccess = useTranslations("contact.success")
+  const tError = useTranslations("contact.error")
+  const locale = useLocale()
+  const errorMessageFor = (code: string): string =>
+    KNOWN_ERROR_CODES.has(code) ? tErrors(code) : tErrors("generic")
+
+  const [values, setValues] = useState<ContactInput>(INITIAL_STATE)
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
+  const [sentName, setSentName] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function update<K extends keyof ContactInput>(key: K, value: ContactInput[K]) {
+    setValues((prev) => ({ ...prev, [key]: value }))
+    // Limpiar el error del campo al escribir — feedback positivo sin
+    // tener que re-submittear para ver que se corrigió.
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    }
+  }
+
+  function reset() {
+    setValues(INITIAL_STATE)
+    setFieldErrors({})
+    setSentName(null)
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const parsed = contactSchema.safeParse(values)
+    if (!parsed.success) {
+      const next: FieldErrors = {}
+      for (const issue of parsed.error.issues) {
+        const path = issue.path[0]
+        if (typeof path === "string" && !next[path as keyof ContactInput]) {
+          next[path as keyof ContactInput] = errorMessageFor(issue.message)
+        }
+      }
+      setFieldErrors(next)
+      return
+    }
+
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/contact", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            // El server usa este header para resolver el label legible
+            // del `type` en el subject del email.
+            "x-locale": locale,
+          },
+          body: JSON.stringify(parsed.data),
+        })
+        if (res.ok) {
+          setSentName(parsed.data.name)
+          return
+        }
+        // 400 validation_error: el server rechazó por schema (drift entre
+        // cliente y server, o usuario tampering con el payload). Volcamos
+        // las `issues` a fieldErrors para que el user vea exactamente qué
+        // campo está mal. Cualquier otro status (5xx, 429, etc) cae al
+        // toast genérico de "problema de conexión".
+        if (res.status === 400) {
+          const body = (await res.json().catch(() => null)) as
+            | { issues?: Array<{ path: (string | number)[]; message: string }> }
+            | null
+          if (body?.issues?.length) {
+            const next: FieldErrors = {}
+            for (const issue of body.issues) {
+              const path = issue.path[0]
+              if (typeof path === "string" && !next[path as keyof ContactInput]) {
+                next[path as keyof ContactInput] = errorMessageFor(issue.message)
+              }
+            }
+            setFieldErrors(next)
+            return
+          }
+        }
+        toast.error(tError("title"), { description: tError("body") })
+      } catch {
+        toast.error(tError("title"), { description: tError("body") })
+      }
+    })
+  }
+
+  if (sentName) {
+    return (
+      <div
+        className="flex flex-col items-center gap-l text-center py-2xl"
+        role="status"
+      >
+        <div className="w-16 h-16 rounded-full bg-editorial/15 flex items-center justify-center">
+          <CheckCircle2 className="w-8 h-8 text-editorial" aria-hidden />
+        </div>
+        <Eyebrow accent="editorial">{tSuccess("eyebrow")}</Eyebrow>
+        <h2 className="text-heading-l font-display text-fg-primary">
+          {tSuccess("title", { name: sentName })}
+        </h2>
+        <p className="text-body text-fg-secondary max-w-[40ch] leading-relaxed">
+          {tSuccess("body")}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-s">
+          <Button asChild variant="outline">
+            <Link href="/">{tSuccess("backHome")}</Link>
+          </Button>
+          <Button onClick={reset} variant="ghost">
+            {tSuccess("sendAnother")}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-l" noValidate>
+      <div className="flex flex-col gap-xs">
+        <Label htmlFor="contact-name">{tForm("name")}</Label>
+        <Input
+          id="contact-name"
+          name="name"
+          value={values.name}
+          onChange={(e) => update("name", e.target.value)}
+          placeholder={tForm("namePlaceholder")}
+          required
+          minLength={2}
+          maxLength={120}
+          autoComplete="name"
+          aria-invalid={Boolean(fieldErrors.name)}
+          aria-describedby={fieldErrors.name ? "contact-name-error" : undefined}
+        />
+        {fieldErrors.name ? (
+          <p id="contact-name-error" className="text-body-s text-status-danger">
+            {fieldErrors.name}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <Label htmlFor="contact-email">{tForm("email")}</Label>
+        <Input
+          id="contact-email"
+          name="email"
+          type="email"
+          value={values.email}
+          onChange={(e) => update("email", e.target.value)}
+          placeholder={tForm("emailPlaceholder")}
+          required
+          maxLength={254}
+          autoComplete="email"
+          aria-invalid={Boolean(fieldErrors.email)}
+          aria-describedby={fieldErrors.email ? "contact-email-error" : undefined}
+        />
+        {fieldErrors.email ? (
+          <p id="contact-email-error" className="text-body-s text-status-danger">
+            {fieldErrors.email}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <Label htmlFor="contact-type">{tForm("type")}</Label>
+        <select
+          id="contact-type"
+          name="type"
+          value={values.type}
+          onChange={(e) => update("type", e.target.value as ContactType)}
+          required
+          aria-invalid={Boolean(fieldErrors.type)}
+          aria-describedby={fieldErrors.type ? "contact-type-error" : undefined}
+          className={cn(
+            "h-9 rounded-m border border-input bg-bg-surface px-s text-body-s",
+            "text-fg-primary",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+          )}
+        >
+          {CONTACT_TYPES.map((value) => (
+            <option key={value} value={value}>
+              {tTypes(CONTACT_TYPE_I18N_KEY[value])}
+            </option>
+          ))}
+        </select>
+        {fieldErrors.type ? (
+          <p id="contact-type-error" className="text-body-s text-status-danger">
+            {fieldErrors.type}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-col gap-xs">
+        <Label htmlFor="contact-message">{tForm("message")}</Label>
+        <Textarea
+          id="contact-message"
+          name="message"
+          value={values.message}
+          onChange={(e) => update("message", e.target.value)}
+          placeholder={tForm("messagePlaceholder")}
+          rows={6}
+          required
+          minLength={10}
+          maxLength={2000}
+          aria-invalid={Boolean(fieldErrors.message)}
+          aria-describedby={
+            fieldErrors.message ? "contact-message-error" : "contact-message-hint"
+          }
+          className="resize-y"
+        />
+        {fieldErrors.message ? (
+          <p id="contact-message-error" className="text-body-s text-status-danger">
+            {fieldErrors.message}
+          </p>
+        ) : (
+          <p id="contact-message-hint" className="text-body-s text-fg-tertiary">
+            {tForm("messageHint")}
+          </p>
+        )}
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isPending}
+        className="self-start rounded-pill bg-brand text-on-brand font-semibold px-xl py-m text-body-l hover:bg-brand-dim disabled:opacity-60"
+      >
+        {isPending ? tForm("submitting") : tForm("submit")}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -43,6 +43,7 @@ const INITIAL_STATE: ContactInput = {
   email: "",
   type: "event_suggestion",
   message: "",
+  website: "", // honeypot
 }
 
 /** Códigos de error definidos en el schema. Cualquier código no listado
@@ -281,6 +282,25 @@ export default function ContactForm() {
             {tForm("messageHint")}
           </p>
         )}
+      </div>
+
+      {/* Honeypot — campo invisible para humanos pero llenable por bots
+          de spam clásicos. Si llega no-vacío, el server descarta el
+          request silenciosamente. `aria-hidden` + `tabIndex={-1}` para
+          que asistencias técnicas y navegación por teclado lo salteen.
+          `autoComplete="off"` y `name="website"` (campo común que los
+          bots agresivos completan por inferencia del name). */}
+      <div aria-hidden className="absolute -left-[9999px] w-0 h-0 overflow-hidden">
+        <label htmlFor="contact-website">Website</label>
+        <input
+          id="contact-website"
+          type="text"
+          name="website"
+          tabIndex={-1}
+          autoComplete="off"
+          value={values.website ?? ""}
+          onChange={(e) => update("website", e.target.value)}
+        />
       </div>
 
       <Button

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -194,7 +194,12 @@ export default function ContactForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-l" noValidate>
+    <form
+      method="post"
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-l"
+      noValidate
+    >
       <div className="flex flex-col gap-xs">
         <Label htmlFor="contact-name">{tForm("name")}</Label>
         <Input

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -43,7 +43,6 @@ const INITIAL_STATE: ContactInput = {
   email: "",
   type: "event_suggestion",
   message: "",
-  website: "", // honeypot
 }
 
 /** Códigos de error definidos en el schema. Cualquier código no listado
@@ -72,6 +71,13 @@ export default function ContactForm() {
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
   const [sentName, setSentName] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  // Honeypot — vive en estado separado a propósito: NO forma parte del
+  // tipo `ContactInput` ni del schema de validación cliente, así el
+  // bundle del cliente no tiene una pista de que existe (un atacante
+  // que inspecciona el zod schema en el JS no ve `website`). El input
+  // sigue presente en el DOM porque ahí es donde el bot lo completa;
+  // mandamos su valor al server junto con el resto del payload.
+  const [honeypot, setHoneypot] = useState("")
 
   function update<K extends keyof ContactInput>(key: K, value: ContactInput[K]) {
     setValues((prev) => ({ ...prev, [key]: value }))
@@ -90,6 +96,7 @@ export default function ContactForm() {
     setValues(INITIAL_STATE)
     setFieldErrors({})
     setSentName(null)
+    setHoneypot("")
   }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -117,7 +124,14 @@ export default function ContactForm() {
             // del `type` en el subject del email.
             "x-locale": locale,
           },
-          body: JSON.stringify(parsed.data),
+          // Mergeamos el honeypot fuera del schema cliente — el server
+          // lo valida con `contactRequestSchema` (que sí lo conoce) y
+          // descarta el request si viene no-vacío. Si el honeypot está
+          // vacío (caso humano), lo omitimos para no enviar string vacío
+          // al server (se valida con `.optional()`).
+          body: JSON.stringify(
+            honeypot ? { ...parsed.data, website: honeypot } : parsed.data
+          ),
         })
         if (res.ok) {
           setSentName(parsed.data.name)
@@ -158,7 +172,7 @@ export default function ContactForm() {
         role="status"
       >
         <div className="w-16 h-16 rounded-full bg-editorial/15 flex items-center justify-center">
-          <CheckCircle2 className="w-8 h-8 text-editorial" aria-hidden />
+          <CheckCircle2 className="w-8 h-8 text-editorial" aria-hidden={true} />
         </div>
         <Eyebrow accent="editorial">{tSuccess("eyebrow")}</Eyebrow>
         <h2 className="text-heading-l font-display text-fg-primary">
@@ -289,8 +303,14 @@ export default function ContactForm() {
           request silenciosamente. `aria-hidden` + `tabIndex={-1}` para
           que asistencias técnicas y navegación por teclado lo salteen.
           `autoComplete="off"` y `name="website"` (campo común que los
-          bots agresivos completan por inferencia del name). */}
-      <div aria-hidden className="absolute -left-[9999px] w-0 h-0 overflow-hidden">
+          bots agresivos completan por inferencia del name).
+          El valor vive en `honeypot` (state separado, fuera de `values`)
+          para que el bundle del cliente no exponga el campo en el zod
+          schema. */}
+      <div
+        aria-hidden={true}
+        className="absolute -left-[9999px] w-0 h-0 overflow-hidden"
+      >
         <label htmlFor="contact-website">Website</label>
         <input
           id="contact-website"
@@ -298,8 +318,8 @@ export default function ContactForm() {
           name="website"
           tabIndex={-1}
           autoComplete="off"
-          value={values.website ?? ""}
-          onChange={(e) => update("website", e.target.value)}
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
         />
       </div>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,16 +5,15 @@
  *  1. Marca: BrandLockup vertical + tagline.
  *  2. EXPLORAR: links públicos (Eventos, Artistas, Esta semana).
  *  3. PARA VOS: aplicar como creator, sign-in.
- *  4. COMUNIDAD: Instagram, newsletter (placeholder), email mailto.
+ *  4. COMUNIDAD: Instagram, newsletter (placeholder), link a /contact.
+ *
+ * **`mailto:info@lahuelladelcaminante.de` removido**: el email expuesto
+ * era invitación abierta a scrapers. Reemplazado por link a `/contact`
+ * con form (decisión de producto, PR 8.5).
  *
  * Debajo de las columnas, línea separadora con copyright a la izquierda y
  * links a Impressum/Datenschutz a la derecha (`#` por ahora; el contenido
  * legal se redacta en una épica aparte).
- *
- * Es server component: no necesita hooks ni sesión. La distinción "mostrar
- * email solo a creator/admin" del Footer viejo se elimina — el email
- * `info@...` ahora aparece a todos, alineado con el handoff (sección
- * pública de contacto).
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT.md` §3 + §6.
  */
@@ -82,9 +81,7 @@ export async function Footer() {
             <FooterLink href="#" external>
               {t("newsletter")}
             </FooterLink>
-            <FooterLink href="mailto:info@lahuelladelcaminante.de" external>
-              info@lahuelladelcaminante.de
-            </FooterLink>
+            <FooterLink href="/contact">{t("contact")}</FooterLink>
           </FooterColumn>
         </div>
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -12,6 +12,16 @@ const envSchema = z.object({
   CLOUDINARY_API_SECRET: z.string().optional().default(""),
   RESEND_API_KEY: z.string().optional().default(""),
   TRIGGER_SECRET_KEY: z.string().optional().default(""),
+  /**
+   * Email del founder al que llegan los mensajes de `/contact`. Si no
+   * está definida, el handler cae a `info@lahuelladelcaminante.de`
+   * (mismo destino histórico de `triggerApplicationNotification`).
+   */
+  CONTACT_RECIPIENT_EMAIL: z
+    .string()
+    .email()
+    .optional()
+    .default("info@lahuelladelcaminante.de"),
 })
 
 export const env = envSchema.parse(process.env)

--- a/src/lib/trigger.ts
+++ b/src/lib/trigger.ts
@@ -290,6 +290,13 @@ export async function triggerContactNotification(payload: {
   // en profundidad — colapsamos newlines a espacio y recortamos extra.
   const safeSubjectName = payload.name.replace(/[\r\n]+/g, " ").trim().slice(0, 100)
   const safeSubjectLabel = payload.typeLabel.replace(/[\r\n]+/g, " ").trim().slice(0, 60)
+  // Mismo tratamiento para el email que va al `Reply-To` header y al
+  // `<a href="mailto:">` del template. Zod `.email()` debería filtrar
+  // CRLF, pero defense in depth: aún si una versión futura de zod o un
+  // edge case lo deja pasar, no permitimos que llegue a un header MIME.
+  // También cortamos `,` y `;` por si se intenta inyectar múltiples
+  // destinatarios via Reply-To.
+  const safeEmail = payload.email.replace(/[\r\n,;]+/g, "").trim()
 
   const html = `<!DOCTYPE html>
 <html lang="${escapeHtml(payload.locale)}">
@@ -317,7 +324,7 @@ export async function triggerContactNotification(payload: {
             <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
               <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Email</p>
               <p style="color:#c0392b;font-size:15px;font-weight:600;margin:0">
-                <a href="mailto:${encodeURIComponent(payload.email)}" style="color:#c0392b;text-decoration:none">${escapeHtml(payload.email)}</a>
+                <a href="mailto:${escapeHtml(safeEmail)}" style="color:#c0392b;text-decoration:none">${escapeHtml(safeEmail)}</a>
               </p>
             </td></tr>
             <tr><td style="padding:14px 20px">
@@ -343,7 +350,7 @@ export async function triggerContactNotification(payload: {
     payload.to,
     `[Contacto · ${safeSubjectLabel}] ${safeSubjectName}`,
     html,
-    { replyTo: payload.email }
+    { replyTo: safeEmail }
   )
 }
 

--- a/src/lib/trigger.ts
+++ b/src/lib/trigger.ts
@@ -1,4 +1,9 @@
-async function sendEmail(to: string, subject: string, html: string) {
+async function sendEmail(
+  to: string,
+  subject: string,
+  html: string,
+  options: { replyTo?: string } = {}
+) {
   if (!process.env.RESEND_API_KEY) return
   const { getResend } = await import("./email")
   await getResend().emails.send({
@@ -6,6 +11,7 @@ async function sendEmail(to: string, subject: string, html: string) {
     to,
     subject,
     html,
+    ...(options.replyTo ? { replyTo: options.replyTo } : {}),
   })
 }
 
@@ -249,4 +255,106 @@ export async function triggerApplicationNotification(payload: {
     `Nueva solicitud: ${payload.name} quiere publicar eventos`,
     html
   )
+}
+
+/**
+ * Email al founder con un mensaje del form de `/contact`. Subject
+ * pre-clasificado para que sea fácil triage en la inbox:
+ * `[Contacto · {typeLabel}] {nombre}`.
+ *
+ * - `to`: destinatario, resuelto por el caller desde
+ *   `env.CONTACT_RECIPIENT_EMAIL` (fallback a `info@lahuelladelcaminante.de`).
+ * - `typeLabel`: label legible del tipo (ej. "Prensa o medios") — el
+ *   caller ya lo resolvió con i18n.
+ * - `replyTo`: el email del remitente se setea como Reply-To para que
+ *   responder desde la inbox vaya directo a la persona, sin tener que
+ *   copiar el campo Email del cuerpo del mail.
+ */
+export async function triggerContactNotification(payload: {
+  to: string
+  name: string
+  email: string
+  type: string
+  typeLabel: string
+  message: string
+  /** Locale del request que originó el mensaje. Setea `lang` del HTML
+   * del email para que clientes de mail con corrección ortográfica/
+   * traducción usen el idioma correcto. El header visible del email
+   * sigue en castellano (lo lee el founder), pero el `lang` refleja la
+   * realidad de quién escribió el contenido. */
+  locale: string
+}) {
+  // Sanitización defensiva: zod ya valida `name` con `max(120)`, pero un
+  // CRLF en el medio pasaría el length check y podría meterse en el
+  // `Subject:` MIME header. Resend probablemente lo cubre, pero defendemos
+  // en profundidad — colapsamos newlines a espacio y recortamos extra.
+  const safeSubjectName = payload.name.replace(/[\r\n]+/g, " ").trim().slice(0, 100)
+  const safeSubjectLabel = payload.typeLabel.replace(/[\r\n]+/g, " ").trim().slice(0, 60)
+
+  const html = `<!DOCTYPE html>
+<html lang="${escapeHtml(payload.locale)}">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#0e0407;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#0e0407;padding:40px 20px">
+    <tr><td align="center">
+      <table width="100%" style="max-width:580px;background:#130609;border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,0.08)">
+
+        <tr><td style="background:#1a0c10;padding:28px 32px;border-bottom:1px solid rgba(255,255,255,0.06)">
+          <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.2em;text-transform:uppercase;margin:0 0 6px">La Huella del Caminante</p>
+          <h1 style="color:#ffffff;font-size:20px;font-weight:800;margin:0">Nuevo mensaje desde /contact</h1>
+        </td></tr>
+
+        <tr><td style="padding:32px">
+          <table width="100%" cellpadding="0" cellspacing="0" style="background:#0e0407;border-radius:10px;overflow:hidden">
+            <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Tipo de consulta</p>
+              <p style="color:#ffffff;font-size:15px;font-weight:600;margin:0">${escapeHtml(payload.typeLabel)}</p>
+            </td></tr>
+            <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Nombre</p>
+              <p style="color:#ffffff;font-size:15px;font-weight:600;margin:0">${escapeHtml(payload.name)}</p>
+            </td></tr>
+            <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Email</p>
+              <p style="color:#c0392b;font-size:15px;font-weight:600;margin:0">
+                <a href="mailto:${encodeURIComponent(payload.email)}" style="color:#c0392b;text-decoration:none">${escapeHtml(payload.email)}</a>
+              </p>
+            </td></tr>
+            <tr><td style="padding:14px 20px">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 8px">Mensaje</p>
+              <p style="color:#e8d5d0;font-size:14px;line-height:1.7;margin:0;white-space:pre-wrap">${escapeHtml(payload.message)}</p>
+            </td></tr>
+          </table>
+        </td></tr>
+
+        <tr><td style="border-top:1px solid rgba(255,255,255,0.06);padding:18px 32px;text-align:center">
+          <p style="color:rgba(255,255,255,0.2);font-size:12px;margin:0">
+            © ${new Date().getFullYear()} La Huella del Caminante · Berlín
+          </p>
+        </td></tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+
+  await sendEmail(
+    payload.to,
+    `[Contacto · ${safeSubjectLabel}] ${safeSubjectName}`,
+    html,
+    { replyTo: payload.email }
+  )
+}
+
+/** Escape mínimo para interpolar input del user en el HTML del email.
+ * Suficiente para evitar HTML injection en una plantilla controlada
+ * (no markdown ni script tags). */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
 }

--- a/src/lib/validators/contact.ts
+++ b/src/lib/validators/contact.ts
@@ -23,12 +23,39 @@ export const CONTACT_TYPES = [
 
 export type ContactType = (typeof CONTACT_TYPES)[number]
 
+/**
+ * Strip de caracteres invisibles que pueden facilitar abuse:
+ *  - `U+200B-U+200F`: zero-width chars + direccional marks (LRM/RLM).
+ *  - `U+202A-U+202E`: overrides de direccionalidad (RLO, LRO, etc).
+ *    Sin esto, un nombre malicioso con RLO puede renderizarse invertido
+ *    en la inbox del founder y facilitar phishing visual.
+ *  - `U+2060-U+2069`: word joiner + invisible operators / formatting.
+ *
+ * Newlines/tabs (`\n`, `\r`, `\t`) se PRESERVAN porque el `message`
+ * legítimamente tiene saltos de línea. El subject del email aplica su
+ * propio `.replace(/[\r\n]+/g, " ")` para CRLF en headers.
+ */
+function stripInvisibleAbusableChars(value: string): string {
+  return value.replace(/[​-‏‪-‮⁠-⁩]/g, "")
+}
+
+/** Normalize Unicode (NFKC: combina equivalentes y desambigua compatibles)
+ * para evitar homoglyphs que crucen el form vía caracteres equivalentes. */
+function normalizeAndStrip(value: string): string {
+  return stripInvisibleAbusableChars(value.normalize("NFKC"))
+}
+
 export const contactSchema = z.object({
   name: z
     .string()
     .trim()
-    .min(2, { message: "name_too_short" })
-    .max(120, { message: "name_too_long" }),
+    .transform(normalizeAndStrip)
+    .pipe(
+      z
+        .string()
+        .min(2, { message: "name_too_short" })
+        .max(120, { message: "name_too_long" })
+    ),
   email: z
     .string()
     .trim()
@@ -40,8 +67,24 @@ export const contactSchema = z.object({
   message: z
     .string()
     .trim()
-    .min(10, { message: "message_too_short" })
-    .max(2000, { message: "message_too_long" }),
+    .transform(normalizeAndStrip)
+    .pipe(
+      z
+        .string()
+        .min(10, { message: "message_too_short" })
+        .max(2000, { message: "message_too_long" })
+    ),
+  /**
+   * Honeypot — campo invisible (CSS `display:none`) que un humano nunca
+   * llena pero los bots de spam clásicos sí. Si llega no-vacío, el
+   * server descarta silenciosamente el request con un 200 fake (no le
+   * damos pista al bot de que detectamos el honeypot — si rebota 4xx,
+   * el atacante ajusta el bot).
+   *
+   * Opcional en el schema (puede no estar presente en el payload) pero
+   * si está, debe estar vacío para pasar el check del server.
+   */
+  website: z.string().optional(),
 })
 
 export type ContactInput = z.infer<typeof contactSchema>

--- a/src/lib/validators/contact.ts
+++ b/src/lib/validators/contact.ts
@@ -1,7 +1,14 @@
 /**
- * Schema zod compartido cliente/servidor para el form de contacto
- * (`/contact`). El cliente lo usa para validar antes del submit; el route
- * handler `/api/contact` lo re-aplica para no confiar en el cliente.
+ * Schemas zod del form de contacto (`/contact`). Hay dos:
+ *
+ *  - `contactSchema`: el contrato user-facing. Lo usa el cliente para
+ *    validar antes del submit y para tipar el estado del form. NO
+ *    incluye el honeypot — los bots que inspeccionan el bundle del
+ *    cliente no encuentran pista de que existe.
+ *  - `contactRequestSchema`: extiende `contactSchema` agregando el
+ *    campo honeypot `website`. Es el schema que aplica el server al
+ *    re-validar el payload entrante. Si `website` viene no-vacío, el
+ *    handler descarta silenciosamente (200 fake, sin pista al bot).
  *
  * Mantener un único `safeParse` en server es la línea anti-tampering;
  * la validación de cliente es solo UX (feedback inmediato).
@@ -45,6 +52,9 @@ function normalizeAndStrip(value: string): string {
   return stripInvisibleAbusableChars(value.normalize("NFKC"))
 }
 
+/** Schema user-facing — sin honeypot. Consumido por el cliente para
+ * validación + tipado del state del form. El bundle del cliente NO
+ * expone que existe un honeypot. */
 export const contactSchema = z.object({
   name: z
     .string()
@@ -74,20 +84,25 @@ export const contactSchema = z.object({
         .min(10, { message: "message_too_short" })
         .max(2000, { message: "message_too_long" })
     ),
-  /**
-   * Honeypot — campo invisible (CSS `display:none`) que un humano nunca
-   * llena pero los bots de spam clásicos sí. Si llega no-vacío, el
-   * server descarta silenciosamente el request con un 200 fake (no le
-   * damos pista al bot de que detectamos el honeypot — si rebota 4xx,
-   * el atacante ajusta el bot).
-   *
-   * Opcional en el schema (puede no estar presente en el payload) pero
-   * si está, debe estar vacío para pasar el check del server.
-   */
-  website: z.string().optional(),
 })
 
 export type ContactInput = z.infer<typeof contactSchema>
+
+/**
+ * Schema server-side — extiende `contactSchema` con el honeypot
+ * `website`. Si llega no-vacío, el handler descarta silenciosamente
+ * (200 fake, sin pista al bot para que no ajuste su estrategia).
+ *
+ * Opcional en el schema (puede no estar presente en el payload — un
+ * cliente legítimo no manda el campo) pero si está, no debe contener
+ * data. El handler aplica la verificación de "no-vacío" sobre el
+ * resultado del parse.
+ */
+export const contactRequestSchema = contactSchema.extend({
+  website: z.string().optional(),
+})
+
+export type ContactRequest = z.infer<typeof contactRequestSchema>
 
 /**
  * Mapeo `ContactType` → key dentro del namespace i18n `contact.form.types`.

--- a/src/lib/validators/contact.ts
+++ b/src/lib/validators/contact.ts
@@ -1,0 +1,61 @@
+/**
+ * Schema zod compartido cliente/servidor para el form de contacto
+ * (`/contact`). El cliente lo usa para validar antes del submit; el route
+ * handler `/api/contact` lo re-aplica para no confiar en el cliente.
+ *
+ * Mantener un único `safeParse` en server es la línea anti-tampering;
+ * la validación de cliente es solo UX (feedback inmediato).
+ */
+
+import { z } from "zod"
+
+/** Tipos de consulta soportados por el dropdown. Estables — no traducir;
+ * el componente que renderiza el `<select>` resuelve el label via i18n
+ * por cada key. Estos valores viajan al server y aparecen en el subject
+ * del email. */
+export const CONTACT_TYPES = [
+  "event_suggestion",
+  "report_issue",
+  "press",
+  "partnership",
+  "other",
+] as const
+
+export type ContactType = (typeof CONTACT_TYPES)[number]
+
+export const contactSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(2, { message: "name_too_short" })
+    .max(120, { message: "name_too_long" }),
+  email: z
+    .string()
+    .trim()
+    .email({ message: "email_invalid" })
+    .max(254, { message: "email_too_long" }),
+  type: z.enum(CONTACT_TYPES, {
+    message: "type_invalid",
+  }),
+  message: z
+    .string()
+    .trim()
+    .min(10, { message: "message_too_short" })
+    .max(2000, { message: "message_too_long" }),
+})
+
+export type ContactInput = z.infer<typeof contactSchema>
+
+/**
+ * Mapeo `ContactType` → key dentro del namespace i18n `contact.form.types`.
+ * Vive acá (no en el client ni en el server) para que ambos consumidores
+ * compartan la misma fuente y agregar un tipo nuevo fuerce actualizar
+ * los dos lados (TS bloquea si falta una key).
+ */
+export const CONTACT_TYPE_I18N_KEY: Record<ContactType, string> = {
+  event_suggestion: "eventSuggestion",
+  report_issue: "reportIssue",
+  press: "press",
+  partnership: "partnership",
+  other: "other",
+}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -354,8 +354,61 @@
     "community": "Community",
     "apply": "Bewerben",
     "newsletter": "Newsletter",
+    "contact": "Schreib uns",
     "impressum": "Impressum",
     "datenschutz": "Datenschutz"
+  },
+  "contact": {
+    "metaTitle": "Kontakt",
+    "metaDescription": "Schreib uns für Vorschläge, Presse, Partnerschaften oder was du sonst brauchst.",
+    "eyebrow": "KONTAKT",
+    "title": "Schreib uns.",
+    "body": "Wir lesen jede Nachricht. Wir antworten meistens innerhalb von 2-3 Werktagen. Wenn du als Künstler:in deine Events veröffentlichen möchtest, gibt es einen <applyLink>eigenen Ablauf</applyLink>.",
+    "form": {
+      "name": "Dein Name",
+      "namePlaceholder": "Wie heißt du?",
+      "email": "Deine E-Mail",
+      "emailPlaceholder": "du@email.com",
+      "type": "Art der Anfrage",
+      "types": {
+        "eventSuggestion": "Event vorschlagen",
+        "reportIssue": "Problem melden",
+        "press": "Presse oder Medien",
+        "partnership": "Kooperation oder Partnerschaft",
+        "other": "Sonstiges"
+      },
+      "message": "Deine Nachricht",
+      "messagePlaceholder": "Erzähl uns, worum es geht...",
+      "messageHint": "Zwischen 10 und 2000 Zeichen.",
+      "submit": "Nachricht senden",
+      "submitting": "Wird gesendet...",
+      "errors": {
+        "name_too_short": "Mindestens 2 Zeichen.",
+        "name_too_long": "Höchstens 120 Zeichen.",
+        "email_invalid": "Ungültige E-Mail.",
+        "email_too_long": "E-Mail ist zu lang.",
+        "type_invalid": "Bitte eine Art der Anfrage wählen.",
+        "message_too_short": "Mindestens 10 Zeichen.",
+        "message_too_long": "Höchstens 2000 Zeichen.",
+        "generic": "Bitte prüf die Formularfelder."
+      }
+    },
+    "success": {
+      "eyebrow": "NACHRICHT GESENDET",
+      "title": "Danke, {name}.",
+      "body": "Wir haben deine Nachricht erhalten. Wir antworten an die angegebene E-Mail, in der Regel innerhalb von 2-3 Werktagen.",
+      "backHome": "Zurück zur Startseite",
+      "sendAnother": "Weitere Nachricht senden"
+    },
+    "error": {
+      "title": "Nachricht konnte nicht gesendet werden",
+      "body": "Es gab ein Verbindungsproblem. Versuch es gleich noch einmal."
+    },
+    "alternatives": {
+      "title": "Andere Pfade, uns zu erreichen",
+      "instagramLabel": "@lahuelladelcaminante auf Instagram",
+      "artist": "Bist du Künstler:in oder Veranstalter:in? Um deine Events zu veröffentlichen, <applyLink>bewirb dich hier</applyLink>."
+    }
   },
   "status": {
     "pending": "Ausstehend",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -354,8 +354,61 @@
     "community": "Community",
     "apply": "Apply",
     "newsletter": "Newsletter",
+    "contact": "Get in touch",
     "impressum": "Impressum",
     "datenschutz": "Datenschutz"
+  },
+  "contact": {
+    "metaTitle": "Contact",
+    "metaDescription": "Reach out for suggestions, press, partnerships, or anything else.",
+    "eyebrow": "CONTACT",
+    "title": "Get in touch.",
+    "body": "We read every message. We usually reply within 2-3 business days. If you're an artist looking to publish your events, there's a <applyLink>dedicated flow</applyLink>.",
+    "form": {
+      "name": "Your name",
+      "namePlaceholder": "What should we call you?",
+      "email": "Your email",
+      "emailPlaceholder": "you@email.com",
+      "type": "Inquiry type",
+      "types": {
+        "eventSuggestion": "Suggest an event",
+        "reportIssue": "Report an issue",
+        "press": "Press or media",
+        "partnership": "Collaboration or partnership",
+        "other": "Other"
+      },
+      "message": "Your message",
+      "messagePlaceholder": "Tell us what's up...",
+      "messageHint": "Between 10 and 2000 characters.",
+      "submit": "Send message",
+      "submitting": "Sending...",
+      "errors": {
+        "name_too_short": "At least 2 characters.",
+        "name_too_long": "Maximum 120 characters.",
+        "email_invalid": "Invalid email.",
+        "email_too_long": "Email is too long.",
+        "type_invalid": "Pick an inquiry type.",
+        "message_too_short": "At least 10 characters.",
+        "message_too_long": "Maximum 2000 characters.",
+        "generic": "Please check the form fields."
+      }
+    },
+    "success": {
+      "eyebrow": "MESSAGE SENT",
+      "title": "Thanks, {name}.",
+      "body": "We got your message. We'll reply to the email you provided, usually within 2-3 business days.",
+      "backHome": "Back to home",
+      "sendAnother": "Send another message"
+    },
+    "error": {
+      "title": "We couldn't send your message",
+      "body": "There was a connection issue. Please try again in a moment."
+    },
+    "alternatives": {
+      "title": "Other paths",
+      "instagramLabel": "@lahuelladelcaminante on Instagram",
+      "artist": "Are you an artist or organizer? To publish your events, <applyLink>apply here</applyLink>."
+    }
   },
   "status": {
     "pending": "Pending",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -354,8 +354,61 @@
     "community": "Comunidad",
     "apply": "Aplicar",
     "newsletter": "Newsletter",
+    "contact": "Escribinos",
     "impressum": "Impressum",
     "datenschutz": "Datenschutz"
+  },
+  "contact": {
+    "metaTitle": "Contacto",
+    "metaDescription": "Escribinos por sugerencias, prensa, partnerships o lo que necesites.",
+    "eyebrow": "CONTACTO",
+    "title": "Hablanos.",
+    "body": "Leemos todos los mensajes. Solemos responder en 2-3 días hábiles. Si lo tuyo es aplicar como artista, hay un <applyLink>flujo específico</applyLink>.",
+    "form": {
+      "name": "Tu nombre",
+      "namePlaceholder": "¿Cómo te llamás?",
+      "email": "Tu email",
+      "emailPlaceholder": "vos@email.com",
+      "type": "Tipo de consulta",
+      "types": {
+        "eventSuggestion": "Sugerir un evento",
+        "reportIssue": "Reportar un problema",
+        "press": "Prensa o medios",
+        "partnership": "Colaboración o partnership",
+        "other": "Otro"
+      },
+      "message": "Tu mensaje",
+      "messagePlaceholder": "Contanos en qué andás...",
+      "messageHint": "Entre 10 y 2000 caracteres.",
+      "submit": "Enviar mensaje",
+      "submitting": "Enviando...",
+      "errors": {
+        "name_too_short": "Mínimo 2 caracteres.",
+        "name_too_long": "Máximo 120 caracteres.",
+        "email_invalid": "Email inválido.",
+        "email_too_long": "Email demasiado largo.",
+        "type_invalid": "Seleccioná un tipo de consulta.",
+        "message_too_short": "Mínimo 10 caracteres.",
+        "message_too_long": "Máximo 2000 caracteres.",
+        "generic": "Revisá los datos del form."
+      }
+    },
+    "success": {
+      "eyebrow": "MENSAJE ENVIADO",
+      "title": "Gracias, {name}.",
+      "body": "Recibimos tu mensaje. Te respondemos al email que dejaste, normalmente en 2-3 días hábiles.",
+      "backHome": "Volver al inicio",
+      "sendAnother": "Enviar otro mensaje"
+    },
+    "error": {
+      "title": "No pudimos enviar tu mensaje",
+      "body": "Hubo un problema de conexión. Probá de nuevo en un momento."
+    },
+    "alternatives": {
+      "title": "Otros caminos",
+      "instagramLabel": "@lahuelladelcaminante en Instagram",
+      "artist": "¿Sos artista u organizador? Para publicar tus eventos, <applyLink>aplicá acá</applyLink>."
+    }
   },
   "status": {
     "pending": "Pendiente",


### PR DESCRIPTION
## Summary

Nueva página pública `/contact` con form que dispara un email pre-clasificado al founder via Resend. Reemplaza el `mailto:info@lahuelladelcaminante.de` que vivía en el footer y exponía el email a scrapers de spam.

## Pantalla `/contact`

- Layout centrado `max-w-2xl`, header con eyebrow + h1 + body.
- Form con 4 campos: nombre, email, tipo de consulta (dropdown), mensaje.
- Validación con schema zod compartido cliente/servidor (`src/lib/validators/contact.ts`).
- Success state inline (no navega): saluda con el nombre + 2 botones (volver al inicio / enviar otro).
- Bloque "Otros caminos" debajo: link a Instagram + link al flujo `/apply` para artistas.

## Tipos de consulta del dropdown

| Key (estable, va al subject) | Label visible |
|---|---|
| `event_suggestion` | Sugerir un evento |
| `report_issue` | Reportar un problema |
| `press` | Prensa o medios |
| `partnership` | Colaboración o partnership |
| `other` | Otro |

Subject del email: `[Contacto · <typeLabel>] <nombre>` para triage fácil. `replyTo` se setea al email del user para responder directo desde la inbox.

## Sin captcha

Decisión de producto: si llega spam real, lo agregamos. No instalar preventivamente.

## Variable de entorno

**`CONTACT_RECIPIENT_EMAIL`** — nueva. Email destino de los mensajes. Opcional en zod env (fallback a `info@lahuelladelcaminante.de`, mismo destino histórico de `/apply`). **Configurar en producción antes de mergear** si se quiere otro destinatario. Documentada en `.env.local.example`.

> Bonus: el `.env.local.example` ahora está trackeable (`.gitignore` con excepción `!.env.local.example`). Antes existía físicamente pero estaba gitignored — nuevos devs no veían qué env vars necesitan.

## Footer

Columna COMUNIDAD: `mailto:info@lahuelladelcaminante.de` → link interno a `/contact` con string `footer.contact` ("Escribinos" / "Get in touch" / "Schreib uns").

Verificable: `grep -r "info@lahuelladelcaminante" src/` — los hits restantes son docstrings, templates de email outbound y el fallback de la env var. **Ningún string renderizado al user expone el email.**

## Out of scope explícito

- `/apply` queda intacto (es otro tipo de email, otro flujo).
- Sin captcha (ver arriba).
- Sin sistema de "tickets" / persistencia de mensajes en DB.
- Sin lógica de auth/roles (la página es pública).

## Reviewers internos

**`architecture-reviewer`**: 0 ALTO + 3 MEDIO + 5 BAJO.
- ✅ MEDIO: mapeo `ContactType → i18nKey` duplicado entre cliente/server → unificado en `CONTACT_TYPE_I18N_KEY` exportado del validator.
- ✅ MEDIO: errores del server 400 perdían las `issues` → ahora se vuelcan a `fieldErrors` por campo, network/5xx van al toast genérico.
- ✅ MEDIO: HTML del email hardcoded `lang="es"` → recibe `locale` del request.
- ✅ BAJO: `name`/`typeLabel` en el subject del email — sanitizados con `replace(/[\r\n]+/g, " ").trim().slice(0, N)` para defensa-en-profundidad contra header injection.
- ✅ BAJO: `encodeURI` → `encodeURIComponent` en `mailto:`.
- ✅ BAJO: `useErrorMessage` hook redundante → función pura con `KNOWN_ERROR_CODES` Set.
- 🗒️ BAJO: `<select>` nativo con styling duplicado de `<Input>` — esperar segundo uso para extraer primitive.
- 🗒️ BAJO: `<header>` interno dentro de `<main>` — legal HTML5.

**`i18n-reviewer`**: 0 ALTO + 3 MEDIO + 2 BAJO.
- ✅ MEDIO: DE `success.body` repetía "meistens" → "in der Regel" en la segunda.
- ✅ MEDIO: DE `alternatives.title` "Andere Wege uns zu erreichen" parsing ambiguo → "Andere Pfade, uns zu erreichen" (preserva metáfora marca + Komma vor erweitertem Infinitiv).
- ✅ MEDIO: DE `errors.type_invalid` imperativo cortante "Wähl..." → descriptivo "Bitte eine Art der Anfrage wählen." (consistente con resto del set).
- ✅ BAJO: EN `alternatives.title` "Other ways to reach us" → "Other paths" para preservar metáfora "huella/caminos".
- ✅ BAJO: `namePlaceholder` sin `?` en los 3 locales → agregado para cerrar la pregunta.

## Test plan

- [ ] `/es/contact`, `/en/contact`, `/de/contact` renderizan 200 con form completo.
- [ ] Submit con datos válidos → confirmación inline con nombre del user + email enviado vía Resend (verificar en logs Resend si dev tiene `RESEND_API_KEY` seteada).
- [ ] Subject del email recibido: `[Contacto · <labellocalizado>] <nombre>`.
- [ ] Reply-To del email apunta al email del user (responder desde inbox va directo).
- [ ] Submit con email inválido / mensaje corto → error inline por campo, sin POST.
- [ ] Submit tampering payload (curl con `type: "hack"`) → 400 con `issues` JSON, form muestra el error en el campo (no como toast).
- [ ] Submit con red caída → toast de error, datos del form se mantienen.
- [ ] "Enviar otro mensaje" → reset full + vuelve al form inicial.
- [ ] Cambiar idioma desde `/contact` → form y confirmación cambian copy; URL conserva path.
- [ ] Footer ya no muestra el email — muestra "Escribinos" linkeado a `/contact` (verificar las 4 columnas en todas las páginas).
- [ ] `grep -r "info@lahuelladelcaminante" src/` no devuelve resultados visibles para el user.
- [ ] Sin errores en consola.
- [ ] **Producción**: setear `CONTACT_RECIPIENT_EMAIL` en el entorno antes del deploy si se quiere otro destinatario que `info@lahuelladelcaminante.de`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized contact page with client-side form, validation, submission states, honeypot anti-abuse, and success UI.
  * Server-side contact endpoint with origin checks, re-validation, localized handling, and email notifications (Reply‑To preserved).
  * Contact page includes alternative contact options (Instagram) and artist/application links.

* **Chores**
  * Added example environment file and updated ignore rules to include it.
  * Replaced public footer email with an internal contact page link.
  * Added ES/EN/DE translations for the contact flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->