### PR TITLE
feat: redesign auth screens (sign-in, sign-up, application sent, user states)

### DIFF
--- a/docs/design/BACKLOG.md
+++ b/docs/design/BACKLOG.md
@@ -90,6 +90,40 @@ form de contacto).
 - Mismo helper se puede reusar en `/api/applications/submit` y futuros
   endpoints públicos.
 
+### Prisma — index en `Application.email` + enum para `Application.status` — prioridad MEDIA
+
+**Origen:** PR de auth (`feat/redesign-auth-screens`). El review de
+arquitectura detectó deuda inherited que esta PR consolida.
+
+Dos consumidores hoy hacen `Application.findFirst({ where: { email } })`:
+el hook `databaseHooks.user.create.after` en `src/lib/auth.ts` (corre
+en cada signup) y la nueva pantalla `/user-pending` (corre en cada
+visita). El modelo `Application` no tiene `@@index([email])` —
+seq-scan que escala mal cuando crezca la tabla.
+
+Aparte, `Application.status: String` con comentario `// pending | approved
+| rejected` debería ser enum — hoy un typo silencioso en el hook (ej.
+`status: "aproved"`) rompe el flow de activación sin ningún error de TS.
+
+- Migration:
+  ```prisma
+  enum ApplicationStatus {
+    pending
+    approved
+    rejected
+  }
+
+  model Application {
+    ...
+    status ApplicationStatus @default(pending)
+    @@index([email])
+  }
+  ```
+- Actualizar callers: `src/lib/auth.ts:34` y `src/app/[locale]/user-pending/page.tsx`.
+- Bonus: agregar FK opcional `Application.userId` para que el matching
+  no dependa de email (problema: user puede cambiar email después de
+  aplicar).
+
 ### Security headers globales en `next.config.ts` — prioridad MEDIA
 
 **Origen:** PR 8.5 (`/contact`) y aplicable al sitio entero.

--- a/src/app/[locale]/(auth)/layout.tsx
+++ b/src/app/[locale]/(auth)/layout.tsx
@@ -1,7 +1,35 @@
+/**
+ * Layout austero del grupo `(auth)`. Cubre las páginas `/sign-in` y
+ * `/sign-up` (y a futuro `/forgot-password` cuando se implemente).
+ *
+ * No renderiza Header/Footer globales — auth es un flow enfocado y los
+ * elementos de navegación general distraen. En lugar de eso, un mini
+ * header de 64px de alto con:
+ *  - `BrandLockup` a la izquierda (linkeado a `/` para que el user pueda
+ *    salir del flow sin perderse).
+ *  - `LanguageSwitcher` a la derecha (lección del spec de QA — cambio
+ *    de idioma debe estar disponible en cada auth screen).
+ *
+ * Las páginas hijas consumen `AuthShell` para armar la grilla 7:5 interna.
+ * El `AuthShell` calcula su `min-h` restando los 64px del mini header
+ * (`var(--auth-header-h)` con fallback `4rem`).
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §1.1, §3.2 ("Decisión del
+ * dev" — optamos por layout dedicado en vez de variant del Header global,
+ * para no agregar surface al componente Header crítico).
+ */
+
+import BrandLockup from "@/components/brand/BrandLockup"
+import LanguageSwitcher from "@/components/layout/LanguageSwitcher"
+
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-muted/30 px-4">
-      {children}
+    <div className="min-h-screen bg-bg-page" style={{ "--auth-header-h": "4rem" } as React.CSSProperties}>
+      <header className="flex h-16 items-center justify-between px-l">
+        <BrandLockup orientation="horizontal" href="/" />
+        <LanguageSwitcher />
+      </header>
+      <main>{children}</main>
     </div>
   )
 }

--- a/src/app/[locale]/(auth)/layout.tsx
+++ b/src/app/[locale]/(auth)/layout.tsx
@@ -4,15 +4,16 @@
  *
  * No renderiza Header/Footer globales — auth es un flow enfocado y los
  * elementos de navegación general distraen. En lugar de eso, un mini
- * header de 64px de alto con:
+ * header de 64px (`h-16`) con:
  *  - `BrandLockup` a la izquierda (linkeado a `/` para que el user pueda
  *    salir del flow sin perderse).
  *  - `LanguageSwitcher` a la derecha (lección del spec de QA — cambio
  *    de idioma debe estar disponible en cada auth screen).
  *
  * Las páginas hijas consumen `AuthShell` para armar la grilla 7:5 interna.
- * El `AuthShell` calcula su `min-h` restando los 64px del mini header
- * (`var(--auth-header-h)` con fallback `4rem`).
+ * `AuthShell` resta los 64px del header del `min-h` via `calc(100vh - 4rem)`
+ * — la altura está cementada en los dos lugares: si cambia acá, actualizar
+ * también en `AuthShell.tsx`.
  *
  * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §1.1, §3.2 ("Decisión del
  * dev" — optamos por layout dedicado en vez de variant del Header global,
@@ -24,7 +25,7 @@ import LanguageSwitcher from "@/components/layout/LanguageSwitcher"
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-bg-page" style={{ "--auth-header-h": "4rem" } as React.CSSProperties}>
+    <div className="min-h-screen bg-bg-page">
       <header className="flex h-16 items-center justify-between px-l">
         <BrandLockup orientation="horizontal" href="/" />
         <LanguageSwitcher />

--- a/src/app/[locale]/(auth)/sign-in/page.tsx
+++ b/src/app/[locale]/(auth)/sign-in/page.tsx
@@ -1,94 +1,137 @@
-"use client"
+/**
+ * `/[locale]/sign-in` — pantalla de inicio de sesión rediseñada.
+ *
+ * Server component que arma el `AuthShell` 7:5 con:
+ *  - Columna izquierda (col-span-7): heading + `<SignInForm>` (client) +
+ *    footer rich-text con links a sign-up y apply.
+ *  - Columna derecha (col-span-5, hidden en mobile): manifiesto editorial
+ *    + 3 thumbnails 1:1 de eventos destacados + stats strip.
+ *
+ * Las dos queries de datos del panel (`getFeaturedEvents(3)` y
+ * `getUpcomingStats()`) se disparan en paralelo. Ambas están cacheadas
+ * con `unstable_cache` (5 min) — no añaden carga relevante a esta ruta
+ * caliente.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §1.1.
+ */
 
-import { useTranslations } from "next-intl"
-import { useParams, useRouter } from "next/navigation"
-import { signIn } from "@/lib/auth-client"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import Link from "next/link"
-import { toast } from "sonner"
+import { getTranslations, setRequestLocale } from "next-intl/server"
+import { Link } from "@/i18n/navigation"
+import AuthShell from "@/components/auth/AuthShell"
+import SignInForm from "@/components/auth/SignInForm"
+import Eyebrow from "@/components/ui/Eyebrow"
+import FlyerImage from "@/components/ui/FlyerImage"
+import { getFeaturedEvents, getUpcomingStats } from "@/services/events"
 
-const schema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-})
-type FormData = z.infer<typeof schema>
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "auth.signIn" })
+  return { title: t("metaTitle") }
+}
 
-export default function SignInPage() {
-  const t = useTranslations("auth")
-  const tCommon = useTranslations("common")
-  const router = useRouter()
-  const { locale } = useParams<{ locale: string }>()
+export default async function SignInPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale)
 
-  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
-    resolver: zodResolver(schema),
-  })
+  const t = await getTranslations({ locale, namespace: "auth.signIn" })
+  const tHero = await getTranslations({ locale, namespace: "auth.signIn.hero" })
 
-  async function onSubmit(data: FormData) {
-    const res = await signIn.email({
-      email: data.email,
-      password: data.password,
-    })
-
-    if (res.error) {
-      toast.error(res.error.message ?? tCommon("error"))
-      return
-    }
-
-    router.push(`/${locale}/dashboard`)
-  }
+  // Disparar las dos queries en paralelo — son independientes y ambas
+  // cacheadas. Si una falla, igual queremos renderizar la otra (el form
+  // izquierdo no depende de los datos del hero, sería peor degradar el
+  // sign-in entero por una query de eventos).
+  const [events, stats] = await Promise.all([
+    getFeaturedEvents(3).catch(() => []),
+    getUpcomingStats().catch(() => null),
+  ])
 
   return (
-    <Card className="w-full max-w-sm">
-      <CardHeader>
-        <CardTitle>{t("signIn")}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-1">
-            <Label htmlFor="email">{t("email")}</Label>
-            <Input id="email" type="email" {...register("email")} />
-            {errors.email && <p className="text-xs text-destructive">{errors.email.message}</p>}
-          </div>
-
-          <div className="space-y-1">
-            <Label htmlFor="password">{t("password")}</Label>
-            <Input id="password" type="password" {...register("password")} />
-            {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
-          </div>
-
-          <Button type="submit" className="w-full" disabled={isSubmitting}>
-            {isSubmitting ? tCommon("loading") : t("signIn")}
-          </Button>
-
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full"
-            onClick={() => signIn.social({ provider: "google", callbackURL: `/${locale}/dashboard` })}
-          >
-            {t("continueWithGoogle")}
-          </Button>
-
-          <p className="text-center text-sm text-muted-foreground">
-            {t("noAccount")}{" "}
-            <Link href={`/${locale}/sign-up`} className="underline">
-              {t("signUp")}
-            </Link>
+    <AuthShell
+      hero={
+        <div className="flex flex-col gap-l">
+          <Eyebrow accent="brand" as="p">
+            {tHero("eyebrow")}
+          </Eyebrow>
+          <h2 className="text-display-m font-display leading-tight text-fg-primary">
+            {tHero.rich("title", {
+              accent: (chunks) => (
+                <span className="text-editorial italic">{chunks}</span>
+              ),
+            })}
+          </h2>
+          <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+            {tHero("body")}
           </p>
 
-          <div className="text-center">
-            <Link href={`/${locale}`} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-              ← {t("backHome")}
-            </Link>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+          {events.length > 0 ? (
+            <div className="mt-l grid grid-cols-3 gap-s">
+              {events.map((ev) => (
+                <FlyerImage
+                  key={ev.id}
+                  publicId={ev.coverImagePublicId ?? undefined}
+                  src={ev.coverImage ?? undefined}
+                  alt={ev.coverImageAlt ?? ev.title}
+                  aspectRatio="1:1"
+                  fallbackAccent="brand"
+                  className="rounded-m"
+                />
+              ))}
+            </div>
+          ) : null}
+
+          {stats ? (
+            <p className="mt-s font-mono text-eyebrow uppercase text-fg-tertiary">
+              {tHero("statsFormat", {
+                shows: stats.shows,
+                cities: stats.cities,
+              })}
+            </p>
+          ) : null}
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-l">
+        <Eyebrow accent="brand" as="p">
+          {t("eyebrow")}
+        </Eyebrow>
+        <h1 className="text-display-l font-display leading-tight text-fg-primary">
+          {t("title")}
+        </h1>
+        <p className="text-body leading-relaxed text-fg-secondary">
+          {t("subtitle")}
+        </p>
+
+        <SignInForm locale={locale} />
+
+        <p className="text-body-s text-fg-secondary">
+          {t.rich("footer", {
+            createAccount: (chunks) => (
+              <Link
+                href="/sign-up"
+                className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+              >
+                {chunks}
+              </Link>
+            ),
+            applyAsArtist: (chunks) => (
+              <Link
+                href="/apply"
+                className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+              >
+                {chunks}
+              </Link>
+            ),
+          })}
+        </p>
+      </div>
+    </AuthShell>
   )
 }

--- a/src/app/[locale]/(auth)/sign-in/page.tsx
+++ b/src/app/[locale]/(auth)/sign-in/page.tsx
@@ -55,6 +55,8 @@ export default async function SignInPage({
 
   return (
     <AuthShell
+      formAriaLabel={t("formAriaLabel")}
+      heroAriaLabel={t("heroAriaLabel")}
       hero={
         <div className="flex flex-col gap-l">
           <Eyebrow accent="brand" as="p">

--- a/src/app/[locale]/(auth)/sign-up/page.tsx
+++ b/src/app/[locale]/(auth)/sign-up/page.tsx
@@ -1,93 +1,140 @@
-"use client"
+/**
+ * `/[locale]/sign-up` — pantalla de crear cuenta rediseñada.
+ *
+ * Server component que arma el `AuthShell` 7:5 con:
+ *  - Columna izquierda (col-span-7): heading + `<SignUpForm>` (client) +
+ *    footer con link a sign-in.
+ *  - Columna derecha (col-span-5, hidden en mobile): 3 step cards del
+ *    journey (creás cuenta → aplicás → publicás) con tiempos + bloque
+ *    de soporte con link a `/contact`.
+ *
+ * Sin datos dinámicos en esta pantalla (a diferencia de /sign-in que
+ * fetcha eventos destacados) — el hero es puro contenido editorial.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §1.2.
+ */
 
-import { useTranslations } from "next-intl"
-import { useParams, useRouter } from "next/navigation"
-import { signUp } from "@/lib/auth-client"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import Link from "next/link"
-import { toast } from "sonner"
+import { getTranslations, setRequestLocale } from "next-intl/server"
+import { Link } from "@/i18n/navigation"
+import AuthShell from "@/components/auth/AuthShell"
+import SignUpForm from "@/components/auth/SignUpForm"
+import Eyebrow from "@/components/ui/Eyebrow"
 
-const schema = z.object({
-  name: z.string().min(2),
-  email: z.string().email(),
-  password: z.string().min(8),
-})
-type FormData = z.infer<typeof schema>
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "auth.signUp" })
+  return { title: t("metaTitle") }
+}
 
-export default function SignUpPage() {
-  const t = useTranslations("auth")
-  const tCommon = useTranslations("common")
-  const router = useRouter()
-  const { locale } = useParams<{ locale: string }>()
+/** Step cards de la columna hero. Los textos vienen de i18n; este array
+ * solo define la estructura visual (número + key del título + key del
+ * timing). Mantener acá (no en el JSON) para que la cantidad de pasos
+ * sea decisión de código, no de traducción. */
+const STEPS = [
+  { number: "01", titleKey: "step1Title", timeKey: "step1Time" },
+  { number: "02", titleKey: "step2Title", timeKey: "step2Time" },
+  { number: "03", titleKey: "step3Title", timeKey: "step3Time" },
+] as const
 
-  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({
-    resolver: zodResolver(schema),
-  })
+export default async function SignUpPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  setRequestLocale(locale)
 
-  async function onSubmit(data: FormData) {
-    const res = await signUp.email({
-      name: data.name,
-      email: data.email,
-      password: data.password,
-    })
-
-    if (res.error) {
-      toast.error(res.error.message ?? tCommon("error"))
-      return
-    }
-
-    router.push(`/${locale}`)
-  }
+  const t = await getTranslations({ locale, namespace: "auth.signUp" })
+  const tHero = await getTranslations({ locale, namespace: "auth.signUp.hero" })
 
   return (
-    <Card className="w-full max-w-sm">
-      <CardHeader>
-        <CardTitle>{t("signUp")}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-1">
-            <Label htmlFor="name">{t("name")}</Label>
-            <Input id="name" type="text" {...register("name")} />
-            {errors.name && <p className="text-xs text-destructive">{errors.name.message}</p>}
-          </div>
+    <AuthShell
+      hero={
+        <div className="flex flex-col gap-l">
+          <Eyebrow accent="brand" as="p">
+            {tHero("eyebrow")}
+          </Eyebrow>
+          <h2 className="text-display-m font-display leading-tight text-fg-primary">
+            {tHero.rich("title", {
+              accent: (chunks) => (
+                <span className="text-editorial italic">{chunks}</span>
+              ),
+            })}
+          </h2>
 
-          <div className="space-y-1">
-            <Label htmlFor="email">{t("email")}</Label>
-            <Input id="email" type="email" {...register("email")} />
-            {errors.email && <p className="text-xs text-destructive">{errors.email.message}</p>}
-          </div>
+          <ol className="mt-l flex flex-col gap-m">
+            {STEPS.map((step) => (
+              <li
+                key={step.number}
+                className="flex items-start gap-m rounded-l border border-border bg-bg-surface-2 p-l"
+              >
+                <span
+                  aria-hidden={true}
+                  className="font-mono text-eyebrow text-editorial leading-none pt-[2px]"
+                >
+                  {step.number}
+                </span>
+                <div className="flex flex-col gap-xs">
+                  <p className="text-body font-semibold text-fg-primary leading-snug">
+                    {tHero(step.titleKey)}
+                  </p>
+                  <p className="text-caption text-fg-tertiary">
+                    {tHero(step.timeKey)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
 
-          <div className="space-y-1">
-            <Label htmlFor="password">{t("password")}</Label>
-            <Input id="password" type="password" {...register("password")} />
-            {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
-          </div>
-
-          <Button type="submit" className="w-full" disabled={isSubmitting}>
-            {isSubmitting ? tCommon("loading") : t("signUp")}
-          </Button>
-
-          <p className="text-center text-sm text-muted-foreground">
-            {t("haveAccount")}{" "}
-            <Link href={`/${locale}/sign-in`} className="underline">
-              {t("signIn")}
-            </Link>
+          <p className="mt-l text-body-s leading-relaxed text-fg-secondary">
+            {tHero.rich("support", {
+              contactLink: (chunks) => (
+                <Link
+                  href="/contact"
+                  className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
           </p>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-l">
+        <Eyebrow accent="brand" as="p">
+          {t("eyebrow")}
+        </Eyebrow>
+        <h1 className="text-display-l font-display leading-tight text-fg-primary">
+          {t.rich("title", {
+            accent: (chunks) => (
+              <span className="text-brand italic">{chunks}</span>
+            ),
+          })}
+        </h1>
+        <p className="text-body leading-relaxed text-fg-secondary">
+          {t("subtitle")}
+        </p>
 
-          <div className="text-center">
-            <Link href={`/${locale}`} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-              ← {t("backHome")}
-            </Link>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+        <SignUpForm locale={locale} />
+
+        <p className="text-body-s text-fg-secondary">
+          {t.rich("footer", {
+            signInLink: (chunks) => (
+              <Link
+                href="/sign-in"
+                className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+              >
+                {chunks}
+              </Link>
+            ),
+          })}
+        </p>
+      </div>
+    </AuthShell>
   )
 }

--- a/src/app/[locale]/(auth)/sign-up/page.tsx
+++ b/src/app/[locale]/(auth)/sign-up/page.tsx
@@ -53,6 +53,8 @@ export default async function SignUpPage({
 
   return (
     <AuthShell
+      formAriaLabel={t("formAriaLabel")}
+      heroAriaLabel={t("heroAriaLabel")}
       hero={
         <div className="flex flex-col gap-l">
           <Eyebrow accent="brand" as="p">

--- a/src/app/[locale]/(protected)/dashboard/artists/[id]/edit/page.tsx
+++ b/src/app/[locale]/(protected)/dashboard/artists/[id]/edit/page.tsx
@@ -22,13 +22,21 @@ export default async function EditArtistPage({
   })
   if (!artistData) notFound()
 
+  // `coverImage*` se deriva del primer Image relacionado. `ArtistDetail`
+  // (en `src/services/artists.ts`) requiere los 3 campos — derivamos
+  // los tres del mismo origen para mantener consistencia con cómo lo
+  // arma el service oficial. Sin esto, TS falla por shape incompleto
+  // (regresión inherited de PR 8).
+  const firstImage = artistData.images[0]
   const artist = {
     id: artistData.id,
     name: artistData.name,
     slug: artistData.slug,
     origin: artistData.origin,
     genres: artistData.genres,
-    coverImage: artistData.images[0]?.url ?? null,
+    coverImage: firstImage?.url ?? null,
+    coverImagePublicId: firstImage?.publicId ?? null,
+    coverImageAlt: firstImage?.alt ?? null,
     bio: artistData.bio,
     socialMedia: artistData.socialMedia,
     images: artistData.images,

--- a/src/app/[locale]/user-blocked/page.tsx
+++ b/src/app/[locale]/user-blocked/page.tsx
@@ -1,7 +1,47 @@
-import { getTranslations } from "next-intl/server"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+/**
+ * `/[locale]/user-blocked` — pantalla mostrada cuando un user logueado
+ * tiene `UserProfile.status === "BLOCKED"`. Disparada por `requireActive`
+ * (`src/services/auth.ts`) que redirige acá antes de servir cualquier
+ * ruta protegida.
+ *
+ * Rediseño del handoff v2 §1.5. Estado terminal — el copy es directo
+ * pero no agresivo: explica el bloqueo + lista qué SIGUE funcionando
+ * para que el user no asuma "perdí todo el sitio". Decisión cerrada de
+ * producto: distinguir "bloqueado del panel creator" de "bloqueado del
+ * sitio entero" reduce frustración y mantiene al user en lo público.
+ *
+ * Guard: si no hay session, redirect a `/sign-in` (mismo patrón que
+ * /user-pending — la URL no debería mostrar contenido a anónimos).
+ *
+ * CTA primario "Escribirnos →" linkea a `/contact` (existe en main
+ * desde PR #20) — es la única acción que el user puede tomar para
+ * resolver el bloqueo.
+ */
+
+import { getTranslations, setRequestLocale } from "next-intl/server"
+import { redirect } from "next/navigation"
+import { getCurrentUser } from "@/services/auth"
+import { Link } from "@/i18n/navigation"
+import BrandLockup from "@/components/brand/BrandLockup"
+import StatusHero from "@/components/auth/StatusHero"
+import SignOutButton from "@/components/auth/SignOutButton"
+import Eyebrow from "@/components/ui/Eyebrow"
 import { Button } from "@/components/ui/button"
-import Link from "next/link"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "account.blocked" })
+  return { title: t("metaTitle") }
+}
+
+/** Items de "qué sigue funcionando". Keys i18n nombradas (no array)
+ * para que next-intl pueda type-checar cada string individualmente.
+ * Si se agrega/quita un item, actualizar acá Y en los 3 messages.* . */
+const STILL_WORKS_KEYS = ["canSee", "canBrowse", "cannot"] as const
 
 export default async function UserBlockedPage({
   params,
@@ -9,21 +49,70 @@ export default async function UserBlockedPage({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params
-  const t = await getTranslations({ locale, namespace: "auth" })
+  setRequestLocale(locale)
+
+  const user = await getCurrentUser()
+  if (!user) {
+    redirect(`/${locale}/sign-in`)
+  }
+
+  const t = await getTranslations({ locale, namespace: "account.blocked" })
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <Card className="max-w-md w-full text-center border-destructive">
-        <CardHeader>
-          <CardTitle className="text-destructive">{t("blockedTitle")}</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-muted-foreground">{t("blockedDescription")}</p>
-          <Button variant="outline" asChild>
-            <Link href={`/${locale}`}>Volver al inicio</Link>
+    <div className="min-h-screen bg-bg-page">
+      <header className="flex h-16 items-center px-l">
+        <BrandLockup orientation="horizontal" href="/" />
+      </header>
+
+      <main className="mx-auto flex max-w-[560px] flex-col items-center gap-l px-l py-2xl text-center">
+        <StatusHero variant="blocked" />
+
+        <Eyebrow accent="brand" as="p">
+          {t("eyebrow")}
+        </Eyebrow>
+
+        <h1 className="text-display-m font-display leading-tight text-fg-primary">
+          {t("title")}
+        </h1>
+
+        <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+          {t("body")}
+        </p>
+
+        <div className="mt-s flex flex-wrap items-center justify-center gap-s">
+          <Button
+            asChild
+            className="h-11 bg-brand text-on-brand font-semibold hover:bg-brand-dim"
+          >
+            <Link href="/contact">{t("ctaContact")}</Link>
           </Button>
-        </CardContent>
-      </Card>
+          <SignOutButton label={t("ctaLogout")} className="h-11" />
+        </div>
+
+        {/* Bloque "qué sigue funcionando" — surface elevada, alineado
+            izquierda para que la lista se lea como tal. Es lo que
+            distingue "bloqueado del panel" de "bloqueado del sitio
+            entero" (handoff §1.5). */}
+        <div className="mt-xl w-full rounded-l border border-border bg-bg-surface p-l text-left">
+          <p className="font-mono text-eyebrow uppercase text-fg-secondary">
+            {t("stillWorksTitle")}
+          </p>
+          <ul className="mt-m flex flex-col gap-s">
+            {STILL_WORKS_KEYS.map((key) => (
+              <li
+                key={key}
+                className="flex items-start gap-s text-body-s leading-relaxed text-fg-secondary"
+              >
+                <span
+                  aria-hidden={true}
+                  className="mt-[8px] inline-block h-1 w-1 shrink-0 rounded-full bg-fg-tertiary"
+                />
+                <span>{t(key)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
     </div>
   )
 }

--- a/src/app/[locale]/user-blocked/page.tsx
+++ b/src/app/[locale]/user-blocked/page.tsx
@@ -57,6 +57,7 @@ export default async function UserBlockedPage({
   }
 
   const t = await getTranslations({ locale, namespace: "account.blocked" })
+  const tAccount = await getTranslations({ locale, namespace: "account" })
 
   return (
     <div className="min-h-screen bg-bg-page">
@@ -86,7 +87,11 @@ export default async function UserBlockedPage({
           >
             <Link href="/contact">{t("ctaContact")}</Link>
           </Button>
-          <SignOutButton label={t("ctaLogout")} className="h-11" />
+          <SignOutButton
+            label={t("ctaLogout")}
+            errorLabel={tAccount("signOutError")}
+            className="h-11"
+          />
         </div>
 
         {/* Bloque "qué sigue funcionando" — surface elevada, alineado

--- a/src/app/[locale]/user-pending/page.tsx
+++ b/src/app/[locale]/user-pending/page.tsx
@@ -1,7 +1,61 @@
-import { getTranslations } from "next-intl/server"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+/**
+ * `/[locale]/user-pending` — pantalla mostrada cuando un user logueado
+ * tiene `UserProfile.status === "PENDING"`. Disparada por `requireActive`
+ * (en `src/services/auth.ts`) que redirige acá antes de servir cualquier
+ * ruta protegida.
+ *
+ * Rediseño del handoff v2 §1.4 con peso editorial: bombilla glow +
+ * eyebrow dorado + h1 cálido + fecha de aplicación visible + escape
+ * hatch si pasaron más de 3 días.
+ *
+ * NOTA SOBRE EL FLUJO QUE DISPARA PENDING (handoff blocker 1):
+ * El hook `databaseHooks.user.create.after` en `src/lib/auth.ts` hoy
+ * siempre escribe `status: ACTIVE` (tanto si hay Application aprobada
+ * como si no). En la práctica esta pantalla solo se renderiza si un
+ * admin pone status PENDING manualmente en DB. Arreglar ese hook es
+ * out of scope de esta PR (toca lógica de Better Auth — fuera del
+ * scope explícito). Esta pantalla está lista para cuando ese arreglo
+ * se haga en otro PR.
+ *
+ * Application matching: `Application` no tiene FK con `User`. Se
+ * matchea por email (mismo pattern que el hook). Si no hay match
+ * (caso: status PENDING por vía admin sin Application previa), el copy
+ * degrada a una variante sin fecha (`bodyNoDate`).
+ *
+ * Guard de seguridad: si no hay session, redirect a `/sign-in` (no
+ * tener este guard antes era una regresión menor — la URL es accesible
+ * sin auth y mostraba el cardo viejo a anónimos).
+ */
+
+import { getTranslations, setRequestLocale } from "next-intl/server"
+import { redirect } from "next/navigation"
+import { getCurrentUser } from "@/services/auth"
+import { prisma } from "@/lib/prisma"
+import { Link } from "@/i18n/navigation"
+import BrandLockup from "@/components/brand/BrandLockup"
+import StatusHero from "@/components/auth/StatusHero"
+import SignOutButton from "@/components/auth/SignOutButton"
+import Eyebrow from "@/components/ui/Eyebrow"
 import { Button } from "@/components/ui/button"
-import Link from "next/link"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "account.pending" })
+  return { title: t("metaTitle") }
+}
+
+/** Formato amigable de fecha. ES: `15 de mayo` · EN: `May 15` ·
+ * DE: `15. Mai`. Sin año — el copy ya implica "hace poco" (1-2 días). */
+function formatApplicationDate(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+  }).format(date)
+}
 
 export default async function UserPendingPage({
   params,
@@ -9,21 +63,93 @@ export default async function UserPendingPage({
   params: Promise<{ locale: string }>
 }) {
   const { locale } = await params
-  const t = await getTranslations({ locale, namespace: "auth" })
+  setRequestLocale(locale)
+
+  // Guard de auth — si llega un anónimo, mandarlo a sign-in en lugar
+  // de mostrar la pantalla "tu cuenta está en revisión" (que sería
+  // confuso para alguien que no tiene cuenta).
+  const user = await getCurrentUser()
+  if (!user) {
+    redirect(`/${locale}/sign-in`)
+  }
+
+  const t = await getTranslations({ locale, namespace: "account.pending" })
+
+  // Application por email. Devolver la más reciente — un user podría
+  // haber aplicado más de una vez con el mismo email.
+  const application = await prisma.application.findFirst({
+    where: { email: user.email },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+  })
+
+  const formattedDate = application
+    ? formatApplicationDate(application.createdAt, locale)
+    : null
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <Card className="max-w-md w-full text-center">
-        <CardHeader>
-          <CardTitle>{t("pendingTitle")}</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-muted-foreground">{t("pendingDescription")}</p>
-          <Button variant="outline" asChild>
-            <Link href={`/${locale}`}>Volver al inicio</Link>
+    <div className="min-h-screen bg-bg-page">
+      {/* Mini header austero — solo BrandLockup, sin Header global ni
+          LanguageSwitcher. Las pantallas de estado de cuenta son
+          terminales: el user no debería navegar nada acá excepto
+          cerrar sesión o volver a la agenda pública. */}
+      <header className="flex h-16 items-center px-l">
+        <BrandLockup orientation="horizontal" href="/" />
+      </header>
+
+      <main className="mx-auto flex max-w-[560px] flex-col items-center gap-l px-l py-2xl text-center">
+        <StatusHero variant="pending" />
+
+        <Eyebrow accent="editorial" as="p">
+          {t("eyebrow")}
+        </Eyebrow>
+
+        <h1 className="text-display-m font-display leading-tight text-fg-primary">
+          {t.rich("title", {
+            accent: (chunks) => (
+              <span className="text-editorial italic">{chunks}</span>
+            ),
+          })}
+        </h1>
+
+        <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+          {formattedDate
+            ? t.rich("bodyWithDate", {
+                date: formattedDate,
+                strong: (chunks) => (
+                  <strong className="font-semibold text-fg-primary">
+                    {chunks}
+                  </strong>
+                ),
+              })
+            : t("bodyNoDate")}
+        </p>
+
+        <div className="mt-s flex flex-wrap items-center justify-center gap-s">
+          <Button
+            asChild
+            className="h-11 bg-brand text-on-brand font-semibold hover:bg-brand-dim"
+          >
+            <Link href="/events">{t("ctaPrimary")}</Link>
           </Button>
-        </CardContent>
-      </Card>
+          <SignOutButton label={t("ctaSecondary")} className="h-11" />
+        </div>
+
+        <div className="mt-xl w-full rounded-l border border-border bg-bg-surface p-l text-left">
+          <p className="text-body-s leading-relaxed text-fg-secondary">
+            {t.rich("escapeHatch", {
+              contactLink: (chunks) => (
+                <Link
+                  href="/contact"
+                  className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </p>
+        </div>
+      </main>
     </div>
   )
 }

--- a/src/app/[locale]/user-pending/page.tsx
+++ b/src/app/[locale]/user-pending/page.tsx
@@ -74,6 +74,7 @@ export default async function UserPendingPage({
   }
 
   const t = await getTranslations({ locale, namespace: "account.pending" })
+  const tAccount = await getTranslations({ locale, namespace: "account" })
 
   // Application por email. Devolver la más reciente — un user podría
   // haber aplicado más de una vez con el mismo email.
@@ -132,7 +133,11 @@ export default async function UserPendingPage({
           >
             <Link href="/events">{t("ctaPrimary")}</Link>
           </Button>
-          <SignOutButton label={t("ctaSecondary")} className="h-11" />
+          <SignOutButton
+            label={t("ctaSecondary")}
+            errorLabel={tAccount("signOutError")}
+            className="h-11"
+          />
         </div>
 
         <div className="mt-xl w-full rounded-l border border-border bg-bg-surface p-l text-left">

--- a/src/components/apply/ApplyForm.tsx
+++ b/src/components/apply/ApplyForm.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
-import { CheckCircle2 } from "lucide-react"
+import ApplySubmittedScreen from "./ApplySubmittedScreen"
 
 export function ApplyForm() {
   const t = useTranslations("apply")
@@ -16,7 +16,12 @@ export function ApplyForm() {
   const [email, setEmail] = useState("")
   const [message, setMessage] = useState("")
   const [loading, setLoading] = useState(false)
-  const [sent, setSent] = useState(false)
+  // `submittedAt` reemplaza al booleano `sent` previo: además de servir
+  // como flag de "ya se envió" (truthy / falsy), guarda el instante
+  // exacto del submit para mostrarlo en el primer paso del timeline
+  // del rediseño (`ApplySubmittedScreen`). El handoff v2 §1.3 pide ese
+  // timestamp explícito en el paso "Recibida".
+  const [submittedAt, setSubmittedAt] = useState<Date | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   async function handleSubmit(e: React.FormEvent) {
@@ -33,7 +38,9 @@ export function ApplyForm() {
         const data = await res.json()
         throw new Error(data.error ?? "Error")
       }
-      setSent(true)
+      // `new Date()` acá (no en el render condicional) para que el
+      // timestamp se congele al momento del éxito, no en cada rerender.
+      setSubmittedAt(new Date())
     } catch {
       setError(tCommon("error"))
     } finally {
@@ -41,16 +48,8 @@ export function ApplyForm() {
     }
   }
 
-  if (sent) {
-    return (
-      <div className="flex flex-col items-center gap-5 py-12 text-center">
-        <div className="w-16 h-16 rounded-full bg-primary/15 flex items-center justify-center">
-          <CheckCircle2 className="w-8 h-8 text-primary" />
-        </div>
-        <h3 className="text-2xl font-black">{t("successTitle")}</h3>
-        <p className="text-muted-foreground max-w-sm leading-relaxed">{t("successBody")}</p>
-      </div>
-    )
+  if (submittedAt) {
+    return <ApplySubmittedScreen submittedAt={submittedAt} />
   }
 
   return (

--- a/src/components/apply/ApplySubmittedScreen.tsx
+++ b/src/components/apply/ApplySubmittedScreen.tsx
@@ -1,0 +1,164 @@
+/**
+ * ApplySubmittedScreen — pantalla "Solicitud enviada" del `/apply` flow.
+ *
+ * El handoff v2 §1.3 trata este touchpoint como el **último del journey
+ * de aplicación** y le da peso editorial: no es un "check verde +
+ * botón", es la confirmación cálida + roadmap de qué sigue.
+ *
+ * Layout:
+ *  - Desktop: split 1:1 (hero izq, timeline der).
+ *  - Mobile: stack vertical (hero → timeline → CTAs → footnote).
+ *
+ * Renderizado por `ApplyForm` cuando `sent === true` — vive dentro de
+ * `/apply` page, no es ruta separada. Esto preserva el state del form
+ * sin query params ni cookies y mantiene el routing intacto.
+ *
+ * El timestamp del "Recibida" viene del prop `submittedAt` (pasado por
+ * el caller con `new Date()` al momento del submit). Se formatea según
+ * el locale del request.
+ *
+ * Client component porque (a) usa `useTranslations` / `useLocale` para
+ * resolver el copy + formato de fecha según locale activo, y (b) es
+ * renderizado desde `ApplyForm` que es client (no cruza boundary).
+ * Si en el futuro hay que renderizar este screen desde server, mover
+ * el formato + i18n al caller server y pasar los strings ya resueltos.
+ *
+ * IMPORTANTE: el copy de "En revisión" dice "Un humano mira tu perfil",
+ * **NO menciona nombres de admins**. Decisión cerrada del handoff §1.3
+ * y §6.6 — el copy debe sobrevivir cambios de equipo y reducir presión
+ * personalizada.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §1.3.
+ */
+
+"use client"
+
+import { useTranslations, useLocale } from "next-intl"
+import { Link } from "@/i18n/navigation"
+import { Button } from "@/components/ui/button"
+import Eyebrow from "@/components/ui/Eyebrow"
+import StepTimeline, {
+  type TimelineStep,
+} from "@/components/auth/StepTimeline"
+
+export interface ApplySubmittedScreenProps {
+  /** Momento del submit del form. Se formatea para mostrarse en el
+   * primer paso del timeline ("Recibida"). */
+  submittedAt: Date
+}
+
+/** Formatea una fecha en el locale dado, formato corto día-mes + hora.
+ * Ej. ES `15 may · 14:32` / EN `May 15 · 2:32 PM` / DE `15. Mai · 14:32`.
+ * El separador `·` se inserta acá porque `Intl.DateTimeFormat` no lo
+ * soporta nativamente — alternativa sería dos `format` calls + join. */
+function formatSubmittedAt(date: Date, locale: string): string {
+  const day = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+  }).format(date)
+  const time = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date)
+  return `${day} · ${time}`
+}
+
+export default function ApplySubmittedScreen({
+  submittedAt,
+}: ApplySubmittedScreenProps) {
+  const t = useTranslations("apply.submitted")
+  const tTimeline = useTranslations("apply.submitted.timeline")
+  const locale = useLocale()
+
+  const formattedDate = formatSubmittedAt(submittedAt, locale)
+
+  // Los 4 estados del timeline. El primero es done (acaba de pasar),
+  // el segundo es active (en revisión ahora), los otros dos todo.
+  // El copy del paso "reviewing" usa **"Un humano mira tu perfil"** —
+  // no menciona nombres de admins (decisión cerrada del handoff §6.6).
+  const steps: TimelineStep[] = [
+    {
+      state: "done",
+      label: tTimeline("received"),
+      sublabel: tTimeline("receivedSub"),
+      when: formattedDate,
+    },
+    {
+      state: "active",
+      label: tTimeline("reviewing"),
+      sublabel: tTimeline("reviewingSub"),
+      when: tTimeline("reviewingWhen"),
+    },
+    {
+      state: "todo",
+      label: tTimeline("approval"),
+      sublabel: tTimeline("approvalSub"),
+      when: tTimeline("approvalWhen"),
+    },
+    {
+      state: "todo",
+      label: tTimeline("publishing"),
+      sublabel: tTimeline("publishingSub"),
+      when: tTimeline("publishingWhen"),
+    },
+  ]
+
+  return (
+    <section
+      aria-labelledby="apply-submitted-heading"
+      className="grid grid-cols-1 gap-2xl lg:grid-cols-2 lg:gap-3xl"
+    >
+      {/* Hero izquierdo — eyebrow + título afectivo + body + CTAs. */}
+      <div className="flex flex-col gap-l">
+        <Eyebrow accent="editorial" as="p">
+          {t("badge")}
+        </Eyebrow>
+        <h1
+          id="apply-submitted-heading"
+          className="text-display-l font-display leading-tight text-fg-primary"
+        >
+          {t.rich("title", {
+            accent: (chunks) => (
+              <span className="text-brand italic">{chunks}</span>
+            ),
+          })}
+        </h1>
+        <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+          {t("body")}
+        </p>
+
+        <div className="mt-s flex flex-wrap items-center gap-s">
+          <Button
+            asChild
+            className="h-11 bg-brand text-on-brand font-semibold hover:bg-brand-dim"
+          >
+            <Link href="/events">{t("ctaPrimary")}</Link>
+          </Button>
+          <Button asChild variant="outline" className="h-11">
+            <Link href="/">{t("ctaSecondary")}</Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Timeline derecha — surface elevada, padding generoso. */}
+      <aside className="rounded-l border border-border bg-bg-surface p-l lg:p-xl">
+        <StepTimeline steps={steps} title={tTimeline("title")} />
+
+        <p className="mt-l border-t border-border pt-l text-body-s leading-relaxed text-fg-tertiary">
+          {t.rich("instagramHint", {
+            ig: (chunks) => (
+              <a
+                href="https://instagram.com/lahuelladelcaminante"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-fg-secondary underline-offset-4 hover:underline hover:text-fg-primary"
+              >
+                {chunks}
+              </a>
+            ),
+          })}
+        </p>
+      </aside>
+    </section>
+  )
+}

--- a/src/components/auth/AuthField.tsx
+++ b/src/components/auth/AuthField.tsx
@@ -1,0 +1,62 @@
+/**
+ * AuthField — wrapper consistente para los campos de los forms de auth.
+ *
+ * Centraliza el patrón Label + slot del input + hint/error en un solo
+ * componente. Cada caller (SignInForm, SignUpForm) pasa el `<Input>` ya
+ * configurado como `children`; este wrapper se encarga del Label arriba
+ * y del mensaje debajo (hint si no hay error, error si lo hay).
+ *
+ * Accesibilidad:
+ *  - `Label` con `htmlFor={id}` para asociación correcta.
+ *  - El input slot debe llevar `aria-invalid` cuando hay error y
+ *    `aria-describedby={hintId | errorId}` apuntando al `<p>` debajo.
+ *    Lo aplica el caller (este wrapper no inyecta props al child) — los
+ *    `id`s del hint y error se exponen como constantes en el caller via
+ *    `${id}-hint` y `${id}-error`.
+ *
+ * Server component — no consume hooks ni state. Reusable en cualquier
+ * form, no atado a react-hook-form ni a una librería específica.
+ */
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+export interface AuthFieldProps {
+  id: string
+  label: string
+  hint?: string
+  error?: string
+  children: React.ReactNode
+  className?: string
+}
+
+export default function AuthField({
+  id,
+  label,
+  hint,
+  error,
+  children,
+  className,
+}: AuthFieldProps) {
+  return (
+    <div className={cn("flex flex-col gap-xs", className)}>
+      <Label htmlFor={id} className="text-body-s text-fg-secondary">
+        {label}
+      </Label>
+      {children}
+      {error ? (
+        <p
+          id={`${id}-error`}
+          className="text-body-s text-status-danger"
+          role="alert"
+        >
+          {error}
+        </p>
+      ) : hint ? (
+        <p id={`${id}-hint`} className="text-caption text-fg-tertiary">
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/auth/AuthShell.tsx
+++ b/src/components/auth/AuthShell.tsx
@@ -38,7 +38,9 @@ export default function AuthShell({
   return (
     <div
       className={cn(
-        "grid min-h-[calc(100vh-var(--auth-header-h,4rem))] grid-cols-1 lg:grid-cols-12",
+        // `4rem` = altura del mini-header del layout `(auth)` (`h-16`).
+        // Sincronizado a mano — si cambia ahí, actualizar acá también.
+        "grid min-h-[calc(100vh-4rem)] grid-cols-1 lg:grid-cols-12",
         className
       )}
     >

--- a/src/components/auth/AuthShell.tsx
+++ b/src/components/auth/AuthShell.tsx
@@ -1,0 +1,64 @@
+/**
+ * AuthShell — layout 7:5 (form izq · panel editorial der) para `/sign-in`
+ * y `/sign-up`. Server component, sin estado.
+ *
+ * Specificaciones del handoff v2 (`docs/design/DESIGN_HANDOFF_OUTPUT_v2.md`
+ * §1.1, §7):
+ *  - Desktop (`lg:`): grid 12 columnas, form ocupa 7, hero ocupa 5.
+ *  - Mobile (< 1024px): single column, hero hidden (`hidden lg:flex`).
+ *    El form queda full-bleed con padding `l` lateral.
+ *  - El form se centra adentro de su columna con `max-w-[440px]` para que
+ *    los inputs no se estiren a 600px+ en pantallas anchas.
+ *
+ * El layout NO renderiza Header/Footer ni BrandLockup — eso lo maneja
+ * `src/app/[locale]/(auth)/layout.tsx` (que envuelve a las páginas del
+ * grupo `(auth)`). El AuthShell solo arma la grilla interna.
+ *
+ * `hero` se renderiza tal cual lo pase el caller — esto deja a cada
+ * pantalla decidir si quiere mostrar 3 thumbnails de eventos, 3 step
+ * cards del journey, una ilustración, o nada (`hero={null}` colapsaría
+ * la columna pero hoy ningún caller lo necesita).
+ */
+
+import { cn } from "@/lib/utils"
+
+export interface AuthShellProps {
+  /** Slot izquierdo — el form de auth + headings + footer del form. */
+  children: React.ReactNode
+  /** Slot derecho — panel editorial. Se oculta en mobile. */
+  hero: React.ReactNode
+  className?: string
+}
+
+export default function AuthShell({
+  children,
+  hero,
+  className,
+}: AuthShellProps) {
+  return (
+    <div
+      className={cn(
+        "grid min-h-[calc(100vh-var(--auth-header-h,4rem))] grid-cols-1 lg:grid-cols-12",
+        className
+      )}
+    >
+      {/* Columna form — 7/12 en desktop. Centra el form en max-w-[440px]
+          adentro de la columna para que no se estire en pantallas anchas. */}
+      <section
+        className="flex items-start justify-center px-l py-2xl lg:col-span-7 lg:items-center lg:py-3xl"
+        aria-label="Formulario"
+      >
+        <div className="w-full max-w-[440px]">{children}</div>
+      </section>
+
+      {/* Columna hero — 5/12 en desktop, oculta en mobile.
+          Surface elevada para distinguirla visualmente del form. */}
+      <aside
+        className="hidden bg-bg-surface lg:col-span-5 lg:flex lg:flex-col lg:justify-center lg:gap-xl lg:px-2xl lg:py-3xl"
+        aria-label="Manifiesto"
+      >
+        {hero}
+      </aside>
+    </div>
+  )
+}

--- a/src/components/auth/AuthShell.tsx
+++ b/src/components/auth/AuthShell.tsx
@@ -27,12 +27,21 @@ export interface AuthShellProps {
   children: React.ReactNode
   /** Slot derecho — panel editorial. Se oculta en mobile. */
   hero: React.ReactNode
+  /** `aria-label` del `<section>` del form. El caller lo provee i18n-aware
+   * (AuthShell es server pero no consume `useTranslations`; recibirlo por
+   * prop mantiene la API simple y deja el copy en el namespace de cada
+   * página). */
+  formAriaLabel: string
+  /** `aria-label` del `<aside>` del hero. Idem `formAriaLabel`. */
+  heroAriaLabel: string
   className?: string
 }
 
 export default function AuthShell({
   children,
   hero,
+  formAriaLabel,
+  heroAriaLabel,
   className,
 }: AuthShellProps) {
   return (
@@ -48,7 +57,7 @@ export default function AuthShell({
           adentro de la columna para que no se estire en pantallas anchas. */}
       <section
         className="flex items-start justify-center px-l py-2xl lg:col-span-7 lg:items-center lg:py-3xl"
-        aria-label="Formulario"
+        aria-label={formAriaLabel}
       >
         <div className="w-full max-w-[440px]">{children}</div>
       </section>
@@ -57,7 +66,7 @@ export default function AuthShell({
           Surface elevada para distinguirla visualmente del form. */}
       <aside
         className="hidden bg-bg-surface lg:col-span-5 lg:flex lg:flex-col lg:justify-center lg:gap-xl lg:px-2xl lg:py-3xl"
-        aria-label="Manifiesto"
+        aria-label={heroAriaLabel}
       >
         {hero}
       </aside>

--- a/src/components/auth/GoogleGlyph.tsx
+++ b/src/components/auth/GoogleGlyph.tsx
@@ -1,0 +1,37 @@
+/**
+ * GoogleGlyph — "G" tipográfica monospace dentro de un círculo con borde.
+ *
+ * **No** es el logo cuatricromático oficial de Google. Decisión explícita
+ * del handoff (`docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §3.3):
+ *  - Evita issues de licencia y atribución de marca.
+ *  - Queda alineado al sistema visual del proyecto (mono + tokens neutros).
+ *
+ * Si en el futuro Google TOS exige el glyph oficial para botones de OAuth,
+ * reemplazar el contenido de este componente por el SVG provisto por Google
+ * sin tocar a los callers (OAuthButton lo consume por composición).
+ *
+ * Decorativo: `aria-hidden={true}` — el caller (`OAuthButton`) provee la
+ * etiqueta semántica via el texto del botón ("Continuar con Google").
+ */
+
+import { cn } from "@/lib/utils"
+
+export interface GoogleGlyphProps {
+  className?: string
+}
+
+export default function GoogleGlyph({ className }: GoogleGlyphProps) {
+  return (
+    <span
+      aria-hidden={true}
+      className={cn(
+        "inline-flex h-5 w-5 items-center justify-center rounded-full",
+        "border border-border-hi font-mono text-body-s font-bold leading-none",
+        "text-fg-primary",
+        className
+      )}
+    >
+      G
+    </span>
+  )
+}

--- a/src/components/auth/OAuthButton.tsx
+++ b/src/components/auth/OAuthButton.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+/**
+ * OAuthButton — botón "Continuar con {provider}" para los flows de OAuth
+ * en `/sign-in` y `/sign-up`.
+ *
+ * Client component porque acepta `onClick` (los callers disparan
+ * `signIn.social({ provider, callbackURL })` desde ahí). Hoy solo
+ * renderiza el glyph de Google; si más adelante se agregan más providers
+ * (Apple, GitHub), agregar variantes condicionales del glyph dentro
+ * de este componente.
+ *
+ * Estilo: variant `outline` + `w-full` + altura cómoda para tap target
+ * en mobile. El glyph va a la izquierda con `gap-s`; el `Button` de
+ * shadcn ya provee `inline-flex items-center gap-2` por default, pero
+ * forzamos `justify-center` para alineación visual con el texto.
+ */
+
+import { Button } from "@/components/ui/button"
+import GoogleGlyph from "./GoogleGlyph"
+
+export interface OAuthButtonProps {
+  provider: "google"
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
+
+export default function OAuthButton({
+  provider,
+  label,
+  onClick,
+  disabled,
+}: OAuthButtonProps) {
+  // Por ahora solo Google. Si agregamos más providers, switch acá.
+  // Mantener el componente cerrado al `provider` prop permite a TS
+  // garantizar exhaustividad cuando se agregue un caso nuevo.
+  const glyph = provider === "google" ? <GoogleGlyph /> : null
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className="h-11 w-full justify-center gap-s text-body font-medium"
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {glyph}
+      <span>{label}</span>
+    </Button>
+  )
+}

--- a/src/components/auth/OrDivider.tsx
+++ b/src/components/auth/OrDivider.tsx
@@ -1,0 +1,36 @@
+/**
+ * OrDivider — separador horizontal con eyebrow centrado.
+ *
+ * Usado entre el bloque OAuth y el form email/password de las pantallas
+ * de auth (handoff v2 §1.1, §1.2). El eyebrow ("O CON EMAIL") viene del
+ * caller via prop `label` para que el texto sea i18n-aware (el componente
+ * mismo es presentacional puro, no consume `useTranslations`).
+ *
+ * Implementación: dos `<hr>` flexibles + un `<span>` central. `role="separator"`
+ * implícito por `<hr>`. El span del label tiene `aria-hidden={true}` porque
+ * el separador en sí mismo ya comunica la división — el texto es solo
+ * decoración tipográfica del breakpoint visual.
+ */
+
+import { cn } from "@/lib/utils"
+import Eyebrow from "@/components/ui/Eyebrow"
+
+export interface OrDividerProps {
+  label: string
+  className?: string
+}
+
+export default function OrDivider({ label, className }: OrDividerProps) {
+  return (
+    <div
+      className={cn("flex items-center gap-m", className)}
+      role="presentation"
+    >
+      <hr className="flex-1 border-t border-border" aria-hidden={true} />
+      <Eyebrow as="span" accent="neutral" aria-hidden={true}>
+        {label}
+      </Eyebrow>
+      <hr className="flex-1 border-t border-border" aria-hidden={true} />
+    </div>
+  )
+}

--- a/src/components/auth/OrDivider.tsx
+++ b/src/components/auth/OrDivider.tsx
@@ -6,10 +6,13 @@
  * caller via prop `label` para que el texto sea i18n-aware (el componente
  * mismo es presentacional puro, no consume `useTranslations`).
  *
- * Implementación: dos `<hr>` flexibles + un `<span>` central. `role="separator"`
- * implícito por `<hr>`. El span del label tiene `aria-hidden={true}` porque
- * el separador en sí mismo ya comunica la división — el texto es solo
- * decoración tipográfica del breakpoint visual.
+ * Implementación: dos `<hr>` flexibles + un `<span>` central wrapping el
+ * `<Eyebrow>`. `role="separator"` implícito por `<hr>`. El wrapper
+ * `<span aria-hidden>` opaca el texto al lector de pantalla — el
+ * separador en sí mismo ya comunica la división y los hijos del OAuth
+ * y form proveen su propio contexto semántico. (Aria-hidden no se
+ * puede pasar directo a `Eyebrow` porque el componente no propaga
+ * props; envolver es el workaround sin tocar `Eyebrow.tsx`.)
  */
 
 import { cn } from "@/lib/utils"
@@ -27,9 +30,11 @@ export default function OrDivider({ label, className }: OrDividerProps) {
       role="presentation"
     >
       <hr className="flex-1 border-t border-border" aria-hidden={true} />
-      <Eyebrow as="span" accent="neutral" aria-hidden={true}>
-        {label}
-      </Eyebrow>
+      <span aria-hidden={true}>
+        <Eyebrow as="span" accent="neutral">
+          {label}
+        </Eyebrow>
+      </span>
       <hr className="flex-1 border-t border-border" aria-hidden={true} />
     </div>
   )

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+/**
+ * SignInForm — form client de `/sign-in`. Maneja:
+ *  - Validación cliente con zod (`signInSchema`) via react-hook-form.
+ *  - OAuth Google via Better Auth `signIn.social` (redirect del browser).
+ *  - Email/password via Better Auth `signIn.email`. En éxito, navigate a
+ *    `/dashboard` (preserva locale via i18n-aware `useRouter`).
+ *  - Mapeo de errores de Better Auth a copy amigable i18n (no exponer
+ *    mensajes técnicos en inglés del SDK al user final).
+ *
+ * El "Olvidaste tu contraseña?" linkea a `/contact` hasta que exista una
+ * ruta `/forgot-password` dedicada. Decisión documentada acá y en BACKLOG:
+ * `/contact` está mergeada y es la vía existente para que un user pida
+ * reset manual mientras tanto. TODO(auth): swap a `/forgot-password`
+ * cuando exista la ruta.
+ */
+
+import { useTranslations } from "next-intl"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { useRouter } from "@/i18n/navigation"
+import { Link } from "@/i18n/navigation"
+import { signIn } from "@/lib/auth-client"
+import { signInSchema, type SignInInput } from "@/lib/validators/auth"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import AuthField from "@/components/auth/AuthField"
+import OAuthButton from "@/components/auth/OAuthButton"
+import OrDivider from "@/components/auth/OrDivider"
+
+/** Códigos de error definidos en el schema o mapeables desde Better Auth.
+ * Lo demás cae al label `generic` del namespace i18n. */
+const KNOWN_ERROR_CODES = new Set<string>([
+  "email_required",
+  "email_invalid",
+  "email_too_long",
+  "password_too_short",
+  "password_too_long",
+])
+
+/** Heurística para mapear errores de Better Auth a códigos i18n.
+ * El SDK devuelve `error.message` en inglés (ej. "Invalid email or password").
+ * Esto nos deja mostrar copy amigable sin acoplar el form al string exacto
+ * que pueda cambiar entre versiones del SDK. Si no matchea ninguno, cae al
+ * código `generic`. */
+function mapAuthErrorToCode(message?: string | null): string {
+  if (!message) return "generic"
+  const lower = message.toLowerCase()
+  if (lower.includes("invalid") && (lower.includes("password") || lower.includes("credential") || lower.includes("email"))) {
+    return "credentials"
+  }
+  return "generic"
+}
+
+export interface SignInFormProps {
+  /** Locale activo del request — usado para el `callbackURL` de OAuth y
+   * para resolver redirects post-login. */
+  locale: string
+}
+
+export default function SignInForm({ locale }: SignInFormProps) {
+  const t = useTranslations("auth.signIn")
+  const tErrors = useTranslations("auth.signIn.errors")
+  const router = useRouter()
+
+  const errorMessageFor = (code: string): string =>
+    KNOWN_ERROR_CODES.has(code) ? tErrors(code) : tErrors(code === "credentials" ? "credentials" : "generic")
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignInInput>({
+    resolver: zodResolver(signInSchema),
+    defaultValues: { email: "", password: "" },
+  })
+
+  async function onSubmit(values: SignInInput) {
+    const res = await signIn.email({
+      email: values.email,
+      password: values.password,
+    })
+
+    if (res.error) {
+      const code = mapAuthErrorToCode(res.error.message)
+      toast.error(errorMessageFor(code))
+      return
+    }
+
+    router.push("/dashboard")
+  }
+
+  function handleGoogleClick() {
+    // signIn.social no devuelve promesa accionable — dispara redirect del
+    // browser. No envolver en try/catch. `callbackURL` debe incluir el
+    // locale para volver a la versión correcta del dashboard.
+    signIn.social({
+      provider: "google",
+      callbackURL: `/${locale}/dashboard`,
+    })
+  }
+
+  return (
+    <form
+      method="post"
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex flex-col gap-l"
+      noValidate
+    >
+      <OAuthButton
+        provider="google"
+        label={t("continueWith", { provider: "Google" })}
+        onClick={handleGoogleClick}
+        disabled={isSubmitting}
+      />
+
+      <OrDivider label={t("orEmail")} />
+
+      <AuthField
+        id="signin-email"
+        label={t("emailLabel")}
+        error={errors.email ? errorMessageFor(errors.email.message ?? "") : undefined}
+      >
+        <Input
+          id="signin-email"
+          type="email"
+          autoComplete="email"
+          placeholder={t("emailPlaceholder")}
+          aria-invalid={Boolean(errors.email)}
+          aria-describedby={errors.email ? "signin-email-error" : undefined}
+          {...register("email")}
+        />
+      </AuthField>
+
+      <div className="flex flex-col gap-xs">
+        <AuthField
+          id="signin-password"
+          label={t("passwordLabel")}
+          error={errors.password ? errorMessageFor(errors.password.message ?? "") : undefined}
+        >
+          <Input
+            id="signin-password"
+            type="password"
+            autoComplete="current-password"
+            placeholder={t("passwordPlaceholder")}
+            aria-invalid={Boolean(errors.password)}
+            aria-describedby={errors.password ? "signin-password-error" : undefined}
+            {...register("password")}
+          />
+        </AuthField>
+        {/* TODO(auth): swap a `/forgot-password` cuando exista la ruta. */}
+        <Link
+          href="/contact"
+          className="self-end text-body-s text-fg-secondary hover:text-fg-primary underline-offset-4 hover:underline"
+        >
+          {t("forgot")}
+        </Link>
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        className="h-11 w-full bg-brand text-on-brand font-semibold hover:bg-brand-dim disabled:opacity-60"
+      >
+        {isSubmitting ? t("submitting") : t("submit")}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -100,10 +100,18 @@ export default function SignInForm({ locale }: SignInFormProps) {
   })
 
   async function onSubmit(values: SignInInput) {
-    const res = await signIn.email({
-      email: values.email,
-      password: values.password,
-    })
+    let res
+    try {
+      res = await signIn.email({
+        email: values.email,
+        password: values.password,
+      })
+    } catch {
+      // Network failure / SDK lanza excepción no manejada — sin esto el
+      // botón queda en isSubmitting indefinido y el user no sabe qué pasó.
+      toast.error(errorMessageFor("generic"))
+      return
+    }
 
     if (res.error) {
       const code = mapAuthErrorToCode(res.error)

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -30,7 +30,9 @@ import AuthField from "@/components/auth/AuthField"
 import OAuthButton from "@/components/auth/OAuthButton"
 import OrDivider from "@/components/auth/OrDivider"
 
-/** Códigos de error definidos en el schema o mapeables desde Better Auth.
+/** Códigos de error que el form sabe traducir. Combina:
+ *  - Códigos del schema zod (`email_invalid`, etc.).
+ *  - Códigos mapeados desde el `error.code` estable de Better Auth.
  * Lo demás cae al label `generic` del namespace i18n. */
 const KNOWN_ERROR_CODES = new Set<string>([
   "email_required",
@@ -38,17 +40,37 @@ const KNOWN_ERROR_CODES = new Set<string>([
   "email_too_long",
   "password_too_short",
   "password_too_long",
+  "credentials",
 ])
 
-/** Heurística para mapear errores de Better Auth a códigos i18n.
- * El SDK devuelve `error.message` en inglés (ej. "Invalid email or password").
- * Esto nos deja mostrar copy amigable sin acoplar el form al string exacto
- * que pueda cambiar entre versiones del SDK. Si no matchea ninguno, cae al
- * código `generic`. */
-function mapAuthErrorToCode(message?: string | null): string {
-  if (!message) return "generic"
-  const lower = message.toLowerCase()
-  if (lower.includes("invalid") && (lower.includes("password") || lower.includes("credential") || lower.includes("email"))) {
+/** Mapeo de `error.code` de Better Auth a códigos i18n del form. Los
+ * códigos del SDK son estables entre versiones (los strings del `.message`
+ * no — pueden cambiar copy en cualquier minor release). Acá listamos solo
+ * los que tienen una traducción específica; el resto cae al fallback. */
+const BETTER_AUTH_CODE_MAP: Record<string, string> = {
+  INVALID_EMAIL_OR_PASSWORD: "credentials",
+  INVALID_EMAIL: "credentials",
+  INVALID_PASSWORD: "credentials",
+}
+
+/** Resuelve el código i18n desde un error de Better Auth. Preferimos
+ * `error.code` por su estabilidad; si no viene, caemos a heurística sobre
+ * `error.message` (último recurso, frágil). */
+function mapAuthErrorToCode(error?: {
+  code?: string | null
+  message?: string | null
+}): string {
+  if (!error) return "generic"
+  if (error.code && BETTER_AUTH_CODE_MAP[error.code]) {
+    return BETTER_AUTH_CODE_MAP[error.code]
+  }
+  const lower = (error.message ?? "").toLowerCase()
+  if (
+    lower.includes("invalid") &&
+    (lower.includes("password") ||
+      lower.includes("credential") ||
+      lower.includes("email"))
+  ) {
     return "credentials"
   }
   return "generic"
@@ -66,7 +88,7 @@ export default function SignInForm({ locale }: SignInFormProps) {
   const router = useRouter()
 
   const errorMessageFor = (code: string): string =>
-    KNOWN_ERROR_CODES.has(code) ? tErrors(code) : tErrors(code === "credentials" ? "credentials" : "generic")
+    KNOWN_ERROR_CODES.has(code) ? tErrors(code) : tErrors("generic")
 
   const {
     register,
@@ -84,7 +106,7 @@ export default function SignInForm({ locale }: SignInFormProps) {
     })
 
     if (res.error) {
-      const code = mapAuthErrorToCode(res.error.message)
+      const code = mapAuthErrorToCode(res.error)
       toast.error(errorMessageFor(code))
       return
     }
@@ -93,13 +115,19 @@ export default function SignInForm({ locale }: SignInFormProps) {
   }
 
   function handleGoogleClick() {
-    // signIn.social no devuelve promesa accionable — dispara redirect del
-    // browser. No envolver en try/catch. `callbackURL` debe incluir el
+    // signIn.social dispara redirect del browser y normalmente no
+    // devuelve. Try/catch defensivo por si el SDK rechaza síncronamente
+    // (config inválida, popup bloqueado, etc.) — sin esto el botón
+    // queda en disabled silencioso. `callbackURL` debe incluir el
     // locale para volver a la versión correcta del dashboard.
-    signIn.social({
-      provider: "google",
-      callbackURL: `/${locale}/dashboard`,
-    })
+    try {
+      signIn.social({
+        provider: "google",
+        callbackURL: `/${locale}/dashboard`,
+      })
+    } catch {
+      toast.error(errorMessageFor("generic"))
+    }
   }
 
   return (

--- a/src/components/auth/SignOutButton.tsx
+++ b/src/components/auth/SignOutButton.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+/**
+ * SignOutButton — botón cliente que dispara `signOut()` de Better Auth
+ * y navega al home post-logout.
+ *
+ * Consumido por `/user-pending` y `/user-blocked` (las dos pantallas
+ * donde el user logueado necesita una salida visible). Aislamos el
+ * trigger en un componente chico para que las pages padre sigan siendo
+ * server components — solo este pedazo cruza el boundary client.
+ *
+ * El redirect post-signOut usa `router.replace("/")` (no `push`) para
+ * que el back del browser no traiga al user de vuelta a la pantalla
+ * de cuenta suspendida/pendiente. Better Auth limpia la cookie de
+ * sesión antes de resolver la promesa, así que para cuando el replace
+ * corre el guard de `/` no encuentra session.
+ */
+
+import { useTransition } from "react"
+import { useRouter } from "@/i18n/navigation"
+import { signOut } from "@/lib/auth-client"
+import { Button } from "@/components/ui/button"
+
+export interface SignOutButtonProps {
+  label: string
+  loadingLabel?: string
+  variant?: "outline" | "ghost" | "default"
+  className?: string
+}
+
+export default function SignOutButton({
+  label,
+  loadingLabel,
+  variant = "outline",
+  className,
+}: SignOutButtonProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  function handleClick() {
+    startTransition(async () => {
+      await signOut()
+      router.replace("/")
+    })
+  }
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      onClick={handleClick}
+      disabled={isPending}
+      className={className}
+    >
+      {isPending && loadingLabel ? loadingLabel : label}
+    </Button>
+  )
+}

--- a/src/components/auth/SignOutButton.tsx
+++ b/src/components/auth/SignOutButton.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useTransition } from "react"
+import { toast } from "sonner"
 import { useRouter } from "@/i18n/navigation"
 import { signOut } from "@/lib/auth-client"
 import { Button } from "@/components/ui/button"
@@ -24,6 +25,10 @@ import { Button } from "@/components/ui/button"
 export interface SignOutButtonProps {
   label: string
   loadingLabel?: string
+  /** Mensaje para el toast de error si signOut falla. El caller lo
+   * provee i18n-aware (este componente no consume `useTranslations`
+   * para mantener su API simple). */
+  errorLabel?: string
   variant?: "outline" | "ghost" | "default"
   className?: string
 }
@@ -31,6 +36,7 @@ export interface SignOutButtonProps {
 export default function SignOutButton({
   label,
   loadingLabel,
+  errorLabel,
   variant = "outline",
   className,
 }: SignOutButtonProps) {
@@ -39,8 +45,18 @@ export default function SignOutButton({
 
   function handleClick() {
     startTransition(async () => {
-      await signOut()
-      router.replace("/")
+      try {
+        await signOut()
+        router.replace("/")
+      } catch {
+        // Si Better Auth falla (network, server down, etc.) el user
+        // queda con sesión activa pero esperando feedback. Toast en
+        // lugar de inline error para consistencia con SignInForm /
+        // SignUpForm (mismo patrón sonner). Fallback a un mensaje
+        // genérico si el caller no pasó `errorLabel` — no rompe el
+        // botón ni deja al user en limbo silencioso.
+        toast.error(errorLabel ?? "Sign out failed. Try again.")
+      }
     })
   }
 

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -95,11 +95,19 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
   })
 
   async function onSubmit(values: SignUpInput) {
-    const res = await signUp.email({
-      name: values.name,
-      email: values.email,
-      password: values.password,
-    })
+    let res
+    try {
+      res = await signUp.email({
+        name: values.name,
+        email: values.email,
+        password: values.password,
+      })
+    } catch {
+      // Network failure / SDK lanza excepción no manejada — sin esto el
+      // botón queda en isSubmitting indefinido y el user no sabe qué pasó.
+      toast.error(errorMessageFor("generic"))
+      return
+    }
 
     if (res.error) {
       const code = mapAuthErrorToCode(res.error)

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -42,15 +42,32 @@ const KNOWN_ERROR_CODES = new Set<string>([
   "password_too_short",
   "password_too_long",
   "terms_required",
+  "email_taken",
 ])
 
-/** Mismo principio que SignInForm: aislar el form del mensaje exacto
- * del SDK. El error más típico del sign-up es "user already exists"
- * (email duplicado); el resto cae a `generic`. */
-function mapAuthErrorToCode(message?: string | null): string {
-  if (!message) return "generic"
-  const lower = message.toLowerCase()
-  if (lower.includes("already") || lower.includes("exist") || lower.includes("registered")) {
+/** Codes estables de Better Auth → códigos i18n del form. Mismo
+ * principio que en SignInForm: preferimos `error.code` por estabilidad
+ * y caemos a heurística sobre `.message` solo como último recurso. */
+const BETTER_AUTH_CODE_MAP: Record<string, string> = {
+  USER_ALREADY_EXISTS: "email_taken",
+  USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL: "email_taken",
+  EMAIL_ALREADY_EXISTS: "email_taken",
+}
+
+function mapAuthErrorToCode(error?: {
+  code?: string | null
+  message?: string | null
+}): string {
+  if (!error) return "generic"
+  if (error.code && BETTER_AUTH_CODE_MAP[error.code]) {
+    return BETTER_AUTH_CODE_MAP[error.code]
+  }
+  const lower = (error.message ?? "").toLowerCase()
+  if (
+    lower.includes("already") ||
+    lower.includes("exist") ||
+    lower.includes("registered")
+  ) {
     return "email_taken"
   }
   return "generic"
@@ -66,9 +83,7 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
   const router = useRouter()
 
   const errorMessageFor = (code: string): string =>
-    KNOWN_ERROR_CODES.has(code) || code === "email_taken"
-      ? tErrors(code)
-      : tErrors("generic")
+    KNOWN_ERROR_CODES.has(code) ? tErrors(code) : tErrors("generic")
 
   const {
     register,
@@ -76,7 +91,7 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
     formState: { errors, isSubmitting },
   } = useForm<SignUpInput>({
     resolver: zodResolver(signUpSchema),
-    defaultValues: { name: "", email: "", password: "", acceptTerms: false as true },
+    defaultValues: { name: "", email: "", password: "", acceptTerms: false },
   })
 
   async function onSubmit(values: SignUpInput) {
@@ -87,7 +102,7 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
     })
 
     if (res.error) {
-      const code = mapAuthErrorToCode(res.error.message)
+      const code = mapAuthErrorToCode(res.error)
       toast.error(errorMessageFor(code))
       return
     }
@@ -96,10 +111,17 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
   }
 
   function handleGoogleClick() {
-    signIn.social({
-      provider: "google",
-      callbackURL: `/${locale}/dashboard`,
-    })
+    // Try/catch defensivo — `signIn.social` normalmente hace redirect
+    // del browser, pero puede rechazar sync con popup bloqueado o
+    // config inválida. Sin esto el botón queda en disabled silencioso.
+    try {
+      signIn.social({
+        provider: "google",
+        callbackURL: `/${locale}/dashboard`,
+      })
+    } catch {
+      toast.error(errorMessageFor("generic"))
+    }
   }
 
   return (

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+/**
+ * SignUpForm — form client de `/sign-up`. Mismo patrón que SignInForm,
+ * extendido con:
+ *  - Campo `name` (2-120 chars).
+ *  - Campo `password` con hint estático de fortaleza (recomendación, no
+ *    obligación — Better Auth solo enforce `minPasswordLength: 8`).
+ *  - Checkbox `acceptTerms` (required) con rich-text wrappers que linkean
+ *    a `/terms` y `/privacy`. Esas rutas no existen aún — apuntan a `#`
+ *    con TODO en el código. Decisión del spec: no bloquear esta PR.
+ *  - OAuth Google (decisión consistente con sign-in: mantener el flow
+ *    OAuth disponible en ambos lados).
+ *
+ * En éxito: redirige a `/dashboard`. Ahí `requireActive()` decide qué
+ * mostrar según el `UserProfile.status` (PENDING → `/user-pending`,
+ * BLOCKED → `/user-blocked`, ACTIVE → render del dashboard). No
+ * deciden acá — toda la lógica de routing post-auth es responsabilidad
+ * del guard de auth.
+ */
+
+import { useTranslations } from "next-intl"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { useRouter, Link } from "@/i18n/navigation"
+import { signUp, signIn } from "@/lib/auth-client"
+import { signUpSchema, type SignUpInput } from "@/lib/validators/auth"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import AuthField from "@/components/auth/AuthField"
+import OAuthButton from "@/components/auth/OAuthButton"
+import OrDivider from "@/components/auth/OrDivider"
+import { cn } from "@/lib/utils"
+
+const KNOWN_ERROR_CODES = new Set<string>([
+  "name_too_short",
+  "name_too_long",
+  "email_required",
+  "email_invalid",
+  "email_too_long",
+  "password_too_short",
+  "password_too_long",
+  "terms_required",
+])
+
+/** Mismo principio que SignInForm: aislar el form del mensaje exacto
+ * del SDK. El error más típico del sign-up es "user already exists"
+ * (email duplicado); el resto cae a `generic`. */
+function mapAuthErrorToCode(message?: string | null): string {
+  if (!message) return "generic"
+  const lower = message.toLowerCase()
+  if (lower.includes("already") || lower.includes("exist") || lower.includes("registered")) {
+    return "email_taken"
+  }
+  return "generic"
+}
+
+export interface SignUpFormProps {
+  locale: string
+}
+
+export default function SignUpForm({ locale }: SignUpFormProps) {
+  const t = useTranslations("auth.signUp")
+  const tErrors = useTranslations("auth.signUp.errors")
+  const router = useRouter()
+
+  const errorMessageFor = (code: string): string =>
+    KNOWN_ERROR_CODES.has(code) || code === "email_taken"
+      ? tErrors(code)
+      : tErrors("generic")
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignUpInput>({
+    resolver: zodResolver(signUpSchema),
+    defaultValues: { name: "", email: "", password: "", acceptTerms: false as true },
+  })
+
+  async function onSubmit(values: SignUpInput) {
+    const res = await signUp.email({
+      name: values.name,
+      email: values.email,
+      password: values.password,
+    })
+
+    if (res.error) {
+      const code = mapAuthErrorToCode(res.error.message)
+      toast.error(errorMessageFor(code))
+      return
+    }
+
+    router.push("/dashboard")
+  }
+
+  function handleGoogleClick() {
+    signIn.social({
+      provider: "google",
+      callbackURL: `/${locale}/dashboard`,
+    })
+  }
+
+  return (
+    <form
+      method="post"
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex flex-col gap-l"
+      noValidate
+    >
+      <OAuthButton
+        provider="google"
+        label={t("continueWith", { provider: "Google" })}
+        onClick={handleGoogleClick}
+        disabled={isSubmitting}
+      />
+
+      <OrDivider label={t("orEmail")} />
+
+      <AuthField
+        id="signup-name"
+        label={t("nameLabel")}
+        error={errors.name ? errorMessageFor(errors.name.message ?? "") : undefined}
+      >
+        <Input
+          id="signup-name"
+          type="text"
+          autoComplete="name"
+          placeholder={t("namePlaceholder")}
+          aria-invalid={Boolean(errors.name)}
+          aria-describedby={errors.name ? "signup-name-error" : undefined}
+          {...register("name")}
+        />
+      </AuthField>
+
+      <AuthField
+        id="signup-email"
+        label={t("emailLabel")}
+        error={errors.email ? errorMessageFor(errors.email.message ?? "") : undefined}
+      >
+        <Input
+          id="signup-email"
+          type="email"
+          autoComplete="email"
+          placeholder={t("emailPlaceholder")}
+          aria-invalid={Boolean(errors.email)}
+          aria-describedby={errors.email ? "signup-email-error" : undefined}
+          {...register("email")}
+        />
+      </AuthField>
+
+      <AuthField
+        id="signup-password"
+        label={t("passwordLabel")}
+        hint={t("passwordHint")}
+        error={errors.password ? errorMessageFor(errors.password.message ?? "") : undefined}
+      >
+        <Input
+          id="signup-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder={t("passwordPlaceholder")}
+          aria-invalid={Boolean(errors.password)}
+          aria-describedby={
+            errors.password ? "signup-password-error" : "signup-password-hint"
+          }
+          {...register("password")}
+        />
+      </AuthField>
+
+      {/* Checkbox de aceptación de términos. No usamos un componente
+          `Checkbox` reusable porque (a) no existe en el proyecto y (b)
+          esta es la única instancia del PR — bikeshed prematuro. El
+          rich-text de la label resuelve los dos links via wrappers
+          `<terms>` y `<privacy>`. TODO(legal): apuntan a `#` hasta que
+          existan las páginas legales (anotado en BACKLOG bajo GDPR). */}
+      <div className="flex flex-col gap-xs">
+        <label
+          htmlFor="signup-accept-terms"
+          className={cn(
+            "flex items-start gap-s text-body-s text-fg-secondary leading-relaxed cursor-pointer",
+            errors.acceptTerms && "text-status-danger"
+          )}
+        >
+          <input
+            id="signup-accept-terms"
+            type="checkbox"
+            className="mt-[3px] h-4 w-4 rounded-sm border border-border-hi accent-brand"
+            aria-invalid={Boolean(errors.acceptTerms)}
+            aria-describedby={
+              errors.acceptTerms ? "signup-accept-terms-error" : undefined
+            }
+            {...register("acceptTerms")}
+          />
+          <span>
+            {t.rich("acceptTerms", {
+              terms: (chunks) => (
+                <Link
+                  href="#"
+                  className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+                >
+                  {chunks}
+                </Link>
+              ),
+              privacy: (chunks) => (
+                <Link
+                  href="#"
+                  className="font-semibold text-fg-primary underline-offset-4 hover:underline"
+                >
+                  {chunks}
+                </Link>
+              ),
+            })}
+          </span>
+        </label>
+        {errors.acceptTerms ? (
+          <p
+            id="signup-accept-terms-error"
+            className="text-body-s text-status-danger"
+            role="alert"
+          >
+            {errorMessageFor(errors.acceptTerms.message ?? "")}
+          </p>
+        ) : null}
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        className="h-11 w-full bg-brand text-on-brand font-semibold hover:bg-brand-dim disabled:opacity-60"
+      >
+        {isSubmitting ? t("submitting") : t("submit")}
+      </Button>
+    </form>
+  )
+}

--- a/src/components/auth/StatusHero.tsx
+++ b/src/components/auth/StatusHero.tsx
@@ -1,0 +1,64 @@
+/**
+ * StatusHero — ícono visual central para `/user-pending` y `/user-blocked`.
+ *
+ * El handoff v2 §1.4, §1.5 pide un ícono que comunique el estado de
+ * cuenta sin texto ni glyph reconocible:
+ *  - `pending`: bombilla con glow dorado (radial gradient + box-shadow).
+ *    Metáfora del "se está horneando" — la peña preparando el plato.
+ *    Variante sutilmente cálida — distingue "estás esperando" de
+ *    "fracasaste". Glow estático por ahora; el spec marca animación
+ *    como opcional fuera del MVP.
+ *  - `blocked`: círculo grande con borde sangre + em-dash centrado.
+ *    Intencionalmente austero — sin emoji de alarma. Es estado
+ *    terminal, no error técnico.
+ *
+ * Decorativo: `aria-hidden={true}`. El caller provee la etiqueta
+ * semántica via eyebrow + h1 al lado/debajo.
+ *
+ * Server component — sin estado interno.
+ */
+
+import { cn } from "@/lib/utils"
+
+export interface StatusHeroProps {
+  variant: "pending" | "blocked"
+  className?: string
+}
+
+export default function StatusHero({ variant, className }: StatusHeroProps) {
+  if (variant === "pending") {
+    return (
+      <div
+        aria-hidden={true}
+        className={cn("flex items-center justify-center", className)}
+      >
+        <div
+          className="relative flex h-24 w-24 items-center justify-center rounded-full"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 50% 45%, var(--color-editorial) 0%, color-mix(in oklab, var(--color-editorial) 50%, transparent) 45%, transparent 75%)",
+            boxShadow:
+              "0 0 60px var(--color-editorial), 0 0 24px color-mix(in oklab, var(--color-editorial) 70%, transparent)",
+          }}
+        >
+          {/* Punto central — el "filamento" de la bombilla. */}
+          <span className="h-3 w-3 rounded-full bg-on-editorial" />
+        </div>
+      </div>
+    )
+  }
+
+  // variant === "blocked"
+  return (
+    <div
+      aria-hidden={true}
+      className={cn("flex items-center justify-center", className)}
+    >
+      <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-brand">
+        <span className="select-none text-display-m font-display leading-none text-brand">
+          —
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/StepTimeline.tsx
+++ b/src/components/auth/StepTimeline.tsx
@@ -1,0 +1,142 @@
+/**
+ * StepTimeline — timeline vertical reusable de N estados con indicadores
+ * visuales (done / active / todo) y conectores entre items.
+ *
+ * Estados visuales:
+ *  - `done`: círculo lleno verde (`bg-status-ok`) con check ✓. Pasos
+ *    completados.
+ *  - `active`: círculo lleno dorado (`bg-editorial`) con glow vía
+ *    `box-shadow`. El paso "en proceso ahora". Solo uno debe estar
+ *    activo a la vez para no confundir la jerarquía visual.
+ *  - `todo`: círculo vacío con borde neutro. Pasos futuros.
+ *
+ * Conector vertical: línea entre items con `border-l` del color del paso
+ * anterior (verde si done, neutral si todo). Skip en el último item.
+ *
+ * Server component — sin estado interno. El caller pasa el array de
+ * steps con sus estados ya resueltos.
+ *
+ * Hoy se consume desde `ApplySubmittedScreen`. Si en el futuro aparece
+ * en el dashboard del creator pre-aprobación, reusar acá — no duplicar.
+ *
+ * Spec: `docs/design/DESIGN_HANDOFF_OUTPUT_v2.md` §1.3 + §3.1.
+ */
+
+import { cn } from "@/lib/utils"
+
+export type StepState = "done" | "active" | "todo"
+
+export interface TimelineStep {
+  /** Estado visual del paso. */
+  state: StepState
+  /** Título principal del paso (ej. "Recibida", "En revisión"). */
+  label: string
+  /** Sub-texto descriptivo (ej. "Hace un momento", "Un humano mira tu perfil"). */
+  sublabel: string
+  /** Timestamp o duración estimada (ej. "15 may · 14:32", "~ 1-2 días"). */
+  when: string
+}
+
+export interface StepTimelineProps {
+  steps: TimelineStep[]
+  /** Label opcional del eyebrow arriba del timeline (ej. "QUÉ SIGUE"). */
+  title?: string
+  className?: string
+}
+
+/** Mapeo de estado → clases del dot indicador. El `active` lleva
+ * `shadow-[...]` con CSS var del editorial para que el glow respete el
+ * theming si se cambia el accent dorado a futuro. */
+const DOT_CLASSES: Record<StepState, string> = {
+  done: "bg-status-ok text-on-brand",
+  active:
+    "bg-editorial text-on-editorial shadow-[0_0_16px_var(--color-editorial)]",
+  todo: "bg-transparent border border-border-hi text-fg-tertiary",
+}
+
+const CONNECTOR_CLASSES: Record<StepState, string> = {
+  done: "bg-status-ok",
+  active: "bg-editorial/40",
+  todo: "bg-border",
+}
+
+function StepDot({ state }: { state: StepState }) {
+  return (
+    <span
+      aria-hidden={true}
+      className={cn(
+        "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-body-s font-bold leading-none",
+        DOT_CLASSES[state]
+      )}
+    >
+      {state === "done" ? "✓" : state === "active" ? "●" : "○"}
+    </span>
+  )
+}
+
+export default function StepTimeline({
+  steps,
+  title,
+  className,
+}: StepTimelineProps) {
+  return (
+    <div className={cn("flex flex-col gap-m", className)}>
+      {title ? (
+        <p className="font-mono text-eyebrow uppercase text-fg-secondary">
+          {title}
+        </p>
+      ) : null}
+
+      <ol className="flex flex-col">
+        {steps.map((step, index) => {
+          const isLast = index === steps.length - 1
+          return (
+            <li
+              key={index}
+              className="relative grid grid-cols-[auto_1fr] gap-m pb-l last:pb-0"
+              aria-current={step.state === "active" ? "step" : undefined}
+            >
+              {/* Connector vertical: línea desde el centro del dot hasta el
+                  siguiente item. Skip en el último. Posicionada absoluta
+                  para no afectar el flow del grid. */}
+              {!isLast ? (
+                <span
+                  aria-hidden={true}
+                  className={cn(
+                    "absolute left-[11px] top-6 bottom-0 w-px",
+                    CONNECTOR_CLASSES[step.state]
+                  )}
+                />
+              ) : null}
+
+              <StepDot state={step.state} />
+
+              <div className="flex flex-col gap-xs pt-[2px]">
+                <div className="flex flex-wrap items-baseline justify-between gap-s">
+                  <p
+                    className={cn(
+                      "text-body font-semibold leading-tight",
+                      step.state === "active"
+                        ? "text-fg-primary"
+                        : step.state === "done"
+                          ? "text-fg-primary"
+                          : "text-fg-secondary"
+                    )}
+                  >
+                    {step.label}
+                  </p>
+                  <p className="font-mono text-caption uppercase text-fg-tertiary">
+                    {step.when}
+                  </p>
+                </div>
+                <p className="text-body-s leading-relaxed text-fg-secondary">
+                  {step.sublabel}
+                </p>
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/src/lib/validators/auth.ts
+++ b/src/lib/validators/auth.ts
@@ -1,0 +1,61 @@
+/**
+ * Schemas zod para los forms de auth (`/sign-in`, `/sign-up`).
+ *
+ * Consumidos por el cliente para validación + tipado del state del form.
+ * Better Auth no usa estos schemas en el server — la validación server-side
+ * la hace Better Auth con sus propios checks (email format, password
+ * strength configurada en `auth.ts`, dedupe de email). Estos schemas son
+ * UX-first: feedback inmediato en cliente con copy amigable i18n.
+ *
+ * Pattern de los `message` errors: en lugar de mensajes hardcoded en
+ * castellano, los schemas devuelven keys (`email_invalid`, `password_too_short`,
+ * etc.) que el form resuelve via `useTranslations("auth.signIn.errors")` /
+ * `useTranslations("auth.signUp.errors")`. Mismo pattern que `contact.ts`
+ * — mantiene la validación libre de idioma y permite agregar locales sin
+ * tocar el schema.
+ */
+
+import { z } from "zod"
+
+/** Mínimo de password — coincide con el setting `minPasswordLength: 8` de
+ * Better Auth en `src/lib/auth.ts`. Si se cambia uno, hay que cambiar el
+ * otro o el form rechaza un password que el server aceptaría (o viceversa). */
+const PASSWORD_MIN = 8
+const PASSWORD_MAX = 128
+
+/** Límite de longitud de email — RFC 5321 §4.5.3.1.3 (254 chars total
+ * para el local + domain). Mismo límite que `contact.ts`. */
+const EMAIL_MAX = 254
+
+export const signInSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .min(1, { message: "email_required" })
+    .email({ message: "email_invalid" })
+    .max(EMAIL_MAX, { message: "email_too_long" }),
+  password: z
+    .string()
+    .min(PASSWORD_MIN, { message: "password_too_short" })
+    .max(PASSWORD_MAX, { message: "password_too_long" }),
+})
+
+export type SignInInput = z.infer<typeof signInSchema>
+
+/**
+ * Sign-up extiende sign-in con:
+ *  - `name`: 2-120 chars, trim — mismo rango que `contact.ts` para consistencia.
+ *  - `acceptTerms`: literal `true`. Forzar el bool literal hace que zod
+ *    rechace `false` con el mismo flujo de error que los demás campos
+ *    (no necesita validación custom).
+ */
+export const signUpSchema = signInSchema.extend({
+  name: z
+    .string()
+    .trim()
+    .min(2, { message: "name_too_short" })
+    .max(120, { message: "name_too_long" }),
+  acceptTerms: z.literal(true, { message: "terms_required" }),
+})
+
+export type SignUpInput = z.infer<typeof signUpSchema>

--- a/src/lib/validators/auth.ts
+++ b/src/lib/validators/auth.ts
@@ -45,9 +45,10 @@ export type SignInInput = z.infer<typeof signInSchema>
 /**
  * Sign-up extiende sign-in con:
  *  - `name`: 2-120 chars, trim — mismo rango que `contact.ts` para consistencia.
- *  - `acceptTerms`: literal `true`. Forzar el bool literal hace que zod
- *    rechace `false` con el mismo flujo de error que los demás campos
- *    (no necesita validación custom).
+ *  - `acceptTerms`: bool con refine `=== true`. Usar `boolean().refine`
+ *    en vez de `z.literal(true)` mantiene la inferencia de tipo como
+ *    `boolean` (RHF `defaultValues` necesita un valor sin cast falso),
+ *    sin perder el mensaje i18n del error.
  */
 export const signUpSchema = signInSchema.extend({
   name: z
@@ -55,7 +56,9 @@ export const signUpSchema = signInSchema.extend({
     .trim()
     .min(2, { message: "name_too_short" })
     .max(120, { message: "name_too_long" }),
-  acceptTerms: z.literal(true, { message: "terms_required" }),
+  acceptTerms: z
+    .boolean()
+    .refine((v) => v === true, { message: "terms_required" }),
 })
 
 export type SignUpInput = z.infer<typeof signUpSchema>

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -465,6 +465,48 @@
         "body": "La Huella ist ein unabhängiges Portal. Wir verkaufen keine Tickets, wir nehmen keine Provision. Wir zeigen einfach, was läuft.",
         "statsFormat": "{shows} KOMMENDE SHOWS · {cities} STÄDTE"
       }
+    },
+    "signUp": {
+      "metaTitle": "Konto erstellen",
+      "eyebrow": "KONTO ERSTELLEN",
+      "title": "Fang an zu <accent>veröffentlichen.</accent>",
+      "subtitle": "Konto erstellen ist der erste Schritt. Dann bewirbst du dich als Creator und wir prüfen dein Profil — meistens 1-2 Tage.",
+      "continueWith": "Mit {provider} fortfahren",
+      "orEmail": "ODER MIT E-MAIL",
+      "nameLabel": "Name",
+      "namePlaceholder": "Wie sollen wir dich nennen",
+      "emailLabel": "E-Mail",
+      "emailPlaceholder": "du@email.de",
+      "passwordLabel": "Passwort",
+      "passwordPlaceholder": "Wähle ein Passwort",
+      "passwordHint": "Mische Großbuchstaben, Zahlen und ein Symbol.",
+      "acceptTerms": "Ich akzeptiere die <terms>AGB</terms> und die <privacy>Datenschutzerklärung</privacy>.",
+      "submit": "Konto erstellen →",
+      "submitting": "Konto wird erstellt...",
+      "footer": "Schon ein Konto? <signInLink>Anmelden</signInLink>",
+      "errors": {
+        "email_taken": "Es gibt schon ein Konto mit dieser E-Mail. Versuche dich anzumelden.",
+        "name_too_short": "Mindestens 2 Zeichen.",
+        "name_too_long": "Maximal 120 Zeichen.",
+        "email_required": "E-Mail ist erforderlich.",
+        "email_invalid": "Ungültige E-Mail.",
+        "email_too_long": "E-Mail zu lang.",
+        "password_too_short": "Mindestens 8 Zeichen.",
+        "password_too_long": "Zu lang.",
+        "terms_required": "Du musst die AGB akzeptieren, um fortzufahren.",
+        "generic": "Wir konnten dein Konto nicht erstellen. Versuche es erneut."
+      },
+      "hero": {
+        "eyebrow": "DREI SCHRITTE · ANDERTHALB TAGE",
+        "title": "Vom neuen Konto zum Live-Event <accent>in Tagen</accent>.",
+        "step1Title": "Konto erstellen",
+        "step1Time": "Jetzt sofort · 1 Min.",
+        "step2Title": "Als Creator bewerben",
+        "step2Time": "Wir prüfen · 1-2 Tage.",
+        "step3Title": "Erstes Event veröffentlichen",
+        "step3Time": "Wann du willst · 3 Min.",
+        "support": "Wir sind in Berlin und antworten auf Spanisch, Englisch und Deutsch. Bei Fragen <contactLink>schreib uns</contactLink>."
+      }
     }
   },
   "common": {

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -435,19 +435,37 @@
     }
   },
   "auth": {
-    "signIn": "Anmelden",
-    "signUp": "Registrieren",
-    "email": "E-Mail",
-    "password": "Passwort",
-    "name": "Vollständiger Name",
-    "continueWithGoogle": "Mit Google fortfahren",
-    "pendingTitle": "Konto wird geprüft",
-    "pendingDescription": "Ihr Konto wird vom Team geprüft. Wir benachrichtigen Sie per E-Mail, wenn es genehmigt wurde.",
-    "blockedTitle": "Konto gesperrt",
-    "blockedDescription": "Ihr Konto wurde gesperrt. Kontaktieren Sie den Administrator.",
-    "noAccount": "Noch kein Konto?",
-    "haveAccount": "Schon ein Konto?",
-    "backHome": "Zur Startseite"
+    "signIn": {
+      "metaTitle": "Anmelden",
+      "eyebrow": "WILLKOMMEN ZURÜCK",
+      "title": "Melde dich an.",
+      "subtitle": "Nur zum Stöbern hier? Du brauchst kein Konto, um Shows zu sehen. Das hier ist für Künstler und Veranstalter.",
+      "continueWith": "Mit {provider} fortfahren",
+      "orEmail": "ODER MIT E-MAIL",
+      "emailLabel": "E-Mail",
+      "emailPlaceholder": "du@email.de",
+      "passwordLabel": "Passwort",
+      "passwordPlaceholder": "Dein Passwort",
+      "forgot": "Passwort vergessen?",
+      "submit": "Anmelden →",
+      "submitting": "Anmeldung läuft...",
+      "footer": "Zum ersten Mal hier? <createAccount>Konto erstellen</createAccount> oder <applyAsArtist>als Künstler bewerben →</applyAsArtist>",
+      "errors": {
+        "credentials": "E-Mail oder Passwort falsch.",
+        "email_required": "E-Mail ist erforderlich.",
+        "email_invalid": "Ungültige E-Mail.",
+        "email_too_long": "E-Mail zu lang.",
+        "password_too_short": "Mindestens 8 Zeichen.",
+        "password_too_long": "Zu lang.",
+        "generic": "Anmeldung fehlgeschlagen. Versuche es gleich noch einmal."
+      },
+      "hero": {
+        "eyebrow": "LIVE · LATEINAMERIKANISCHE MUSIK · DEUTSCHLAND",
+        "title": "Gemacht von einem <accent>von euch</accent>.",
+        "body": "La Huella ist ein unabhängiges Portal. Wir verkaufen keine Tickets, wir nehmen keine Provision. Wir zeigen einfach, was läuft.",
+        "statsFormat": "{shows} KOMMENDE SHOWS · {cities} STÄDTE"
+      }
+    }
   },
   "common": {
     "save": "Speichern",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -457,6 +457,8 @@
   "auth": {
     "signIn": {
       "metaTitle": "Anmelden",
+      "formAriaLabel": "Anmeldeformular",
+      "heroAriaLabel": "Manifest und Agenda",
       "eyebrow": "WILLKOMMEN ZURÜCK",
       "title": "Melde dich an.",
       "subtitle": "Nur zum Stöbern hier? Du brauchst kein Konto, um Shows zu sehen. Das hier ist für Künstler und Veranstalter.",
@@ -488,6 +490,8 @@
     },
     "signUp": {
       "metaTitle": "Konto erstellen",
+      "formAriaLabel": "Registrierungsformular",
+      "heroAriaLabel": "Schritte des Ablaufs",
       "eyebrow": "KONTO ERSTELLEN",
       "title": "Fang an zu <accent>veröffentlichen.</accent>",
       "subtitle": "Konto erstellen ist der erste Schritt. Dann bewirbst du dich als Creator und wir prüfen dein Profil — meistens 1-2 Tage.",
@@ -530,6 +534,7 @@
     }
   },
   "account": {
+    "signOutError": "Abmeldung fehlgeschlagen. Versuche es erneut.",
     "pending": {
       "metaTitle": "Konto wird geprüft",
       "eyebrow": "KONTO WIRD GEPRÜFT",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -73,8 +73,28 @@
     "messagePlaceholder": "Wer bist du? Welche Art von Events organisierst du oder in welcher Stadt trittst du auf? Je mehr du uns erzählst, desto besser können wir es beurteilen.",
     "messageHint": "Mindestens 10 Zeichen.",
     "submit": "Anfrage senden",
-    "successTitle": "Anfrage gesendet!",
-    "successBody": "Wir prüfen deine Anfrage und melden uns per E-Mail. Das dauert in der Regel weniger als 48 Stunden."
+    "submitted": {
+      "badge": "✓ ANFRAGE ERHALTEN",
+      "title": "Wir haben deine Anfrage erhalten, <accent>Wandersleute.</accent>",
+      "body": "Ein Mensch schaut sie sich in den nächsten 1-2 Tagen an. Wenn alles passt, melden wir uns per E-Mail und schalten dein Panel zum Veröffentlichen frei.",
+      "ctaPrimary": "Inzwischen die Agenda ansehen →",
+      "ctaSecondary": "Zur Startseite",
+      "instagramHint": "In der Zwischenzeit: folge uns auf <ig>Instagram @lahuelladelcaminante</ig> — wir posten, wenn wir einen neuen Creator freischalten.",
+      "timeline": {
+        "title": "WAS PASSIERT ALS NÄCHSTES",
+        "received": "Empfangen",
+        "receivedSub": "Gerade eben",
+        "reviewing": "In Prüfung",
+        "reviewingSub": "Ein Mensch schaut sich dein Profil an",
+        "reviewingWhen": "≈ 1-2 Tage",
+        "approval": "Genehmigt · E-Mail",
+        "approvalSub": "Du bekommst eine E-Mail mit dem Link zu deinem Panel",
+        "approvalWhen": "Wenn wir genehmigen",
+        "publishing": "Veröffentlichen",
+        "publishingSub": "Lade dein erstes Event hoch",
+        "publishingWhen": "Wann immer du bereit bist"
+      }
+    }
   },
   "events": {
     "title": "Kommende Veranstaltungen",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -529,6 +529,18 @@
       }
     }
   },
+  "account": {
+    "pending": {
+      "metaTitle": "Konto wird geprüft",
+      "eyebrow": "KONTO WIRD GEPRÜFT",
+      "title": "Deine Anfrage wird <accent>gerade gebacken.</accent>",
+      "bodyWithDate": "Du hast dich am <strong>{date}</strong> als Creator beworben. Wir prüfen in Reihenfolge — meistens 1-2 Werktage. Wir melden uns per E-Mail, sobald es genehmigt ist.",
+      "bodyNoDate": "Wir prüfen in Reihenfolge — meistens 1-2 Werktage. Wir melden uns per E-Mail, sobald es genehmigt ist.",
+      "ctaPrimary": "Öffentliche Agenda ansehen",
+      "ctaSecondary": "Abmelden",
+      "escapeHatch": "Mehr als 3 Tage und keine Antwort? Da ist was kaputt. <contactLink>Schreib uns</contactLink> und wir lösen das."
+    }
+  },
   "common": {
     "save": "Speichern",
     "cancel": "Abbrechen",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -539,6 +539,18 @@
       "ctaPrimary": "Öffentliche Agenda ansehen",
       "ctaSecondary": "Abmelden",
       "escapeHatch": "Mehr als 3 Tage und keine Antwort? Da ist was kaputt. <contactLink>Schreib uns</contactLink> und wir lösen das."
+    },
+    "blocked": {
+      "metaTitle": "Zugang gesperrt",
+      "eyebrow": "ZUGANG GESPERRT",
+      "title": "Dein Konto hat keinen Zugriff auf das Panel.",
+      "body": "Das kann mehrere Gründe haben — Verstoß gegen die Community-Regeln, gemeldete Inhalte, oder ein Fehler von uns. Wenn du denkst, es ist ein Fehler, lass uns reden.",
+      "ctaContact": "Schreib uns →",
+      "ctaLogout": "Abmelden",
+      "stillWorksTitle": "WAS NOCH FUNKTIONIERT",
+      "canSee": "Du kannst weiterhin alle öffentlichen Events der Seite sehen.",
+      "canBrowse": "Du kannst weiterhin Künstlerprofile ansehen.",
+      "cannot": "Du kannst nicht veröffentlichen, bearbeiten oder auf das Creator-Panel zugreifen."
     }
   },
   "common": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -529,6 +529,18 @@
       }
     }
   },
+  "account": {
+    "pending": {
+      "metaTitle": "Account under review",
+      "eyebrow": "ACCOUNT UNDER REVIEW",
+      "title": "Your request is <accent>warming up in the oven.</accent>",
+      "bodyWithDate": "You applied as a creator on <strong>{date}</strong>. We review in order of arrival — usually 1-2 business days. We'll email you the moment it's approved.",
+      "bodyNoDate": "We review in order of arrival — usually 1-2 business days. We'll email you the moment it's approved.",
+      "ctaPrimary": "Browse the public agenda",
+      "ctaSecondary": "Sign out",
+      "escapeHatch": "More than 3 days and no reply? Something broke. <contactLink>Write us</contactLink> and we'll sort it out."
+    }
+  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -457,6 +457,8 @@
   "auth": {
     "signIn": {
       "metaTitle": "Sign in",
+      "formAriaLabel": "Sign-in form",
+      "heroAriaLabel": "Manifesto and agenda",
       "eyebrow": "WELCOME BACK",
       "title": "Sign in.",
       "subtitle": "Just here to browse? You don't need an account to see shows. This is for artists and organizers.",
@@ -488,6 +490,8 @@
     },
     "signUp": {
       "metaTitle": "Create account",
+      "formAriaLabel": "Sign-up form",
+      "heroAriaLabel": "Process steps",
       "eyebrow": "CREATE ACCOUNT",
       "title": "Start <accent>publishing.</accent>",
       "subtitle": "Creating an account is step one. Then you apply as a creator and we review your profile — usually 1-2 days.",
@@ -530,6 +534,7 @@
     }
   },
   "account": {
+    "signOutError": "Couldn't sign you out. Try again.",
     "pending": {
       "metaTitle": "Account under review",
       "eyebrow": "ACCOUNT UNDER REVIEW",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -465,6 +465,48 @@
         "body": "La Huella is an independent portal. We don't sell tickets, we don't take a cut. We just show what's playing.",
         "statsFormat": "{shows} UPCOMING SHOWS · {cities} CITIES"
       }
+    },
+    "signUp": {
+      "metaTitle": "Create account",
+      "eyebrow": "CREATE ACCOUNT",
+      "title": "Start <accent>publishing.</accent>",
+      "subtitle": "Creating an account is step one. Then you apply as a creator and we review your profile — usually 1-2 days.",
+      "continueWith": "Continue with {provider}",
+      "orEmail": "OR WITH EMAIL",
+      "nameLabel": "Name",
+      "namePlaceholder": "What should we call you",
+      "emailLabel": "Email",
+      "emailPlaceholder": "you@email.com",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Create a password",
+      "passwordHint": "Mix uppercase, numbers and a symbol.",
+      "acceptTerms": "I accept the <terms>terms</terms> and the <privacy>privacy policy</privacy>.",
+      "submit": "Create account →",
+      "submitting": "Creating account...",
+      "footer": "Already have an account? <signInLink>Sign in</signInLink>",
+      "errors": {
+        "email_taken": "There's already an account with that email. Try signing in.",
+        "name_too_short": "At least 2 characters.",
+        "name_too_long": "Maximum 120 characters.",
+        "email_required": "Email is required.",
+        "email_invalid": "Invalid email.",
+        "email_too_long": "Email too long.",
+        "password_too_short": "At least 8 characters.",
+        "password_too_long": "Too long.",
+        "terms_required": "You need to accept the terms to continue.",
+        "generic": "We couldn't create your account. Try again."
+      },
+      "hero": {
+        "eyebrow": "THREE STEPS · ONE AND A HALF DAYS",
+        "title": "From new account to live event <accent>in days</accent>.",
+        "step1Title": "Create the account",
+        "step1Time": "Right now · 1 min.",
+        "step2Title": "Apply as a creator",
+        "step2Time": "We review · 1-2 days.",
+        "step3Title": "Publish your first event",
+        "step3Time": "Whenever · 3 min.",
+        "support": "We're based in Berlin and respond in Spanish, English and German. If you have questions, <contactLink>write us</contactLink>."
+      }
     }
   },
   "common": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -73,8 +73,28 @@
     "messagePlaceholder": "Who are you? What kind of events do you organize or where do you perform? The more you tell us, the better we can evaluate.",
     "messageHint": "Minimum 10 characters.",
     "submit": "Send request",
-    "successTitle": "Request sent!",
-    "successBody": "We'll review your request and reach out to the email you provided. It usually takes less than 48 hours."
+    "submitted": {
+      "badge": "✓ REQUEST RECEIVED",
+      "title": "We got your request, <accent>wanderer.</accent>",
+      "body": "A human reviews it in the next 1-2 days. If everything checks out, we email you and unlock your panel so you can publish.",
+      "ctaPrimary": "Browse the agenda meanwhile →",
+      "ctaSecondary": "Back to home",
+      "instagramHint": "Meanwhile: follow us on <ig>Instagram @lahuelladelcaminante</ig> — we post every time we approve a new creator.",
+      "timeline": {
+        "title": "WHAT'S NEXT",
+        "received": "Received",
+        "receivedSub": "Just now",
+        "reviewing": "Under review",
+        "reviewingSub": "A human is looking at your profile",
+        "reviewingWhen": "≈ 1-2 days",
+        "approval": "Approved · email",
+        "approvalSub": "You'll get an email with the link to your panel",
+        "approvalWhen": "When we approve",
+        "publishing": "Publish",
+        "publishingSub": "Upload your first event",
+        "publishingWhen": "Whenever you're ready"
+      }
+    }
   },
   "events": {
     "title": "Upcoming Events",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -539,6 +539,18 @@
       "ctaPrimary": "Browse the public agenda",
       "ctaSecondary": "Sign out",
       "escapeHatch": "More than 3 days and no reply? Something broke. <contactLink>Write us</contactLink> and we'll sort it out."
+    },
+    "blocked": {
+      "metaTitle": "Access suspended",
+      "eyebrow": "ACCESS SUSPENDED",
+      "title": "Your account can't access the panel.",
+      "body": "This can happen for several reasons — community-rules violation, reported content, or a mistake on our end. If you think it's a mistake, let's talk.",
+      "ctaContact": "Write to us →",
+      "ctaLogout": "Sign out",
+      "stillWorksTitle": "WHAT STILL WORKS",
+      "canSee": "You can still see all the public events on the site.",
+      "canBrowse": "You can still browse artist profiles.",
+      "cannot": "You can't publish, edit or access the creator panel."
     }
   },
   "common": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -435,19 +435,37 @@
     }
   },
   "auth": {
-    "signIn": "Sign In",
-    "signUp": "Sign Up",
-    "email": "Email",
-    "password": "Password",
-    "name": "Full name",
-    "continueWithGoogle": "Continue with Google",
-    "pendingTitle": "Account under review",
-    "pendingDescription": "Your account is being reviewed by the team. We will notify you by email when it is approved.",
-    "blockedTitle": "Account suspended",
-    "blockedDescription": "Your account has been suspended. Contact the administrator.",
-    "noAccount": "Don't have an account?",
-    "haveAccount": "Already have an account?",
-    "backHome": "Back to home"
+    "signIn": {
+      "metaTitle": "Sign in",
+      "eyebrow": "WELCOME BACK",
+      "title": "Sign in.",
+      "subtitle": "Just here to browse? You don't need an account to see shows. This is for artists and organizers.",
+      "continueWith": "Continue with {provider}",
+      "orEmail": "OR WITH EMAIL",
+      "emailLabel": "Email",
+      "emailPlaceholder": "you@email.com",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Your password",
+      "forgot": "Forgot your password?",
+      "submit": "Sign in →",
+      "submitting": "Signing in...",
+      "footer": "First time here? <createAccount>Create account</createAccount> or <applyAsArtist>apply as an artist →</applyAsArtist>",
+      "errors": {
+        "credentials": "Wrong email or password.",
+        "email_required": "Email is required.",
+        "email_invalid": "Invalid email.",
+        "email_too_long": "Email too long.",
+        "password_too_short": "At least 8 characters.",
+        "password_too_long": "Too long.",
+        "generic": "Sign-in failed. Try again in a moment."
+      },
+      "hero": {
+        "eyebrow": "LIVE · LATIN MUSIC · GERMANY",
+        "title": "Made by one <accent>of you</accent>.",
+        "body": "La Huella is an independent portal. We don't sell tickets, we don't take a cut. We just show what's playing.",
+        "statsFormat": "{shows} UPCOMING SHOWS · {cities} CITIES"
+      }
+    }
   },
   "common": {
     "save": "Save",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -73,8 +73,28 @@
     "messagePlaceholder": "¿Quién sos? ¿Qué tipo de eventos organizás o en qué ciudad tocás? Cuanto más nos contés, mejor podemos evaluarlo.",
     "messageHint": "Mínimo 10 caracteres.",
     "submit": "Enviar solicitud",
-    "successTitle": "¡Solicitud enviada!",
-    "successBody": "Revisamos tu solicitud y te escribimos al email que dejaste. Suele tardar menos de 48 horas."
+    "submitted": {
+      "badge": "✓ SOLICITUD RECIBIDA",
+      "title": "Recibimos tu solicitud, <accent>caminante.</accent>",
+      "body": "Un humano la mira en los próximos 1-2 días. Si todo da, te avisamos por mail y desbloqueamos tu panel para que publiques.",
+      "ctaPrimary": "Ver agenda mientras tanto →",
+      "ctaSecondary": "Volver al inicio",
+      "instagramHint": "Mientras tanto: seguinos en <ig>Instagram @lahuelladelcaminante</ig> — ahí avisamos cada vez que aprobamos un creator nuevo.",
+      "timeline": {
+        "title": "QUÉ SIGUE",
+        "received": "Recibida",
+        "receivedSub": "Hace un momento",
+        "reviewing": "En revisión",
+        "reviewingSub": "Un humano mira tu perfil",
+        "reviewingWhen": "≈ 1-2 días",
+        "approval": "Aprobada · email",
+        "approvalSub": "Te llega un mail con el link a tu panel",
+        "approvalWhen": "Cuando aprobemos",
+        "publishing": "Publicás",
+        "publishingSub": "Subís tu primer evento",
+        "publishingWhen": "Cuando estés"
+      }
+    }
   },
   "events": {
     "title": "Próximos Eventos",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -457,6 +457,8 @@
   "auth": {
     "signIn": {
       "metaTitle": "Iniciar sesión",
+      "formAriaLabel": "Formulario de inicio de sesión",
+      "heroAriaLabel": "Manifiesto y agenda",
       "eyebrow": "BIENVENIDO DE VUELTA",
       "title": "Iniciá sesión.",
       "subtitle": "¿Sos público? No necesitás cuenta para ver shows. Esto es para artistas y organizadores.",
@@ -488,6 +490,8 @@
     },
     "signUp": {
       "metaTitle": "Crear cuenta",
+      "formAriaLabel": "Formulario de registro",
+      "heroAriaLabel": "Pasos del proceso",
       "eyebrow": "CREAR CUENTA",
       "title": "Empezá a <accent>publicar.</accent>",
       "subtitle": "Crear cuenta es el primer paso. Después aplicás como creator y revisamos tu perfil — suele tomar 1-2 días.",
@@ -530,6 +534,7 @@
     }
   },
   "account": {
+    "signOutError": "No pudimos cerrar tu sesión. Probá de nuevo.",
     "pending": {
       "metaTitle": "Cuenta en revisión",
       "eyebrow": "CUENTA EN REVISIÓN",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -539,6 +539,18 @@
       "ctaPrimary": "Ver agenda pública",
       "ctaSecondary": "Cerrar sesión",
       "escapeHatch": "¿Pasaron más de 3 días y no tuviste respuesta? Algo se rompió. <contactLink>Escribinos</contactLink> y lo resolvemos."
+    },
+    "blocked": {
+      "metaTitle": "Acceso suspendido",
+      "eyebrow": "ACCESO SUSPENDIDO",
+      "title": "Tu cuenta no puede acceder al panel.",
+      "body": "Esto puede pasar por varias razones — incumplimiento de las normas de la comunidad, contenido reportado, o un error nuestro. Si creés que es un error, hablamos.",
+      "ctaContact": "Escribirnos →",
+      "ctaLogout": "Cerrar sesión",
+      "stillWorksTitle": "QUÉ SIGUE FUNCIONANDO",
+      "canSee": "Podés ver todos los eventos públicos del sitio.",
+      "canBrowse": "Podés seguir consultando perfiles de artistas.",
+      "cannot": "No podés publicar, editar ni acceder al panel creator."
     }
   },
   "common": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -529,6 +529,18 @@
       }
     }
   },
+  "account": {
+    "pending": {
+      "metaTitle": "Cuenta en revisión",
+      "eyebrow": "CUENTA EN REVISIÓN",
+      "title": "Tu solicitud está <accent>prendida y se está horneando.</accent>",
+      "bodyWithDate": "Aplicaste como creator el <strong>{date}</strong>. La revisamos en orden de llegada — solemos tardar 1-2 días hábiles. Te avisamos por mail apenas se apruebe.",
+      "bodyNoDate": "La revisamos en orden de llegada — solemos tardar 1-2 días hábiles. Te avisamos por mail apenas se apruebe.",
+      "ctaPrimary": "Ver agenda pública",
+      "ctaSecondary": "Cerrar sesión",
+      "escapeHatch": "¿Pasaron más de 3 días y no tuviste respuesta? Algo se rompió. <contactLink>Escribinos</contactLink> y lo resolvemos."
+    }
+  },
   "common": {
     "save": "Guardar",
     "cancel": "Cancelar",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -435,19 +435,37 @@
     }
   },
   "auth": {
-    "signIn": "Iniciar Sesión",
-    "signUp": "Registrarse",
-    "email": "Email",
-    "password": "Contraseña",
-    "name": "Nombre completo",
-    "continueWithGoogle": "Continuar con Google",
-    "pendingTitle": "Cuenta en revisión",
-    "pendingDescription": "Tu cuenta está siendo revisada por el equipo. Te notificaremos por email cuando sea aprobada.",
-    "blockedTitle": "Cuenta suspendida",
-    "blockedDescription": "Tu cuenta ha sido suspendida. Contacta al administrador.",
-    "noAccount": "¿No tienes cuenta?",
-    "haveAccount": "¿Ya tienes cuenta?",
-    "backHome": "Volver al inicio"
+    "signIn": {
+      "metaTitle": "Iniciar sesión",
+      "eyebrow": "BIENVENIDO DE VUELTA",
+      "title": "Iniciá sesión.",
+      "subtitle": "¿Sos público? No necesitás cuenta para ver shows. Esto es para artistas y organizadores.",
+      "continueWith": "Continuar con {provider}",
+      "orEmail": "O CON EMAIL",
+      "emailLabel": "Email",
+      "emailPlaceholder": "vos@email.com",
+      "passwordLabel": "Contraseña",
+      "passwordPlaceholder": "Tu contraseña",
+      "forgot": "¿Olvidaste tu contraseña?",
+      "submit": "Iniciar sesión →",
+      "submitting": "Iniciando sesión...",
+      "footer": "¿Primera vez por acá? <createAccount>Crear cuenta</createAccount> o <applyAsArtist>aplicá como artista →</applyAsArtist>",
+      "errors": {
+        "credentials": "Email o contraseña incorrectos.",
+        "email_required": "El email es obligatorio.",
+        "email_invalid": "Email inválido.",
+        "email_too_long": "Email demasiado largo.",
+        "password_too_short": "Mínimo 8 caracteres.",
+        "password_too_long": "Demasiado largo.",
+        "generic": "No pudimos iniciar sesión. Probá de nuevo."
+      },
+      "hero": {
+        "eyebrow": "EN VIVO · MÚSICA LATINA · ALEMANIA",
+        "title": "Hecho por uno <accent>de ustedes</accent>.",
+        "body": "La Huella es un portal independiente. No vendemos entradas, no tomamos comisión. Solo mostramos lo que está sonando.",
+        "statsFormat": "{shows} SHOWS PRÓXIMOS · {cities} CIUDADES"
+      }
+    }
   },
   "common": {
     "save": "Guardar",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -465,6 +465,48 @@
         "body": "La Huella es un portal independiente. No vendemos entradas, no tomamos comisión. Solo mostramos lo que está sonando.",
         "statsFormat": "{shows} SHOWS PRÓXIMOS · {cities} CIUDADES"
       }
+    },
+    "signUp": {
+      "metaTitle": "Crear cuenta",
+      "eyebrow": "CREAR CUENTA",
+      "title": "Empezá a <accent>publicar.</accent>",
+      "subtitle": "Crear cuenta es el primer paso. Después aplicás como creator y revisamos tu perfil — suele tomar 1-2 días.",
+      "continueWith": "Continuar con {provider}",
+      "orEmail": "O CON EMAIL",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "Cómo te llamamos",
+      "emailLabel": "Email",
+      "emailPlaceholder": "vos@email.com",
+      "passwordLabel": "Contraseña",
+      "passwordPlaceholder": "Creá una contraseña",
+      "passwordHint": "Mezclá mayúsculas, números y un símbolo.",
+      "acceptTerms": "Acepto los <terms>términos</terms> y la <privacy>política de privacidad</privacy>.",
+      "submit": "Crear cuenta →",
+      "submitting": "Creando cuenta...",
+      "footer": "¿Ya tenés cuenta? <signInLink>Iniciar sesión</signInLink>",
+      "errors": {
+        "email_taken": "Ya hay una cuenta con ese email. Probá iniciar sesión.",
+        "name_too_short": "Mínimo 2 caracteres.",
+        "name_too_long": "Máximo 120 caracteres.",
+        "email_required": "El email es obligatorio.",
+        "email_invalid": "Email inválido.",
+        "email_too_long": "Email demasiado largo.",
+        "password_too_short": "Mínimo 8 caracteres.",
+        "password_too_long": "Demasiado largo.",
+        "terms_required": "Tenés que aceptar los términos para continuar.",
+        "generic": "No pudimos crear tu cuenta. Probá de nuevo."
+      },
+      "hero": {
+        "eyebrow": "TRES PASOS · UN DÍA Y MEDIO",
+        "title": "De cuenta nueva a evento <accent>en vivo</accent>.",
+        "step1Title": "Creás la cuenta",
+        "step1Time": "Ahora mismo · 1 min.",
+        "step2Title": "Aplicás como creator",
+        "step2Time": "Nosotros revisamos · 1-2 días.",
+        "step3Title": "Publicás tu primer evento",
+        "step3Time": "Cuando quieras · 3 min.",
+        "support": "Vivimos en Berlín y respondemos en español, inglés y alemán. Si tenés dudas, <contactLink>escribinos</contactLink>."
+      }
     }
   },
   "common": {


### PR DESCRIPTION
## Resumen

Rediseño completo de las 5 pantallas de auth/cuenta siguiendo el handoff canónico [`docs/design/DESIGN_HANDOFF_OUTPUT_v2.md`](docs/design/DESIGN_HANDOFF_OUTPUT_v2.md):

1. **`/sign-in`** — split 7:5 desktop con form izq + panel editorial der (manifiesto + 3 thumbnails de eventos reales + stats). Form: Google OAuth + email/password + "olvidé mi contraseña" → `/contact` (TODO hasta que exista `/forgot-password`).
2. **`/sign-up`** — split 7:5 con form (name + email + password + checkbox de términos) + 3 step cards del journey en hero derecho.
3. **Pantalla post-submit de `/apply`** — extraída a `ApplySubmittedScreen` con timeline de 4 estados (`✓ Recibida` → `● En revisión` → `○ Aprobada · email` → `○ Publicás`). El timestamp del primer paso usa el momento real del submit.
4. **`/user-pending`** — bombilla glow editorial + fecha de aplicación interpolada (degrada a copy sin fecha si no hay `Application` matching).
5. **`/user-blocked`** — sello sangre + bloque "QUÉ SIGUE FUNCIONANDO" que aclara que solo está bloqueado el panel creator, no el sitio entero.

## Lo que **no** se modificó

- **Lógica de Better Auth** (`src/lib/auth.ts`, `src/lib/auth-client.ts`) — intacta. Solo el form consume `signIn.email`/`.social`/`signUp.email`/`signOut` con error mapping mejorado.
- **Lógica del form de `/apply`** — el `handleSubmit`, validación HTML, fetch a `/api/apply` quedan iguales. Solo cambié el render del `if (sent)` y el state `sent: bool` → `submittedAt: Date | null` para guardar el timestamp del timeline.
- **Header global, dashboard, admin panel, schema de Prisma, middleware.**

## Decisiones cerradas

- **Copy NO menciona nombres de admins** — "un humano" / "el equipo" / "nosotros". Decisión documentada en `StepTimeline.reviewingSub` y verificada por reviewer.
- **Sin checkbox "Mantener sesión"** — Better Auth maneja la persistencia transparentemente.
- **Sin nuevas dependencias.**
- **Sin shadcn nuevo** — checkbox de términos es `<input type="checkbox">` inline (única instancia del PR; bikeshed prematuro crear componente reusable).
- **Link a `/contact`** — funcional desde PR #20 (no TODO). Usado en SignInForm "olvidé contraseña", SignUpForm support, UserPendingPage escape hatch, UserBlockedPage CTA primario.
- **Layout dedicado `(auth)/layout.tsx`** — sin Header global. Decisión: menos invasivo que agregar variant al Header global (que es client crítico con `useSession`).
- **GoogleGlyph custom** — "G" mono en círculo, NO logo cuatricromático oficial (decisión del handoff §3.3 por licencia + sistema visual).
- **Mini agenda en `/sign-in`** — 3 thumbnails reales con `getFeaturedEvents(3)` + stats reales con `getUpcomingStats()`. Ambas cacheadas 5 min con `unstable_cache`.

## ⚠️ DE translations — review pendiente

Las traducciones alemanas fueron **inventadas** por el dev (no nativo). Conservan estructura y tono pero pueden necesitar pasada nativa. Keys que requieren review:

- `auth.signIn.*` (incl. `.hero.*`, `.errors.*`) — `messages/de.json:437-485`
- `auth.signUp.*` (incl. `.hero.*`, `.errors.*`) — `messages/de.json:486-531`
- `apply.submitted.*` (incl. `.timeline.*`) — `messages/de.json:76-99`
- `account.pending.*` — `messages/de.json:534-544`
- `account.blocked.*` — `messages/de.json:545-557`

Términos delicados: `bewerben` vs `anfragen`, `Creator` (anglicismo aceptado), `Panel` (anglicismo), `Wandersleute` (cierre afectivo de "caminante"), `Konto wird gerade gebacken` (metáfora de horneando), `AGB` vs `Nutzungsbedingungen`. Cualquier ajuste va en un commit chico aparte.

## Commits

```
b3860e4 feat(auth): shared shell + form helpers + Google glyph + validators
8305dda feat(auth): rewrite /sign-in with AuthShell + editorial panel
f5b8789 feat(auth): rewrite /sign-up with 3-step hero + terms checkbox
3c05191 feat(apply): editorial submitted screen with QUÉ SIGUE timeline
c78833b feat(account): rewrite /user-pending with glow hero + application date
1ba7a0e feat(account): rewrite /user-blocked with sello + still-works block
548148e fix(dashboard): complete ArtistDetail shape on artist edit page
ce9a35a chore(auth): apply architecture review feedback
```

## Nota sobre `548148e` (fix bonus fuera de scope)

`next build` en `main` venía fallando con `TS2739` por un shape incompleto de `ArtistDetail` en `dashboard/artists/[id]/edit/page.tsx` (regresión inherited de PR 8 — faltaban `coverImagePublicId` y `coverImageAlt`). Sin este fix, el CI de esta PR también iba a romper sin permitirme verificar el build. Aislado a un solo commit con scope claro; **si CR prefiere separarlo en otra PR, rebase es trivial**.

## Notas sobre `/user-pending`

El hook `databaseHooks.user.create.after` en `src/lib/auth.ts` hoy siempre escribe `status: ACTIVE` (tanto si hay Application aprobada como si no). En la práctica, esta pantalla solo se renderiza si un admin pone status `PENDING` manualmente en DB. Arreglar ese hook está **fuera del scope** de esta PR (toca lógica de Better Auth — explícitamente prohibido). La pantalla queda lista para cuando ese fix se haga en otro PR.

## Deudas anotadas en `BACKLOG.md`

El architecture-reviewer detectó deuda inherited de Prisma que esta PR consolida en hot path:
- `Application.email` sin `@@index` + `status: String` sin enum (`@@index([email])` + `enum ApplicationStatus`).

Anotado bajo "Deudas de seguridad y privacidad" → "Prisma — index en `Application.email` + enum para `Application.status`".

## Test plan

- [ ] `/sign-in` desktop ES/EN/DE: split 7:5 visible, 3 thumbnails de eventos reales se cargan, stats correctos.
- [ ] `/sign-in` mobile: solo form, panel oculto, BrandLockup + LanguageSwitcher en header.
- [ ] `/sign-in` con credenciales incorrectas: toast amigable ("Email o contraseña incorrectos"), NO mensaje técnico.
- [ ] `/sign-in` con Google: redirect funciona, vuelve a `/dashboard` post-login.
- [ ] `/sign-up` desktop: split, 3 step cards a la derecha, checkbox de términos required.
- [ ] `/sign-up` con email duplicado: toast amigable ("Ya hay una cuenta con ese email").
- [ ] `/apply` submit exitoso → muestra pantalla "Solicitud enviada" con timeline; "Recibida" tiene timestamp real.
- [ ] Como user PENDING (forzar en DB): `/user-pending` muestra fecha de aplicación si hay match, sino variante `bodyNoDate`.
- [ ] Como user BLOCKED (forzar en DB): `/user-blocked` muestra bloque "qué sigue funcionando" + CTA a `/contact`.
- [ ] Como anónimo entrando a `/user-pending` o `/user-blocked`: redirect a `/sign-in`.
- [ ] Sign-out desde `/user-pending` y `/user-blocked`: redirige a `/`, cookie limpia, back del browser no vuelve.
- [ ] Cambio de idioma desde cada auth screen: mantiene la pantalla, cambia copy.
- [ ] Sin warnings de missing-key en consola al cambiar idioma.
- [ ] `npm run build` pasa sin errores.
- [ ] CodeRabbit pasa sin actionables MAJOR/CRITICAL.

## Verificación visual sugerida

Disponer de un user con cada estado (`PENDING`, `BLOCKED`, `ACTIVE`) para recorrer el flujo completo. Si no hay, forzar manualmente en `UserProfile.status` desde Prisma Studio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-rendered sign-in and sign-up pages with new auth forms and accessibility improvements
  * Google OAuth sign-in and new auth UI components (buttons, glyphs, field/layout primitives)
  * Application submission confirmation screen with a multi-step timeline and timestamp
  * Redesigned account status screens (pending/blocked) with clearer CTAs and sign-out flow

* **Documentation**
  * Backlog entry added for planned application-model migration and indexing
  * Updated localization copy for English, German, and Spanish UIs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->