### PR TITLE
chore: backend hardening (account flow, rate limit, security headers, prisma)

### DIFF
--- a/docs/design/BACKLOG.md
+++ b/docs/design/BACKLOG.md
@@ -69,80 +69,44 @@ operamos en gris legal contra GDPR/DSGVO al servir desde Alemania.
 
 Bloquea poder operar legítimamente en mercado DE a mediano plazo.
 
-### Rate limit IP-based para `/api/contact` — prioridad MEDIA
+### Bonus: FK `Application.userId` — prioridad BAJA
 
-**Origen:** PR 8.5 (`/contact`).
+**Origen:** PR de auth (`feat/redesign-auth-screens`); fragmento
+remanente del item Prisma resuelto en PR #23.
 
-El endpoint hoy se defiende con honeypot + Origin/Referer check, pero no
-hay límite por IP. Un atacante con backend propio (sin browser) que
-bypassee Origin/Referer puede hacer flood al endpoint y agotar quota de
-Resend (afecta uptime del email de aprobaciones/welcome, no solo el
-form de contacto).
+El matching User ↔ Application sigue siendo por email (el hook
+`user.create.after` y el endpoint admin approve buscan por
+`Application.email`). Si un user cambia email entre aplicar y crear
+cuenta, el match se rompe silenciosamente.
 
-- Implementar middleware o helper que use `headers().get("x-forwarded-for")`
-  (cuidado con spoofing — confiar solo en el header agregado por nginx,
-  no en el del cliente).
-- Storage del contador: edge-compatible KV (Upstash/Vercel KV) o tabla
-  Postgres con TTL si no agregamos infra. Postgres es más barato pero
-  agrega latencia al endpoint.
-- Política sugerida: 5 requests por IP por hora. Después devolver 429
-  con `Retry-After`.
-- Mismo helper se puede reusar en `/api/applications/submit` y futuros
-  endpoints públicos.
+- Agregar `userId String?` + `user User? @relation(...)` opcional al
+  modelo Application.
+- Popular el campo cuando el user crea cuenta con email matching.
+- Mantener el matching por email como fallback (cuentas creadas antes
+  de la migración no van a tener `userId`).
+- Cambiar el hook y `/api/apply/[id]` para preferir `userId` cuando
+  esté presente.
 
-### Prisma — index en `Application.email` + enum para `Application.status` — prioridad MEDIA
+## Resueltos
 
-**Origen:** PR de auth (`feat/redesign-auth-screens`). El review de
-arquitectura detectó deuda inherited que esta PR consolida.
+### ~~Rate limit IP-based para `/api/contact` — prioridad MEDIA~~
 
-Dos consumidores hoy hacen `Application.findFirst({ where: { email } })`:
-el hook `databaseHooks.user.create.after` en `src/lib/auth.ts` (corre
-en cada signup) y la nueva pantalla `/user-pending` (corre en cada
-visita). El modelo `Application` no tiene `@@index([email])` —
-seq-scan que escala mal cuando crezca la tabla.
+**Resuelto en PR #23** (`chore: backend hardening`). Utility in-memory
+en `src/lib/rate-limit.ts`, default 3 req/min por IP, aplicado a
+`/api/contact`. Si el tráfico crece, swap a Upstash/Vercel KV
+manteniendo la API `checkRateLimit`.
 
-Aparte, `Application.status: String` con comentario `// pending | approved
-| rejected` debería ser enum — hoy un typo silencioso en el hook (ej.
-`status: "aproved"`) rompe el flow de activación sin ningún error de TS.
+### ~~Prisma — index en `Application.email` + enum `ApplicationStatus` — prioridad MEDIA~~
 
-- Migration:
-  ```prisma
-  enum ApplicationStatus {
-    pending
-    approved
-    rejected
-  }
+**Resuelto en PR #23** (`chore: backend hardening`). Schema actualizado
+con `enum ApplicationStatus { PENDING APPROVED REJECTED }` + `@@index([email])`.
+Call sites migrados a UPPER. Migración SQL manual en
+`prisma/migrations-manual/` (el repo usa `db push`, no `migrate dev`).
 
-  model Application {
-    ...
-    status ApplicationStatus @default(pending)
-    @@index([email])
-  }
-  ```
-- Actualizar callers: `src/lib/auth.ts:34` y `src/app/[locale]/user-pending/page.tsx`.
-- Bonus: agregar FK opcional `Application.userId` para que el matching
-  no dependa de email (problema: user puede cambiar email después de
-  aplicar).
+### ~~Security headers globales en `next.config.ts` — prioridad MEDIA~~
 
-### Security headers globales en `next.config.ts` — prioridad MEDIA
-
-**Origen:** PR 8.5 (`/contact`) y aplicable al sitio entero.
-
-Hoy las respuestas no llevan headers de seguridad (CSP, HSTS, X-Frame,
-referrer-policy, permissions-policy). Vulnerable a clickjacking,
-mixed-content downgrade, leaks de referrer cross-origin.
-
-- Configurar `async headers()` en `next.config.ts` con:
-  - `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
-  - `Content-Security-Policy` ajustado a Cloudinary + Google fonts +
-    Better Auth callbacks (auditar primero qué necesita cada origin —
-    una CSP rota tira el sitio).
-  - `X-Frame-Options: DENY` (o `frame-ancestors 'none'` vía CSP).
-  - `Referrer-Policy: strict-origin-when-cross-origin`.
-  - `Permissions-Policy: camera=(), microphone=(), geolocation=()` por
-    default.
-- Verificar contra securityheaders.com — objetivo: nota A o superior.
-- Considerar `report-uri` para violaciones de CSP en producción (al
-  menos durante el primer mes después del deploy, para detectar falsos
-  positivos antes de pasar de `Content-Security-Policy-Report-Only` a
-  enforcement).
+**Resuelto en PR #23** (`chore: backend hardening`). 6 headers globales
+en `next.config.ts`: X-Frame-Options, X-Content-Type-Options,
+Referrer-Policy, Permissions-Policy, HSTS y CSP. CSP va en modo
+**report-only** por ahora — promover a enforcement en PR siguiente
+después de observar violaciones reales en producción durante 1-2 semanas.

--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,10 @@ const isDev = process.env.NODE_ENV !== "production"
  */
 const cspDirectives = [
   "default-src 'self'",
+  // `object-src 'none'` explícito (en lugar de heredar de default-src):
+  // bloquea <object>, <embed>, <applet> — superficie clásica de XSS via
+  // plugin. Recomendación de OWASP incluso si default-src ya es 'self'.
+  "object-src 'none'",
   `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "img-src 'self' data: blob: https://res.cloudinary.com",

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,42 @@ import createNextIntlPlugin from "next-intl/plugin"
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts")
 
+const isDev = process.env.NODE_ENV !== "production"
+
+/**
+ * CSP en modo report-only.
+ *
+ * Decisión cerrada del PR (Obj 3): primero observamos violaciones en
+ * production con `Content-Security-Policy-Report-Only` durante 1-2
+ * semanas, después promovemos a enforcement (`Content-Security-Policy`)
+ * en un PR siguiente cuando sabemos qué orígenes legítimos faltan.
+ *
+ * Notas por directiva:
+ *  - `script-src 'unsafe-inline'`: Next.js requiere inline scripts para
+ *    el runtime client. Habilitable solo bajando a `'strict-dynamic'`
+ *    con nonces, ruta no trivial en App Router; aceptado por ahora.
+ *  - `'unsafe-eval'`: solo en dev porque turbopack lo necesita para HMR.
+ *    Production no lo lleva.
+ *  - `style-src 'unsafe-inline'`: shadcn/Tailwind/next-intl insertan
+ *    estilos inline. Sin esto el sitio se rompe visual.
+ *  - `img-src res.cloudinary.com`: serving de imágenes.
+ *  - `connect-src api.cloudinary.com`: uploads directos desde browser.
+ *  - `connect-src ws: wss:` solo en dev para HMR.
+ *  - `frame-ancestors 'none'` redundante con `X-Frame-Options: DENY`
+ *    pero recomendado por OWASP — CSP wins en browsers modernos.
+ */
+const cspDirectives = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: blob: https://res.cloudinary.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  `connect-src 'self' https://api.cloudinary.com${isDev ? " ws: wss:" : ""}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ")
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -11,6 +47,46 @@ const nextConfig: NextConfig = {
         hostname: "res.cloudinary.com",
       },
     ],
+  },
+  /**
+   * Security headers globales para todas las rutas.
+   *
+   * Aplica a `/(.*)`. Se mantiene un solo array — todos los headers son
+   * universales (sin variantes per-ruta). Si en algún momento hay que
+   * relajar CSP para una ruta específica (ej. embed admin con iframe),
+   * agregar una segunda entry al array `headers()`.
+   *
+   * HSTS con `preload` requiere submission a hstspreload.org tras
+   * verificar que el sitio funciona OK con HTTPS forzado por 2-3 meses.
+   * No bloqueante en este PR — el header solo declara intent.
+   */
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value:
+              "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Content-Security-Policy-Report-Only",
+            value: cspDirectives,
+          },
+        ],
+      },
+    ]
   },
 }
 

--- a/prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql
+++ b/prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql
@@ -16,33 +16,61 @@
 -- "Already in sync" — confirma que el schema del repo y el estado de
 -- la DB matchean.
 
+-- Idempotente: las 4 operaciones detectan si ya se aplicaron y se
+-- saltean. Re-ejecutar el script no debe romper nada (importante para
+-- retries de deploy o aplicación accidental dos veces).
+
 BEGIN;
 
--- 1) Crear el enum.
-CREATE TYPE "ApplicationStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+-- 1) Crear el enum solo si no existe. `DO $$ ... $$` permite control
+--    flow dentro de SQL; pg_type tiene la lista de tipos definidos.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'ApplicationStatus'
+  ) THEN
+    CREATE TYPE "ApplicationStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+  END IF;
+END
+$$;
 
 -- 2) Normalizar valores existentes (lowercase → UPPER). Tres UPDATEs
 --    explícitos en lugar de un solo `UPPER(status)`: si aparece un valor
---    inesperado en la tabla (typo histórico, valor custom), queda como
---    está y el ALTER TYPE de abajo falla con error claro en lugar de
---    silenciosamente convertir basura en NULL.
+--    inesperado (typo histórico, valor custom), queda como está y el
+--    ALTER TYPE de abajo falla con error claro en lugar de silenciosamente
+--    convertir basura en NULL.
+--
+--    Idempotencia: si la columna ya migró a enum, los `WHERE` matchean
+--    cero filas (los valores son 'PENDING'/'APPROVED'/'REJECTED', no
+--    'pending'/'approved'/'rejected') — los UPDATEs son no-op.
 UPDATE "Application" SET "status" = 'PENDING'  WHERE "status" = 'pending';
 UPDATE "Application" SET "status" = 'APPROVED' WHERE "status" = 'approved';
 UPDATE "Application" SET "status" = 'REJECTED' WHERE "status" = 'rejected';
 
--- 3) Cambiar el tipo de columna. DROP DEFAULT primero porque el cast
---    de varchar a enum no se aplica a defaults; lo re-seteamos al final
---    con el valor del nuevo tipo.
-ALTER TABLE "Application"
-  ALTER COLUMN "status" DROP DEFAULT,
-  ALTER COLUMN "status" TYPE "ApplicationStatus"
-    USING "status"::"ApplicationStatus",
-  ALTER COLUMN "status" SET DEFAULT 'PENDING';
+-- 3) Cambiar el tipo de columna solo si todavía es text (la primera
+--    pasada del script). DROP DEFAULT primero porque el cast de varchar
+--    a enum no se aplica a defaults; lo re-seteamos al final con el
+--    valor del nuevo tipo.
+DO $$
+BEGIN
+  IF (
+    SELECT data_type
+    FROM information_schema.columns
+    WHERE table_name = 'Application' AND column_name = 'status'
+  ) = 'text' THEN
+    ALTER TABLE "Application"
+      ALTER COLUMN "status" DROP DEFAULT,
+      ALTER COLUMN "status" TYPE "ApplicationStatus"
+        USING "status"::"ApplicationStatus",
+      ALTER COLUMN "status" SET DEFAULT 'PENDING';
+  END IF;
+END
+$$;
 
 -- 4) Index para Application.email — consumido por:
 --    - `user.create.after` hook (corre en cada signup).
 --    - `/user-pending` page (corre en cada visita PENDING).
 --    Ambos eran sequential scan antes de este index.
-CREATE INDEX "Application_email_idx" ON "Application"("email");
+CREATE INDEX IF NOT EXISTS "Application_email_idx" ON "Application"("email");
 
 COMMIT;

--- a/prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql
+++ b/prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql
@@ -1,0 +1,48 @@
+-- Aplicar a la DB ANTES de `prisma db push` cuando se mergee este PR.
+--
+-- Local:
+--   psql "$DATABASE_URL" -f prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql
+-- Producción:
+--   Misma cosa apuntando a la URL prod (con backup previo).
+--
+-- ¿Por qué un SQL manual y no `prisma migrate dev`?
+-- El repo usa workflow `prisma db push` (sin migrations versionadas).
+-- `db push` NO puede transformar datos al convertir String → enum: si lo
+-- corremos directo va a pedir reset de la tabla o fallar al castear los
+-- valores existentes. Este script hace la transformación explícita antes
+-- de que `db push` vea el schema nuevo.
+--
+-- Después de aplicar este SQL, `prisma db push` debería reportar
+-- "Already in sync" — confirma que el schema del repo y el estado de
+-- la DB matchean.
+
+BEGIN;
+
+-- 1) Crear el enum.
+CREATE TYPE "ApplicationStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- 2) Normalizar valores existentes (lowercase → UPPER). Tres UPDATEs
+--    explícitos en lugar de un solo `UPPER(status)`: si aparece un valor
+--    inesperado en la tabla (typo histórico, valor custom), queda como
+--    está y el ALTER TYPE de abajo falla con error claro en lugar de
+--    silenciosamente convertir basura en NULL.
+UPDATE "Application" SET "status" = 'PENDING'  WHERE "status" = 'pending';
+UPDATE "Application" SET "status" = 'APPROVED' WHERE "status" = 'approved';
+UPDATE "Application" SET "status" = 'REJECTED' WHERE "status" = 'rejected';
+
+-- 3) Cambiar el tipo de columna. DROP DEFAULT primero porque el cast
+--    de varchar a enum no se aplica a defaults; lo re-seteamos al final
+--    con el valor del nuevo tipo.
+ALTER TABLE "Application"
+  ALTER COLUMN "status" DROP DEFAULT,
+  ALTER COLUMN "status" TYPE "ApplicationStatus"
+    USING "status"::"ApplicationStatus",
+  ALTER COLUMN "status" SET DEFAULT 'PENDING';
+
+-- 4) Index para Application.email — consumido por:
+--    - `user.create.after` hook (corre en cada signup).
+--    - `/user-pending` page (corre en cada visita PENDING).
+--    Ambos eran sequential scan antes de este index.
+CREATE INDEX "Application_email_idx" ON "Application"("email");
+
+COMMIT;

--- a/prisma/migrations-manual/README.md
+++ b/prisma/migrations-manual/README.md
@@ -1,0 +1,57 @@
+# Migrations manuales
+
+El proyecto usa `prisma db push` como workflow principal (sync directo del
+schema sin migrations versionadas). Funciona bien para cambios incrementales
+no destructivos.
+
+Pero algunos cambios — sobre todo los que **transforman datos existentes** —
+no pueden delegarse a `db push` porque:
+
+- Cambios de tipo (ej. `String` → `enum`) requieren cast manual o pueden
+  perder datos.
+- Renames sin `db push` lo detectan como drop + create.
+- Backfills (popular columna nueva con datos derivados).
+
+Para esos casos, este directorio guarda scripts SQL versionados con el
+nombre `YYYY-MM-DD_<descripcion>.sql`. Cada script:
+
+1. Documenta en su header **cuándo** aplicarse (típicamente antes del
+   próximo `db push`).
+2. Es transaccional (`BEGIN` / `COMMIT`) para que un error revierta todo.
+3. Es idempotente cuando es posible, o al menos detecta el estado para
+   no romperse al re-correr.
+
+## Flujo de aplicación
+
+### Local (developer)
+
+```bash
+psql "$DATABASE_URL" -f prisma/migrations-manual/<filename>.sql
+pnpm exec prisma db push    # verifica sync — debería decir "Already in sync"
+pnpm exec prisma generate   # regenera el cliente
+```
+
+### Producción
+
+Backup primero, después:
+
+```bash
+psql "$PRODUCTION_DATABASE_URL" -f prisma/migrations-manual/<filename>.sql
+```
+
+El dev se asegura de hacer `prisma db push` post-deploy si hace falta
+sincronizar índices u otros cambios no-destructivos del mismo PR.
+
+## Migración futura a migrations versionadas
+
+Si en algún momento queremos migrar a `prisma migrate` formal, conviene:
+
+1. Hacer baseline de la DB actual: `prisma migrate diff --from-empty
+   --to-schema-datamodel=prisma/schema.prisma --script > baseline.sql`.
+2. Crear `prisma/migrations/0_baseline/migration.sql` con ese SQL.
+3. Marcar como aplicada en cada entorno: `prisma migrate resolve
+   --applied 0_baseline`.
+4. A partir de ahí, `prisma migrate dev` para cambios nuevos.
+
+Hasta entonces, este directorio cubre el caso de cambios destructivos
+sin imponer ese workflow al resto.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,10 +145,21 @@ model Image {
 
 
 model Application {
-  id        String   @id @default(cuid())
+  id        String            @id @default(cuid())
   name      String
   email     String
   message   String
-  status    String   @default("pending") // pending | approved | rejected
-  createdAt DateTime @default(now())
+  status    ApplicationStatus @default(PENDING)
+  createdAt DateTime          @default(now())
+
+  // Index para los lookups por email del hook `user.create.after`
+  // (corre en cada signup) y de `/user-pending` (corre en cada visita).
+  // Ambos eran seq-scan antes de esta migración.
+  @@index([email])
+}
+
+enum ApplicationStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }

--- a/src/app/[locale]/(admin)/admin/applications/ApplicationActions.tsx
+++ b/src/app/[locale]/(admin)/admin/applications/ApplicationActions.tsx
@@ -8,11 +8,9 @@ import { toast } from "sonner"
 
 interface Props {
   id: string
-  email: string
-  name: string
 }
 
-export function ApplicationActions({ id, email, name }: Props) {
+export function ApplicationActions({ id }: Props) {
   const t = useTranslations("admin")
   const router = useRouter()
   const [loading, setLoading] = useState<"APPROVED" | "REJECTED" | null>(null)
@@ -20,11 +18,17 @@ export function ApplicationActions({ id, email, name }: Props) {
   async function update(status: "APPROVED" | "REJECTED") {
     setLoading(status)
     try {
-      await fetch(`/api/apply/${id}`, {
+      const res = await fetch(`/api/apply/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status, email, name }),
+        body: JSON.stringify({ status }),
       })
+      // Verificar `res.ok` antes de mostrar success — sin esto un 403/500
+      // del server queda como "Aprobado" en el toast (falso positivo).
+      if (!res.ok) {
+        toast.error("Error")
+        return
+      }
       toast.success(status === "APPROVED" ? t("applicationsApprovedMsg") : t("applicationsRejectedMsg"))
       router.refresh()
     } catch {

--- a/src/app/[locale]/(admin)/admin/applications/ApplicationActions.tsx
+++ b/src/app/[locale]/(admin)/admin/applications/ApplicationActions.tsx
@@ -15,9 +15,9 @@ interface Props {
 export function ApplicationActions({ id, email, name }: Props) {
   const t = useTranslations("admin")
   const router = useRouter()
-  const [loading, setLoading] = useState<"approved" | "rejected" | null>(null)
+  const [loading, setLoading] = useState<"APPROVED" | "REJECTED" | null>(null)
 
-  async function update(status: "approved" | "rejected") {
+  async function update(status: "APPROVED" | "REJECTED") {
     setLoading(status)
     try {
       await fetch(`/api/apply/${id}`, {
@@ -25,7 +25,7 @@ export function ApplicationActions({ id, email, name }: Props) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status, email, name }),
       })
-      toast.success(status === "approved" ? t("applicationsApprovedMsg") : t("applicationsRejectedMsg"))
+      toast.success(status === "APPROVED" ? t("applicationsApprovedMsg") : t("applicationsRejectedMsg"))
       router.refresh()
     } catch {
       toast.error("Error")
@@ -41,17 +41,17 @@ export function ApplicationActions({ id, email, name }: Props) {
         variant="outline"
         className="text-red-400 border-red-400/30 hover:bg-red-500/10 hover:text-red-400 rounded-full"
         disabled={!!loading}
-        onClick={() => update("rejected")}
+        onClick={() => update("REJECTED")}
       >
-        {loading === "rejected" ? "..." : t("applicationsReject")}
+        {loading === "REJECTED" ? "..." : t("applicationsReject")}
       </Button>
       <Button
         size="sm"
         className="rounded-full bg-green-600 hover:bg-green-500 text-white"
         disabled={!!loading}
-        onClick={() => update("approved")}
+        onClick={() => update("APPROVED")}
       >
-        {loading === "approved" ? "..." : t("applicationsAccept")}
+        {loading === "APPROVED" ? "..." : t("applicationsAccept")}
       </Button>
     </div>
   )

--- a/src/app/[locale]/(admin)/admin/applications/page.tsx
+++ b/src/app/[locale]/(admin)/admin/applications/page.tsx
@@ -46,7 +46,7 @@ export default async function ApplicationsPage({
                   </div>
                   <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">{app.message}</p>
                 </div>
-                <ApplicationActions id={app.id} email={app.email} name={app.name} />
+                <ApplicationActions id={app.id} />
               </div>
             ))}
           </div>

--- a/src/app/[locale]/(admin)/admin/applications/page.tsx
+++ b/src/app/[locale]/(admin)/admin/applications/page.tsx
@@ -15,8 +15,8 @@ export default async function ApplicationsPage({
     orderBy: { createdAt: "desc" },
   })
 
-  const pending = applications.filter((a) => a.status === "pending")
-  const reviewed = applications.filter((a) => a.status !== "pending")
+  const pending = applications.filter((a) => a.status === "PENDING")
+  const reviewed = applications.filter((a) => a.status !== "PENDING")
 
   return (
     <div className="space-y-8">
@@ -77,11 +77,11 @@ export default async function ApplicationsPage({
                   </div>
                 </div>
                 <span className={`text-xs font-bold px-2.5 py-1 rounded-full ${
-                  app.status === "approved"
+                  app.status === "APPROVED"
                     ? "bg-green-500/15 text-green-500"
                     : "bg-red-500/15 text-red-400"
                 }`}>
-                  {app.status === "approved" ? t("applicationsApproved") : t("applicationsRejected")}
+                  {app.status === "APPROVED" ? t("applicationsApproved") : t("applicationsRejected")}
                 </span>
               </div>
             ))}

--- a/src/app/[locale]/user-pending/page.tsx
+++ b/src/app/[locale]/user-pending/page.tsx
@@ -8,14 +8,14 @@
  * eyebrow dorado + h1 cálido + fecha de aplicación visible + escape
  * hatch si pasaron más de 3 días.
  *
- * NOTA SOBRE EL FLUJO QUE DISPARA PENDING (handoff blocker 1):
- * El hook `databaseHooks.user.create.after` en `src/lib/auth.ts` hoy
- * siempre escribe `status: ACTIVE` (tanto si hay Application aprobada
- * como si no). En la práctica esta pantalla solo se renderiza si un
- * admin pone status PENDING manualmente en DB. Arreglar ese hook es
- * out of scope de esta PR (toca lógica de Better Auth — fuera del
- * scope explícito). Esta pantalla está lista para cuando ese arreglo
- * se haga en otro PR.
+ * FLUJO QUE DISPARA PENDING (activo desde PR #23 backend hardening):
+ * El hook `databaseHooks.user.create.after` en `src/lib/auth.ts` escribe
+ * `status: PENDING` por default para toda cuenta nueva (email/password
+ * y Google OAuth). Excepciones: cuenta con Application APPROVED previa
+ * (sign-up post-aprobación → ACTIVE + creator) o `user.role === "admin"`
+ * (seed manual → ACTIVE). Cuando admin aprueba una Application, el
+ * endpoint `/api/apply/[id]` PATCH bumpea el User asociado a ACTIVE +
+ * creator, destrabando el panel.
  *
  * Application matching: `Application` no tiene FK con `User`. Se
  * matchea por email (mismo pattern que el hook). Si no hay match

--- a/src/app/api/apply/[id]/route.ts
+++ b/src/app/api/apply/[id]/route.ts
@@ -37,8 +37,21 @@ export async function PATCH(
   // El trigger del email queda AFUERA de la transacción a propósito:
   //  - No debe bloquear el commit (Resend roundtrip ~200-400ms).
   //  - Un fallo de Resend no debe rollbackear la promoción.
-  const { application, userMatched } = await prisma.$transaction(
-    async (tx) => {
+  //
+  // Además, leemos el status previo dentro de la transacción para detectar
+  // la transición real: solo notificamos en el "salto a APPROVED", no en
+  // re-clicks del admin sobre una Application ya aprobada (que de otra
+  // manera dispararían un mail duplicado al applicant).
+  const { application, userMatched, transitionedToApproved } =
+    await prisma.$transaction(async (tx) => {
+      const previous = await tx.application.findUnique({
+        where: { id },
+        select: { status: true },
+      })
+      if (!previous) {
+        throw new Error("application_not_found")
+      }
+
       const application = await tx.application.update({
         where: { id },
         data: { status: result.data.status },
@@ -46,10 +59,9 @@ export async function PATCH(
 
       let userMatched = 0
       if (result.data.status === "APPROVED") {
-        // Si el aplicante ya tiene cuenta, bump role + UserProfile.status.
-        // Si todavía no la tiene (caso anónimo via email-de-aprobación),
-        // `updateMany` matchea 0 filas — el hook `user.create.after`
-        // detectará la Application APPROVED cuando se registre.
+        // Los bumps del User corren incluso si ya estaba APPROVED — son
+        // idempotentes y sirven de "self-heal" si el primer approve falló
+        // a mitad antes de la transacción (commits previos al fix).
         //
         // `role: { not: "admin" }` excluye al founder en el caso edge
         // donde aplica con su mismo email — no degradarlo a creator.
@@ -64,18 +76,22 @@ export async function PATCH(
         userMatched = userResult.count
       }
 
-      return { application, userMatched }
-    }
-  )
+      const transitionedToApproved =
+        previous.status !== "APPROVED" &&
+        result.data.status === "APPROVED"
 
-  if (result.data.status === "APPROVED") {
-    // Log estructurado para distinguir "promoví a user existente" de
-    // "no había a quién promover, esperando signup". Sin esto no hay
-    // forma operacional de detectar applicants que se aprobaron pero
-    // nunca volvieron a registrarse.
+      return { application, userMatched, transitionedToApproved }
+    })
+
+  // Solo notificamos (email + log) en la transición real para evitar
+  // duplicados. Si el admin clickea "aprobar" dos veces o vuelve a PATCH
+  // sobre una Application ya APPROVED, no se dispara nada.
+  if (transitionedToApproved) {
+    // Log estructurado SIN PII. Antes incluía `email` crudo — sacado:
+    // operacionalmente alcanza con `id` y `userMatched` para correlacionar
+    // contra Application; el email del applicante no debe vivir en logs.
     console.info("application_approved", {
       id: application.id,
-      email: application.email,
       userMatched: userMatched > 0,
     })
 

--- a/src/app/api/apply/[id]/route.ts
+++ b/src/app/api/apply/[id]/route.ts
@@ -4,10 +4,12 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 import { triggerApplicationApproved } from "@/lib/trigger"
 
+/** Schema reducido — el body solo trae el status nuevo. El email y
+ * name del aplicante se leen del row del DB (no del body) para defensa
+ * contra falsificación: un admin malicioso con credenciales válidas no
+ * podría aprobar una Application apuntando email/name a otra cuenta. */
 const schema = z.object({
   status: z.enum(["APPROVED", "REJECTED"]),
-  email: z.string().email(),
-  name: z.string(),
 })
 
 export async function PATCH(
@@ -26,35 +28,55 @@ export async function PATCH(
     return NextResponse.json({ error: "Validation error" }, { status: 400 })
   }
 
-  // Update + read en una sola operación. Usamos el email/name del row
-  // del DB (no del body del request) como fuente de verdad para el
-  // matching del User y para el trigger del email — no confiamos en
-  // strings que vienen del cliente para identificar al user.
-  const application = await prisma.application.update({
-    where: { id },
-    data: { status: result.data.status },
-  })
+  // Los 3 writes (application + user role + userProfile status) van en
+  // una transacción para que el approve sea atómico: si falla la conexión
+  // a mitad, no quedamos con Application APPROVED pero User sin promover
+  // (caso silencioso donde el applicant ve "fuiste aprobado" en el mail
+  // pero al loguearse sigue redirigido a `/user-pending`).
+  //
+  // El trigger del email queda AFUERA de la transacción a propósito:
+  //  - No debe bloquear el commit (Resend roundtrip ~200-400ms).
+  //  - Un fallo de Resend no debe rollbackear la promoción.
+  const { application, userMatched } = await prisma.$transaction(
+    async (tx) => {
+      const application = await tx.application.update({
+        where: { id },
+        data: { status: result.data.status },
+      })
+
+      let userMatched = 0
+      if (result.data.status === "APPROVED") {
+        // Si el aplicante ya tiene cuenta, bump role + UserProfile.status.
+        // Si todavía no la tiene (caso anónimo via email-de-aprobación),
+        // `updateMany` matchea 0 filas — el hook `user.create.after`
+        // detectará la Application APPROVED cuando se registre.
+        //
+        // `role: { not: "admin" }` excluye al founder en el caso edge
+        // donde aplica con su mismo email — no degradarlo a creator.
+        const userResult = await tx.user.updateMany({
+          where: { email: application.email, role: { not: "admin" } },
+          data: { role: "creator" },
+        })
+        await tx.userProfile.updateMany({
+          where: { user: { email: application.email } },
+          data: { status: "ACTIVE" },
+        })
+        userMatched = userResult.count
+      }
+
+      return { application, userMatched }
+    }
+  )
 
   if (result.data.status === "APPROVED") {
-    // Si el aplicante ya tiene cuenta (caso usual: aplicó después de
-    // signup), bump su UserProfile.status a ACTIVE y role a creator
-    // para destrabar el panel. Si todavía no tiene cuenta (aplicó como
-    // anónimo via email-de-aprobación), el hook `user.create.after`
-    // detectará la Application aprobada cuando se registre y le dará
-    // ACTIVE + creator inmediato.
-    //
-    // `updateMany` con `where` por email permite el caso "0 matches" sin
-    // tirar (a diferencia de `update` que rechaza si no encuentra). El
-    // role bump excluye admins por defensa — un admin con la misma email
-    // (caso edge: founder aplicando como creator) no debería degradar a
-    // creator.
-    await prisma.user.updateMany({
-      where: { email: application.email, role: { not: "admin" } },
-      data: { role: "creator" },
-    })
-    await prisma.userProfile.updateMany({
-      where: { user: { email: application.email } },
-      data: { status: "ACTIVE" },
+    // Log estructurado para distinguir "promoví a user existente" de
+    // "no había a quién promover, esperando signup". Sin esto no hay
+    // forma operacional de detectar applicants que se aprobaron pero
+    // nunca volvieron a registrarse.
+    console.info("application_approved", {
+      id: application.id,
+      email: application.email,
+      userMatched: userMatched > 0,
     })
 
     triggerApplicationApproved({

--- a/src/app/api/apply/[id]/route.ts
+++ b/src/app/api/apply/[id]/route.ts
@@ -5,7 +5,7 @@ import { z } from "zod"
 import { triggerApplicationApproved } from "@/lib/trigger"
 
 const schema = z.object({
-  status: z.enum(["approved", "rejected"]),
+  status: z.enum(["APPROVED", "REJECTED"]),
   email: z.string().email(),
   name: z.string(),
 })
@@ -35,7 +35,7 @@ export async function PATCH(
     data: { status: result.data.status },
   })
 
-  if (result.data.status === "approved") {
+  if (result.data.status === "APPROVED") {
     // Si el aplicante ya tiene cuenta (caso usual: aplicó después de
     // signup), bump su UserProfile.status a ACTIVE y role a creator
     // para destrabar el panel. Si todavía no tiene cuenta (aplicó como

--- a/src/app/api/apply/[id]/route.ts
+++ b/src/app/api/apply/[id]/route.ts
@@ -26,15 +26,40 @@ export async function PATCH(
     return NextResponse.json({ error: "Validation error" }, { status: 400 })
   }
 
-  await prisma.application.update({
+  // Update + read en una sola operación. Usamos el email/name del row
+  // del DB (no del body del request) como fuente de verdad para el
+  // matching del User y para el trigger del email — no confiamos en
+  // strings que vienen del cliente para identificar al user.
+  const application = await prisma.application.update({
     where: { id },
     data: { status: result.data.status },
   })
 
   if (result.data.status === "approved") {
+    // Si el aplicante ya tiene cuenta (caso usual: aplicó después de
+    // signup), bump su UserProfile.status a ACTIVE y role a creator
+    // para destrabar el panel. Si todavía no tiene cuenta (aplicó como
+    // anónimo via email-de-aprobación), el hook `user.create.after`
+    // detectará la Application aprobada cuando se registre y le dará
+    // ACTIVE + creator inmediato.
+    //
+    // `updateMany` con `where` por email permite el caso "0 matches" sin
+    // tirar (a diferencia de `update` que rechaza si no encuentra). El
+    // role bump excluye admins por defensa — un admin con la misma email
+    // (caso edge: founder aplicando como creator) no debería degradar a
+    // creator.
+    await prisma.user.updateMany({
+      where: { email: application.email, role: { not: "admin" } },
+      data: { role: "creator" },
+    })
+    await prisma.userProfile.updateMany({
+      where: { user: { email: application.email } },
+      data: { status: "ACTIVE" },
+    })
+
     triggerApplicationApproved({
-      email: result.data.email,
-      name: result.data.name,
+      email: application.email,
+      name: application.name,
     }).catch(() => {})
   }
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -32,6 +32,7 @@ import {
   type ContactType,
 } from "@/lib/validators/contact"
 import { triggerContactNotification } from "@/lib/trigger"
+import { checkRateLimit, getClientIp } from "@/lib/rate-limit"
 
 async function resolveTypeLabel(type: ContactType, locale: string): Promise<string> {
   const t = await getTranslations({ locale, namespace: "contact.form.types" })
@@ -89,6 +90,22 @@ function fakeOk() {
 export async function POST(request: Request) {
   if (!isAllowedOrigin(request)) {
     return NextResponse.json({ error: "forbidden_origin" }, { status: 403 })
+  }
+
+  // Rate limit IP-based en memoria. 3 req/min default (definido en
+  // `src/lib/rate-limit.ts`). Threat model: bot agresivo desde IP única
+  // intentando drenar quota de Resend. Si el header está vacío, todos
+  // los anónimos caen en el bucket "unknown" y comparten el límite —
+  // browsers reales siempre traen `x-forwarded-for` desde nginx.
+  const rate = checkRateLimit(getClientIp(request.headers))
+  if (!rate.ok) {
+    return NextResponse.json(
+      { error: "rate_limited", retryAfterSec: rate.retryAfterSec },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rate.retryAfterSec) },
+      }
+    )
   }
 
   let body: unknown

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -63,6 +63,7 @@ export default function ContactForm() {
   const tErrors = useTranslations("contact.form.errors")
   const tSuccess = useTranslations("contact.success")
   const tError = useTranslations("contact.error")
+  const tRateLimit = useTranslations("contact.rateLimit")
   const locale = useLocale()
   const errorMessageFor = (code: string): string =>
     KNOWN_ERROR_CODES.has(code) ? tErrors(code) : tErrors("generic")
@@ -140,8 +141,7 @@ export default function ContactForm() {
         // 400 validation_error: el server rechazó por schema (drift entre
         // cliente y server, o usuario tampering con el payload). Volcamos
         // las `issues` a fieldErrors para que el user vea exactamente qué
-        // campo está mal. Cualquier otro status (5xx, 429, etc) cae al
-        // toast genérico de "problema de conexión".
+        // campo está mal.
         if (res.status === 400) {
           const body = (await res.json().catch(() => null)) as
             | { issues?: Array<{ path: (string | number)[]; message: string }> }
@@ -158,6 +158,17 @@ export default function ContactForm() {
             return
           }
         }
+        // 429 rate_limited: el server cortó por exceso de requests
+        // desde la IP del cliente. Mensaje específico — distinto del
+        // genérico "problema de conexión" para que el user entienda
+        // que no es un bug, es defensa anti-spam.
+        if (res.status === 429) {
+          toast.error(tRateLimit("title"), {
+            description: tRateLimit("body"),
+          })
+          return
+        }
+        // Cualquier otro status (5xx, etc.) cae al toast genérico.
         toast.error(tError("title"), { description: tError("body") })
       } catch {
         toast.error(tError("title"), { description: tError("body") })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -47,7 +47,7 @@ export const auth = betterAuth({
           }
 
           const approvedApplication = await prisma.application.findFirst({
-            where: { email: user.email, status: "approved" },
+            where: { email: user.email, status: "APPROVED" },
           })
 
           if (approvedApplication) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -54,13 +54,21 @@ export const auth = betterAuth({
             // Cuenta nace ACTIVE + creator solo si ya hubo aprobación
             // previa de su Application — el matching es por email
             // porque Application no tiene FK a User.
-            await prisma.userProfile.create({
-              data: { userId: user.id, status: "ACTIVE" },
-            })
-            await prisma.user.update({
-              where: { id: user.id },
-              data: { role: "creator" },
-            })
+            //
+            // Las dos writes van en una transacción para que el
+            // onboarding sea atómico: si falla la promoción a creator
+            // tras crear el profile, no quedamos con UserProfile
+            // ACTIVE pero role "user" (caso silencioso donde el user
+            // tiene panel destrabado pero sin permisos de creación).
+            await prisma.$transaction([
+              prisma.userProfile.create({
+                data: { userId: user.id, status: "ACTIVE" },
+              }),
+              prisma.user.update({
+                where: { id: user.id },
+                data: { role: "creator" },
+              }),
+            ])
           } else {
             // Caso default: cuenta nueva sin Application aprobada nace
             // PENDING. El usuario puede browsear el sitio público; al

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,13 +30,30 @@ export const auth = betterAuth({
     user: {
       create: {
         after: async (user) => {
-          // Check if this email has an approved application
+          // Decisión de producto cerrada: cuenta nace PENDING para que
+          // el flow de `/user-pending` se active de verdad. Excepciones:
+          //  - Cuenta con Application APPROVED previa (sign-up post
+          //    aprobación) → activar y subir a creator inmediatamente.
+          //  - Cuenta con `role: admin` (seed manual o creación interna
+          //    desde código) → respetar y dejar ACTIVE. Sign-up público
+          //    no puede asignar role admin (Better Auth `defaultRole:
+          //    "user"` lo bloquea), pero el check defensivo evita
+          //    bloquear al primer admin del seed si lo creamos via DB.
+          if (user.role === "admin") {
+            await prisma.userProfile.create({
+              data: { userId: user.id, status: "ACTIVE" },
+            })
+            return
+          }
+
           const approvedApplication = await prisma.application.findFirst({
             where: { email: user.email, status: "approved" },
           })
 
           if (approvedApplication) {
-            // Approved applicant: activate as artist immediately
+            // Cuenta nace ACTIVE + creator solo si ya hubo aprobación
+            // previa de su Application — el matching es por email
+            // porque Application no tiene FK a User.
             await prisma.userProfile.create({
               data: { userId: user.id, status: "ACTIVE" },
             })
@@ -45,9 +62,14 @@ export const auth = betterAuth({
               data: { role: "creator" },
             })
           } else {
-            // Regular user: active but no artist permissions
+            // Caso default: cuenta nueva sin Application aprobada nace
+            // PENDING. El usuario puede browsear el sitio público; al
+            // intentar entrar a `/dashboard`, `requireActive()` lo
+            // redirige a `/user-pending`. Pasa a ACTIVE cuando admin
+            // aprueba una Application con su mismo email (ver
+            // `src/app/api/apply/[id]/route.ts`).
             await prisma.userProfile.create({
-              data: { userId: user.id, status: "ACTIVE" },
+              data: { userId: user.id, status: "PENDING" },
             })
           }
         },

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -49,9 +49,13 @@ const DEFAULT_CONFIG: RateLimitConfig = {
   maxRequests: 3,
 }
 
-/** Cleanup oportunista: al crear bucket nuevo, recorre el Map y borra
- * todos los expirados. Cost-amortizado bajo (solo corre cuando aparece
- * IP nueva, y solo borra). Evita memory leak sin necesidad de setInterval. */
+/** Cleanup: recorre el Map y borra todos los expirados. Costo bajo
+ * (Map.size típico < cantidad de IPs únicas en la ventana actual), y
+ * la operación es O(n). Llamado al inicio de cada `checkRateLimit` —
+ * garantiza limpieza periódica sin necesidad de `setInterval` ni
+ * runtime separado. Antes corría solo "al crear bucket nuevo", lo que
+ * dejaba un caso patológico: tráfico dominado por las mismas IPs nunca
+ * disparaba cleanup. */
 function pruneExpired(now: number): void {
   for (const [key, bucket] of buckets) {
     if (bucket.resetAt <= now) {
@@ -63,6 +67,13 @@ function pruneExpired(now: number): void {
 /**
  * Verifica si una request del `key` (típicamente IP) puede pasar.
  * Side-effect: incrementa el contador si pasa, o devuelve cuánto esperar.
+ *
+ * En **development** (`NODE_ENV !== "production"`), si la `key` es
+ * `"unknown"` (típicamente porque nginx no está delante seteando
+ * `x-forwarded-for`), se hace **bypass** del rate limit. Evita el
+ * caso "todos los requests del dev local caen en el mismo bucket
+ * y se rate-limitean entre sí". En production NO hay bypass —
+ * `"unknown"` sigue compartiendo bucket para defensa.
  *
  * Uso típico:
  * ```ts
@@ -77,11 +88,15 @@ export function checkRateLimit(
   key: string,
   config: RateLimitConfig = DEFAULT_CONFIG
 ): RateLimitResult {
+  if (process.env.NODE_ENV !== "production" && key === "unknown") {
+    return { ok: true }
+  }
+
   const now = Date.now()
+  pruneExpired(now)
   const bucket = buckets.get(key)
 
   if (!bucket || bucket.resetAt <= now) {
-    pruneExpired(now)
     buckets.set(key, { count: 1, resetAt: now + config.windowMs })
     return { ok: true }
   }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,119 @@
+/**
+ * Rate limit in-memory, IP-based. Sin Redis ni dependencias externas —
+ * suficiente para el tráfico actual de un endpoint público chico como
+ * `/api/contact`. Cuando crezca, swap a Upstash/Vercel KV (mantener
+ * la API `checkRateLimit` para no tocar callers).
+ *
+ * Limitaciones conocidas (por diseño, no bugs):
+ *  - El bucket vive en el process del runtime. En serverless con
+ *    múltiples instancias (no es nuestro caso hoy en el VPS), un
+ *    atacante distribuido en varias instancias podría saltarlo.
+ *    Para el threat model actual (bot solo contra Resend quota), un
+ *    rate limit por-instancia es suficiente.
+ *  - El Map crece con cada IP nueva. Mitigación: cleanup oportunista
+ *    al crear bucket nuevo (recorre el Map y borra expirados). En
+ *    runs largos esto mantiene el Map en O(IPs activas en la ventana).
+ *
+ * Threat model que cubre:
+ *  - Bot agresivo desde una IP única haciendo flood al endpoint.
+ *  - Spam manual desde un browser (incluso saltándose origin/honeypot).
+ *
+ * Threat model que NO cubre:
+ *  - Atacante con botnet rotando IPs. Para eso necesitamos captcha o
+ *    fingerprinting de browser — fuera del scope de este PR.
+ */
+
+export interface RateLimitConfig {
+  /** Ventana de tiempo en ms. */
+  windowMs: number
+  /** Requests máximos por bucket en la ventana. */
+  maxRequests: number
+}
+
+export type RateLimitResult =
+  | { ok: true }
+  | { ok: false; retryAfterSec: number }
+
+interface Bucket {
+  count: number
+  resetAt: number
+}
+
+const buckets = new Map<string, Bucket>()
+
+/** Default razonable para forms de contacto: 3 requests por minuto por
+ * IP. Permite 3 envíos legítimos (probar / corregir / re-enviar) sin
+ * bloquear, pero corta el flood básico. */
+const DEFAULT_CONFIG: RateLimitConfig = {
+  windowMs: 60_000,
+  maxRequests: 3,
+}
+
+/** Cleanup oportunista: al crear bucket nuevo, recorre el Map y borra
+ * todos los expirados. Cost-amortizado bajo (solo corre cuando aparece
+ * IP nueva, y solo borra). Evita memory leak sin necesidad de setInterval. */
+function pruneExpired(now: number): void {
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) {
+      buckets.delete(key)
+    }
+  }
+}
+
+/**
+ * Verifica si una request del `key` (típicamente IP) puede pasar.
+ * Side-effect: incrementa el contador si pasa, o devuelve cuánto esperar.
+ *
+ * Uso típico:
+ * ```ts
+ * const res = checkRateLimit(ip)
+ * if (!res.ok) {
+ *   return NextResponse.json({ error: "rate_limited" }, { status: 429,
+ *     headers: { "Retry-After": String(res.retryAfterSec) } })
+ * }
+ * ```
+ */
+export function checkRateLimit(
+  key: string,
+  config: RateLimitConfig = DEFAULT_CONFIG
+): RateLimitResult {
+  const now = Date.now()
+  const bucket = buckets.get(key)
+
+  if (!bucket || bucket.resetAt <= now) {
+    pruneExpired(now)
+    buckets.set(key, { count: 1, resetAt: now + config.windowMs })
+    return { ok: true }
+  }
+
+  if (bucket.count >= config.maxRequests) {
+    return {
+      ok: false,
+      retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    }
+  }
+
+  bucket.count += 1
+  return { ok: true }
+}
+
+/** Extrae IP del request priorizando `x-forwarded-for` (set por nginx)
+ * sobre `x-real-ip` (fallback). Si ambos faltan, devuelve "unknown" —
+ * el rate limit agrupa todos los anónimos bajo esa misma key, lo que
+ * NO bloquea tráfico legítimo (browsers reales siempre pasan headers)
+ * pero sí limita a un atacante que pase los headers vacíos.
+ *
+ * `x-forwarded-for` puede traer una lista `client, proxy1, proxy2` —
+ * tomamos el primer valor (el IP del cliente original). nginx en
+ * nuestro setup ya agrega el correcto al principio.
+ */
+export function getClientIp(headers: Headers): string {
+  const forwardedFor = headers.get("x-forwarded-for")
+  if (forwardedFor) {
+    const first = forwardedFor.split(",")[0]?.trim()
+    if (first) return first
+  }
+  const realIp = headers.get("x-real-ip")
+  if (realIp) return realIp.trim()
+  return "unknown"
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -112,23 +112,57 @@ export function checkRateLimit(
   return { ok: true }
 }
 
+/**
+ * Validación format-only de IPv4 e IPv6. NO valida ranges, reserved
+ * blocks, ni semántica — solo "esto tiene forma de IP". Lo suficiente
+ * para descartar strings arbitrarios inyectados como `x-forwarded-for`
+ * en un setup mal configurado (sin nginx delante limpiando el header).
+ *
+ * - IPv4: 4 octets 0-255 separados por punto. Regex liberal (acepta
+ *   ceros leading, ej. `001.002.003.004`); el goal es format, no
+ *   canonicalización.
+ * - IPv6: hex y `:`, con soporte para `::` compresión. Regex simple
+ *   pero suficiente para descartar payload tipo `<script>` o `'OR 1=1`.
+ */
+const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/
+const IPV6_RE = /^[0-9a-fA-F:]+$/
+
+function isValidIp(value: string): boolean {
+  if (IPV4_RE.test(value)) {
+    return value
+      .split(".")
+      .every((oct) => {
+        const n = Number(oct)
+        return n >= 0 && n <= 255
+      })
+  }
+  return IPV6_RE.test(value) && value.includes(":")
+}
+
 /** Extrae IP del request priorizando `x-forwarded-for` (set por nginx)
- * sobre `x-real-ip` (fallback). Si ambos faltan, devuelve "unknown" —
- * el rate limit agrupa todos los anónimos bajo esa misma key, lo que
- * NO bloquea tráfico legítimo (browsers reales siempre pasan headers)
- * pero sí limita a un atacante que pase los headers vacíos.
+ * sobre `x-real-ip` (fallback). Valida formato antes de devolver — si
+ * el header trae basura (atacante inyectando `x-forwarded-for: foo` en
+ * un setup sin proxy delante), no la usamos como key del rate limit
+ * (sería bypass trivial: rotar `x-forwarded-for` por cada request).
+ *
+ * Si nada pasa validación, devuelve "unknown" — agrupa todos los
+ * anónimos bajo esa misma key. NO bloquea tráfico legítimo (browsers
+ * reales detrás de nginx pasan IPs válidas) pero sí limita al atacante
+ * con headers vacíos o inválidos.
  *
  * `x-forwarded-for` puede traer una lista `client, proxy1, proxy2` —
- * tomamos el primer valor (el IP del cliente original). nginx en
- * nuestro setup ya agrega el correcto al principio.
+ * tomamos el primer valor (IP del cliente original). nginx en nuestro
+ * setup ya agrega el correcto al principio. Si el repo cambia a estar
+ * detrás de un CDN (Cloudflare, etc.), revisar este orden — algunos
+ * CDNs agregan su edge al principio en lugar del final.
  */
 export function getClientIp(headers: Headers): string {
   const forwardedFor = headers.get("x-forwarded-for")
   if (forwardedFor) {
     const first = forwardedFor.split(",")[0]?.trim()
-    if (first) return first
+    if (first && isValidIp(first)) return first
   }
-  const realIp = headers.get("x-real-ip")
-  if (realIp) return realIp.trim()
+  const realIp = headers.get("x-real-ip")?.trim()
+  if (realIp && isValidIp(realIp)) return realIp
   return "unknown"
 }

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -424,6 +424,10 @@
       "title": "Nachricht konnte nicht gesendet werden",
       "body": "Es gab ein Verbindungsproblem. Versuch es gleich noch einmal."
     },
+    "rateLimit": {
+      "title": "Zu viele Anfragen",
+      "body": "Warte einen Moment, bevor du es erneut versuchst."
+    },
     "alternatives": {
       "title": "Andere Pfade, uns zu erreichen",
       "instagramLabel": "@lahuelladelcaminante auf Instagram",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -424,6 +424,10 @@
       "title": "We couldn't send your message",
       "body": "There was a connection issue. Please try again in a moment."
     },
+    "rateLimit": {
+      "title": "Too many requests",
+      "body": "Wait a moment before trying again."
+    },
     "alternatives": {
       "title": "Other paths",
       "instagramLabel": "@lahuelladelcaminante on Instagram",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -424,6 +424,10 @@
       "title": "No pudimos enviar tu mensaje",
       "body": "Hubo un problema de conexión. Probá de nuevo en un momento."
     },
+    "rateLimit": {
+      "title": "Demasiadas solicitudes",
+      "body": "Esperá un momento antes de probar de nuevo."
+    },
     "alternatives": {
       "title": "Otros caminos",
       "instagramLabel": "@lahuelladelcaminante en Instagram",


### PR DESCRIPTION
## Resumen

PR de hardening backend que resuelve 4 deudas/issues en un solo paquete coherente:

1. **Bug funcional del flujo de cuenta**: el hook `databaseHooks.user.create.after` siempre escribía `status: ACTIVE`, haciendo que `/user-pending` (rediseñada en PR #22) fuera código muerto. Ahora la cuenta nace `PENDING` (Opción A del spec) y pasa a `ACTIVE` cuando admin aprueba una Application matching por email.
2. **Rate limit IP-based** in-memory (sin Redis ni deps externas) aplicado a `/api/contact`. 3 req/min default. Maneja 429 con toast amigable.
3. **Security headers globales** en `next.config.ts`: X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, HSTS 2y, CSP **report-only**.
4. **Prisma**: `Application.status` String → `enum ApplicationStatus { PENDING APPROVED REJECTED }` + `@@index([email])`. 5 call sites migrados a UPPER. Migración SQL manual (el repo usa `db push`, no `migrate dev`).

## Flujo de cuenta — cómo funciona ahora

```
sign-up (email/password o Google OAuth)
   ↓
hook user.create.after corre:
   - si user.role === "admin": ACTIVE (defensa contra seed manual)
   - si hay Application APPROVED con mismo email: ACTIVE + role creator
   - default: PENDING
   ↓
user logueado intenta /dashboard
   ↓
requireActive() ve PENDING → redirect a /user-pending
   ↓
admin aprueba Application en /admin/applications
   ↓
/api/apply/[id] PATCH en transacción:
   - Application.status = APPROVED
   - User.role = creator (excepto admins)
   - UserProfile.status = ACTIVE
   - dispara email "tu cuenta fue aprobada" (afuera de la transacción)
   ↓
user vuelve a /dashboard → entra normal
```

## CSP en modo report-only

Por ahora `Content-Security-Policy-Report-Only`. Razón: CSP es fácil de romper si se configura mal (Cloudinary uploads, Better Auth callbacks, Google fonts). Plan: observar violaciones en producción durante 1-2 semanas, después promover a `Content-Security-Policy` enforcing en PR siguiente cuando sepamos qué orígenes legítimos faltan.

## ⚠️ Migración Prisma — aplicación manual requerida al deployar

El repo usa `prisma db push` (sync directo). El cambio String → enum no se puede automatizar con `db push` (pediría reset o fallaría al castear datos existentes). Por eso:

- **SQL manual** en `prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql` con CREATE TYPE + UPDATEs (lowercase → UPPER) + ALTER COLUMN + CREATE INDEX. Transaccional (BEGIN/COMMIT).
- **Workflow**: `psql "$DATABASE_URL" -f prisma/migrations-manual/<file>.sql` ANTES de `prisma db push`.
- `prisma/migrations-manual/README.md` documenta el workflow y deja la puerta abierta para migrar a `prisma migrate` formal en el futuro.

## Threat model

**Rate limit cubre**:
- Bot agresivo desde IP única drenando Resend quota / spammeando inbox.
- Spam manual desde un browser que saltó honeypot + origin check.

**NO cubre**:
- Botnets con IP rotation (necesita captcha o fingerprinting — anotado en BACKLOG futuro).
- Atacante distribuido si el server corre en serverless con múltiples instancias (no es nuestro caso en el VPS hoy).

## Commits

```
3b149fa fix(auth): default new accounts to PENDING in user.create.after hook
c439f14 feat(admin): bump User.status + role when approving application
e704005 feat(security): IP-based rate limit + apply to /api/contact
28f24a6 feat(security): global security headers (CSP report-only, HSTS, X-Frame, etc.)
5900ba7 feat(prisma): ApplicationStatus enum + index on Application.email
9988c12 chore(backlog): mark rate-limit / prisma / security-headers as resolved
b2d5c1b chore(backend): apply architecture review feedback
```

El último commit (`b2d5c1b`) aplica feedback del architecture-reviewer interno: transacción en approve endpoint, log estructurado, schema PATCH limpio, res.ok check en cliente, rate-limit bypass en dev cuando IP === "unknown", cleanup al inicio de cada call, comment obsoleto actualizado.

## Deudas resueltas en BACKLOG

- ✅ Rate limit IP-based para `/api/contact` (MEDIA)
- ✅ Prisma: index en `Application.email` + enum `ApplicationStatus` (MEDIA)
- ✅ Security headers globales en `next.config.ts` (MEDIA)

Sigue activo bajo "Deudas de seguridad y privacidad":
- 🔴 GDPR consent + Datenschutzerklärung (ALTA) — explícitamente fuera de scope, próxima PR.
- 🟡 FK `Application.userId` (BAJA, bonus) — mejora del matching User↔Application.

## Test plan

### Flujo de cuenta (requiere DB local activa + Better Auth + Resend env)
- [ ] Aplicar la migración SQL local primero: `psql "$DATABASE_URL" -f prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql`.
- [ ] `pnpm exec prisma db push` (debería decir "Already in sync").
- [ ] Sign-up nuevo con email/password → redirect a `/dashboard` → `requireActive` redirige a `/user-pending`.
- [ ] Sign-up con Google OAuth → mismo comportamiento.
- [ ] Como PENDING, navegar a `/events`, `/artists`, `/contact` → permite acceso.
- [ ] Como PENDING, llenar `/apply` → submit OK, queda en estado "Solicitud enviada".
- [ ] Como admin, ir a `/admin/applications` → aprobar una application → ver el toast "Aprobado".
- [ ] El user aprobado vuelve a entrar a `/dashboard` → accede normal (status ACTIVE, role creator).

### Rate limit
- [ ] Enviar 3 mensajes desde `/contact` en menos de 60s → los 3 pasan.
- [ ] Enviar un 4to → toast "Demasiadas solicitudes".
- [ ] Esperar 60s → poder enviar de nuevo.
- [ ] En dev local sin nginx delante: NO rate-limita (bypass cuando IP === "unknown").

### Security headers
- [ ] Inspector → Network → Response Headers de cualquier ruta → ver los 6 headers nuevos.
- [ ] Intentar embeber el sitio en un `<iframe src="...">` externo → bloqueado por X-Frame-Options DENY.
- [ ] Console del browser → ver si CSP report-only loggea violaciones inesperadas (Cloudinary, Google OAuth, etc.).

### Prisma
- [ ] `\\d "Application"` en psql → `status` debe ser tipo `ApplicationStatus`, no text.
- [ ] `\\di "Application_email_idx"` → debe existir.
- [ ] Crear Application via `/apply` → status del row queda `PENDING`.
- [ ] Aprobar via admin → status queda `APPROVED`.

## Nota post-merge (al deployar)

1. Backup de la DB de producción primero.
2. Aplicar el SQL: `psql "$PRODUCTION_DATABASE_URL" -f prisma/migrations-manual/2026-05-16_application_status_enum_and_email_index.sql`.
3. Deployar el código.
4. Sanity check: crear cuenta con mail temporal → debería caer en `/user-pending`.
5. Sanity check: aprobar la application del mail temporal → debería destrabar dashboard.
6. Observar logs de CSP durante 1-2 semanas; planificar PR de promotion a enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IP-based rate limiting on contact submissions with retry-after messaging
  * Global security headers enabled site-wide
  * Typed application statuses with PENDING/APPROVED/REJECTED and improved admin approval flow (triggers email on real transitions)

* **Bug Fixes / UX**
  * Admin UI and status badges updated to reflect new status values
  * Contact form shows specific rate-limit error messages

* **Documentation**
  * Prisma migrations manual and backlog updates (including resolved items and a low-priority FK note)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->