### PR TITLE
chore(deploy): install all Linux-native binaries after rsync

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,8 +18,33 @@ rsync -az --delete .next/ $VPS:$REMOTE_DIR/.next/
 echo "→ Syncing node_modules to VPS..."
 rsync -az --delete node_modules/ $VPS:$REMOTE_DIR/node_modules/
 
-echo "→ Installing Linux-specific native packages..."
-ssh $VPS "cd $REMOTE_DIR && npm install @parcel/watcher-linux-x64-glibc --no-save 2>/dev/null || true"
+echo "→ Installing Linux-specific native binaries..."
+# El rsync de `node_modules/` desde Mac (arm64) pisa los binarios nativos
+# Linux que necesita el runtime del VPS. Hay que re-instalarlos para que
+# Next/SWC/Tailwind/lightningcss/etc puedan cargar sus addons compilados.
+# `--no-save` evita modificar package.json/package-lock.json del VPS
+# (en el pasado se agregaron sin esa flag y quedó drift git que abortó
+# pulls — ver commit que introdujo este fix).
+#
+# Si en el futuro Next/Prisma/Tailwind suben de versión y agregan un
+# binario Linux nuevo, agregarlo a esta lista. Síntoma típico de uno
+# que falta: PM2 entra en restart loop apenas se hace `pm2 restart`, y
+# `pm2 logs lahuella` muestra "Cannot find module ...-linux-x64-..."
+# en el primer log line.
+#
+# `|| true` mantiene back-compat con el patrón previo: si un install
+# falla (network down, versión renombrada), el deploy continúa. Deuda
+# conocida — si pasa, el sitio se rompe en runtime y lo notamos por
+# el health check siguiente.
+ssh $VPS "cd $REMOTE_DIR && npm install --no-save \
+  @next/swc-linux-x64-gnu \
+  @parcel/watcher-linux-x64-glibc \
+  @rolldown/binding-linux-x64-gnu \
+  @swc/core-linux-x64-gnu \
+  @tailwindcss/oxide-linux-x64-gnu \
+  @unrs/resolver-binding-linux-x64-gnu \
+  lightningcss-linux-x64-gnu \
+  2>/dev/null || true"
 
 echo "→ Regenerating Prisma client on VPS..."
 ssh $VPS "cd $REMOTE_DIR && npx prisma generate"


### PR DESCRIPTION
## Resumen

Fix de deuda crónica del deploy. `deploy.sh` rsyncea `node_modules/`
desde la Mac (arm64) al VPS Linux, pisando binarios nativos. La línea
de re-install actual solo cubre uno (`@parcel/watcher-linux-x64-glibc`),
los otros 6 binarios Linux fueron agregados a mano al `package.json` del
VPS sin `--no-save`, dejando drift git.

## Síntoma que disparó esto

Al intentar deployar PR #23 hoy, `git pull` en el VPS abortó:

```
error: Your local changes to the following files would be overwritten by merge:
  package-lock.json
  package.json
Aborting
```

Inspección del diff del VPS mostró que los cambios eran 7 binarios
Linux x64 sumados a `dependencies` (sin `--no-save` en su día).

## Cambio

Una línea que se vuelve 7 binarios en `npm install --no-save`. Más
comentarios extensos para que el próximo dev que vea esto sepa:
 - **Por qué** existe esa línea (rsync pisa binarios Linux).
 - **Síntoma** cuando un binario nuevo falta tras una update de Next/Prisma/etc.
   (PM2 restart loop + `Cannot find module ...-linux-x64-...` en logs).
 - **Cómo** detectarlo y agregarlo.

## Post-merge

Después de mergear:
1. SSH al VPS, `git reset --hard origin/main` para limpiar el drift histórico.
2. Re-correr `bash deploy.sh` desde local.
3. Esta vez el flow es determinístico — sin tocar el VPS a mano.

## Deuda registrada en el código

El `|| true` final enmascara fallas de install. Si en el futuro queremos
fail-fast, sacarlo + agregar health check post-restart. Anotado en el
comment del deploy.sh.

## Test plan

- [ ] Mergear esta PR.
- [ ] `git reset --hard origin/main` en VPS.
- [ ] `bash deploy.sh` desde local — debería completar sin abortar.
- [ ] `pm2 status` en VPS — sin restart loops.
- [ ] `curl -I https://lahuelladelcaminante.de` — 200 OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment process with improved handling of native binary dependencies on production servers, ensuring more reliable installation and better system compatibility while preserving existing deployment workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->