### PR TITLE
feat: public signup with separate creator application flow

### DIFF
--- a/prisma/migrations-manual/2026-05-20_userprofile_status_pending_to_active.sql
+++ b/prisma/migrations-manual/2026-05-20_userprofile_status_pending_to_active.sql
@@ -1,0 +1,38 @@
+-- Aplicar a la DB DESPUÉS de deployar el código de
+-- `feat/public-signup-creator-flow`.
+--
+-- Local: psql "$DATABASE_URL" -f prisma/migrations-manual/2026-05-20_userprofile_status_pending_to_active.sql
+-- Prod:  misma cosa apuntando a la URL de producción.
+--
+-- CONTEXTO
+-- Antes de este PR, el hook `user.create.after` escribía
+-- `UserProfile.status = PENDING` por default. El modelo nuevo separa
+-- el estado de la CUENTA (siempre `ACTIVE`) del rol creator: el
+-- "pending" de "todavía no sos creator" vive en `Application.status`,
+-- no en `UserProfile.status`. Las cuentas que nacieron con el hook
+-- viejo y quedaron en `PENDING` hay que normalizarlas a `ACTIVE` —
+-- su status nunca debió bloquear nada.
+--
+-- ESTADO AL ESCRIBIR ESTE SCRIPT (inspección de producción del
+-- 2026-05-20): **0 filas** en `UserProfile` con `status = 'PENDING'`.
+-- Este UPDATE es **no-op hoy**. Se deja documentado como red de
+-- seguridad por si una cuenta quedara en `PENDING` por un signup en
+-- vuelo durante el deploy, o por cualquier edge-case futuro.
+--
+-- IMPORTANTE: el UPDATE solo toca `status`. NUNCA `role`. Una cuenta
+-- con `role` creator/admin mantiene su rol intacto — solo se le
+-- normaliza el status que el hook viejo dejó mal. NO incluir `role`
+-- en el SET.
+--
+-- El `@default` de la columna (`PENDING` → `ACTIVE`) lo sincroniza
+-- `prisma db push` durante el deploy (cambio no-destructivo); no hace
+-- falta un ALTER COLUMN acá.
+--
+-- Idempotente: re-ejecutar el script no rompe nada (los UPDATEs
+-- siguientes matchean 0 filas).
+
+BEGIN;
+
+UPDATE "UserProfile" SET "status" = 'ACTIVE' WHERE "status" = 'PENDING';
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,9 +68,14 @@ model Verification {
 // --- Tablas de dominio ---
 
 model UserProfile {
-  id        String     @id @default(cuid())
-  userId    String     @unique
-  status    UserStatus @default(PENDING)
+  id     String @id @default(cuid())
+  userId String @unique
+  // Estado de la CUENTA, no del rol. Toda cuenta nueva nace `ACTIVE`
+  // (signup público inmediato). `BLOCKED` solo si un admin la bloquea.
+  // El "pending" de "todavía no sos creator" vive en `Application.status`,
+  // no acá. El hook `user.create.after` siempre setea status explícito;
+  // este default cubre cualquier insert que lo omita.
+  status    UserStatus @default(ACTIVE)
   bio       String?
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt

--- a/src/app/[locale]/(protected)/dashboard/layout.tsx
+++ b/src/app/[locale]/(protected)/dashboard/layout.tsx
@@ -31,7 +31,12 @@ export default async function DashboardLayout({
   const { user } = await requireActive(locale)
 
   // Un `role: user` no es creator todavía → pantalla intermedia en vez
-  // del shell. `children` (los page.tsx de las sub-rutas) no se renderiza.
+  // del shell. Al no devolver `children`, los `page.tsx` de las
+  // sub-rutas ni siquiera se invocan (RSC los construye lazy como prop):
+  // su `requireRole("creator")` y sus fetches no corren. Por eso un user
+  // no-creator en `/dashboard/events/create` ve el gate sin loop ni
+  // doble-redirect. Invariante a preservar: este branch NUNCA debe
+  // renderizar `children`.
   if (!isCreatorOrAdmin(user.role)) {
     return <CreatorGate locale={locale} userEmail={user.email} />
   }

--- a/src/app/[locale]/(protected)/dashboard/layout.tsx
+++ b/src/app/[locale]/(protected)/dashboard/layout.tsx
@@ -2,13 +2,23 @@
  * Layout del dashboard del creator (y admin que tenga contenido propio).
  * Envuelve todo `/dashboard/**` con `DashboardShell` (sidebar desktop +
  * tab bar mobile). El check de auth ya lo hace `(protected)/layout.tsx`
- * arriba; acá solo necesitamos resolver el rol del user para pintar el
- * sidebar con el accent correcto.
+ * arriba; acá resolvemos el rol para decidir qué renderizar.
+ *
+ * Modelo de cuenta (`feat/public-signup-creator-flow`): un `role: user`
+ * autenticado es legítimo — navega el sitio público — pero NO accede al
+ * panel creator. Cuando intenta entrar a `/dashboard/**`, en lugar de un
+ * redirect abrupto ve la pantalla intermedia `CreatorGate` (con 3
+ * sub-estados según su `Application`: nunca aplicó / esperando / rechazado).
+ *
+ * `CreatorGate` se renderiza acá en el LAYOUT — no en `page.tsx` — para
+ * que cubra todo `/dashboard/**` (events, artists, profile, create…) con
+ * un solo punto de decisión. Un `user` no-creator que escriba a mano
+ * `/dashboard/events/create` ve el gate, no el shell de creator.
  */
 
-import { redirect } from "next/navigation"
 import { requireActive, isCreatorOrAdmin } from "@/services/auth"
 import DashboardShell from "@/components/dashboard/DashboardShell"
+import CreatorGate from "@/components/dashboard/CreatorGate"
 
 export default async function DashboardLayout({
   children,
@@ -20,14 +30,10 @@ export default async function DashboardLayout({
   const { locale } = await params
   const { user } = await requireActive(locale)
 
-  // Guard de rol: el dashboard está pensado para creator/admin. Un user
-  // común autenticado (role `user`) no debería ver el shell de creator
-  // ni las pantallas que asumen capacidad de crear eventos/artistas.
-  // Redirige a la home pública (la app no tiene una landing específica
-  // para `user` regular hoy). Centralizar el check acá evita repetirlo
-  // en cada page.
+  // Un `role: user` no es creator todavía → pantalla intermedia en vez
+  // del shell. `children` (los page.tsx de las sub-rutas) no se renderiza.
   if (!isCreatorOrAdmin(user.role)) {
-    redirect(`/${locale}`)
+    return <CreatorGate locale={locale} userEmail={user.email} />
   }
 
   // El dashboard de `/dashboard/**` es siempre creator-themed (fucsia +

--- a/src/components/dashboard/CreatorGate.tsx
+++ b/src/components/dashboard/CreatorGate.tsx
@@ -19,7 +19,13 @@
  *
  * El caso `APPROVED` no debería llegar acá (el user ya sería `creator`).
  * Si llega — approve a medias, role no bumpeado — se trata como
- * sub-estado 2 ("esperá") para no mostrar algo roto.
+ * sub-estado 2 ("esperá") para no mostrar algo roto, y se loggea un
+ * warning para que el estado inconsistente sea visible en los logs.
+ *
+ * NO monta su propio header/shell: vive dentro del `(protected)/layout.tsx`
+ * que ya provee `Header` + `Footer` globales. Solo aporta el `<main>`
+ * centrado. (El patrón "shell austero con BrandLockup propio" de
+ * `/user-pending` aplica allá porque esa ruta vive fuera de `(protected)`.)
  *
  * Server component — hace el query directo, sin estado. Solo el
  * `SignOutButton` del sub-estado 2 cruza a client.
@@ -28,7 +34,6 @@
 import { getTranslations } from "next-intl/server"
 import { Link } from "@/i18n/navigation"
 import { prisma } from "@/lib/prisma"
-import BrandLockup from "@/components/brand/BrandLockup"
 import StatusHero from "@/components/auth/StatusHero"
 import SignOutButton from "@/components/auth/SignOutButton"
 import Eyebrow from "@/components/ui/Eyebrow"
@@ -49,19 +54,13 @@ function formatApplicationDate(date: Date, locale: string): string {
   }).format(date)
 }
 
-/** Shell mínimo compartido por los 3 sub-estados: header austero con
- * BrandLockup + main centrado. Sin Header global ni DashboardShell —
- * el user acá no debería navegar nada salvo las CTAs del sub-estado. */
-function GateShell({ children }: { children: React.ReactNode }) {
+/** Contenedor centrado compartido por los 3 sub-estados. NO incluye
+ * header ni footer — el `(protected)/layout.tsx` ya los provee. */
+function GateLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-bg-page">
-      <header className="flex h-16 items-center px-l">
-        <BrandLockup orientation="horizontal" href="/" />
-      </header>
-      <main className="mx-auto flex max-w-[560px] flex-col items-center gap-l px-l py-2xl text-center">
-        {children}
-      </main>
-    </div>
+    <main className="mx-auto flex max-w-[560px] flex-col items-center gap-l px-l py-3xl text-center">
+      {children}
+    </main>
   )
 }
 
@@ -83,6 +82,17 @@ export default async function CreatorGate({
     application &&
     (application.status === "PENDING" || application.status === "APPROVED")
   ) {
+    if (application.status === "APPROVED") {
+      // Estado inconsistente: la Application está aprobada pero el user
+      // sigue siendo `role: user` (por eso llegó al gate). Significa que
+      // el approve no terminó de bumpear el role. Lo mostramos como
+      // "en revisión" para no exhibir algo roto, pero lo dejamos en
+      // logs para diagnóstico.
+      console.warn("creator_gate_approved_but_not_creator", {
+        email: userEmail,
+      })
+    }
+
     const t = await getTranslations({ locale, namespace: "account.pending" })
     const tAccount = await getTranslations({ locale, namespace: "account" })
     const formattedDate = formatApplicationDate(
@@ -91,7 +101,7 @@ export default async function CreatorGate({
     )
 
     return (
-      <GateShell>
+      <GateLayout>
         <StatusHero variant="pending" />
         <Eyebrow accent="editorial" as="p">
           {t("eyebrow")}
@@ -126,7 +136,7 @@ export default async function CreatorGate({
             className="h-11"
           />
         </div>
-      </GateShell>
+      </GateLayout>
     )
   }
 
@@ -135,7 +145,7 @@ export default async function CreatorGate({
   // ── Sub-estado 3 — Application REJECTED ──────────────────────────────
   if (application && application.status === "REJECTED") {
     return (
-      <GateShell>
+      <GateLayout>
         <Eyebrow accent="brand" as="p">
           {t("rejected.eyebrow")}
         </Eyebrow>
@@ -156,13 +166,13 @@ export default async function CreatorGate({
             <Link href="/contact">{t("rejected.ctaContact")}</Link>
           </Button>
         </div>
-      </GateShell>
+      </GateLayout>
     )
   }
 
   // ── Sub-estado 1 — nunca aplicó (no hay Application) ─────────────────
   return (
-    <GateShell>
+    <GateLayout>
       <Eyebrow accent="brand" as="p">
         {t("notCreator.eyebrow")}
       </Eyebrow>
@@ -183,6 +193,6 @@ export default async function CreatorGate({
           <Link href="/">{t("notCreator.ctaHome")}</Link>
         </Button>
       </div>
-    </GateShell>
+    </GateLayout>
   )
 }

--- a/src/components/dashboard/CreatorGate.tsx
+++ b/src/components/dashboard/CreatorGate.tsx
@@ -69,11 +69,12 @@ export default async function CreatorGate({
   userEmail,
 }: CreatorGateProps) {
   // Application más reciente del user (puede haber aplicado más de una
-  // vez). `select` acotado — solo necesitamos status + fecha.
+  // vez). `select` acotado — status + fecha + id (el id solo se usa
+  // para el log de diagnóstico del caso APPROVED-a-medias, sin PII).
   const application = await prisma.application.findFirst({
     where: { email: userEmail },
     orderBy: { createdAt: "desc" },
-    select: { status: true, createdAt: true },
+    select: { id: true, status: true, createdAt: true },
   })
 
   // ── Sub-estado 2 — Application PENDING (o APPROVED a medias) ──────────
@@ -88,8 +89,12 @@ export default async function CreatorGate({
       // el approve no terminó de bumpear el role. Lo mostramos como
       // "en revisión" para no exhibir algo roto, pero lo dejamos en
       // logs para diagnóstico.
+      //
+      // Logueamos `applicationId` (cuid random, no-PII) en lugar del
+      // email — alcanza para ir directo al row de Application en la DB
+      // sin filtrar un identificador personal a los logs.
       console.warn("creator_gate_approved_but_not_creator", {
-        email: userEmail,
+        applicationId: application.id,
       })
     }
 

--- a/src/components/dashboard/CreatorGate.tsx
+++ b/src/components/dashboard/CreatorGate.tsx
@@ -1,0 +1,188 @@
+/**
+ * CreatorGate — pantalla intermedia que ve un usuario con `role: user`
+ * al intentar entrar a `/dashboard`.
+ *
+ * Desde el cambio de modelo (`feat/public-signup-creator-flow`), una
+ * cuenta nueva nace `ACTIVE` + `role: user` — navega el sitio público
+ * pero NO accede al panel creator. Cuando intenta entrar a `/dashboard`,
+ * el `DashboardLayout` renderiza este componente en lugar del
+ * `DashboardShell`.
+ *
+ * Tres sub-estados según la `Application` del usuario (matcheada por
+ * email — `Application` no tiene FK a `User`):
+ *  1. Sin Application → "tu cuenta todavía no es de creator" + CTA aplicar.
+ *  2. Application PENDING → pantalla de "en revisión" (mismo patrón
+ *     visual que `/user-pending`, reusa `StatusHero` + copy
+ *     `account.pending.*`).
+ *  3. Application REJECTED → "tu solicitud no fue aprobada" + CTA
+ *     volver a aplicar (decisión cerrada: se puede re-aplicar).
+ *
+ * El caso `APPROVED` no debería llegar acá (el user ya sería `creator`).
+ * Si llega — approve a medias, role no bumpeado — se trata como
+ * sub-estado 2 ("esperá") para no mostrar algo roto.
+ *
+ * Server component — hace el query directo, sin estado. Solo el
+ * `SignOutButton` del sub-estado 2 cruza a client.
+ */
+
+import { getTranslations } from "next-intl/server"
+import { Link } from "@/i18n/navigation"
+import { prisma } from "@/lib/prisma"
+import BrandLockup from "@/components/brand/BrandLockup"
+import StatusHero from "@/components/auth/StatusHero"
+import SignOutButton from "@/components/auth/SignOutButton"
+import Eyebrow from "@/components/ui/Eyebrow"
+import { Button } from "@/components/ui/button"
+
+export interface CreatorGateProps {
+  locale: string
+  /** Email de la cuenta logueada — usado para matchear la `Application`. */
+  userEmail: string
+}
+
+/** Formato amigable de fecha. ES: `15 de mayo` · EN: `May 15` ·
+ * DE: `15. Mai`. Mismo formato que `/user-pending`. */
+function formatApplicationDate(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+  }).format(date)
+}
+
+/** Shell mínimo compartido por los 3 sub-estados: header austero con
+ * BrandLockup + main centrado. Sin Header global ni DashboardShell —
+ * el user acá no debería navegar nada salvo las CTAs del sub-estado. */
+function GateShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-bg-page">
+      <header className="flex h-16 items-center px-l">
+        <BrandLockup orientation="horizontal" href="/" />
+      </header>
+      <main className="mx-auto flex max-w-[560px] flex-col items-center gap-l px-l py-2xl text-center">
+        {children}
+      </main>
+    </div>
+  )
+}
+
+export default async function CreatorGate({
+  locale,
+  userEmail,
+}: CreatorGateProps) {
+  // Application más reciente del user (puede haber aplicado más de una
+  // vez). `select` acotado — solo necesitamos status + fecha.
+  const application = await prisma.application.findFirst({
+    where: { email: userEmail },
+    orderBy: { createdAt: "desc" },
+    select: { status: true, createdAt: true },
+  })
+
+  // ── Sub-estado 2 — Application PENDING (o APPROVED a medias) ──────────
+  // Reusa el patrón visual de `/user-pending` + el copy `account.pending.*`.
+  if (
+    application &&
+    (application.status === "PENDING" || application.status === "APPROVED")
+  ) {
+    const t = await getTranslations({ locale, namespace: "account.pending" })
+    const tAccount = await getTranslations({ locale, namespace: "account" })
+    const formattedDate = formatApplicationDate(
+      application.createdAt,
+      locale
+    )
+
+    return (
+      <GateShell>
+        <StatusHero variant="pending" />
+        <Eyebrow accent="editorial" as="p">
+          {t("eyebrow")}
+        </Eyebrow>
+        <h1 className="text-display-m font-display leading-tight text-fg-primary">
+          {t.rich("title", {
+            accent: (chunks) => (
+              <span className="text-editorial italic">{chunks}</span>
+            ),
+          })}
+        </h1>
+        <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+          {t.rich("bodyWithDate", {
+            date: formattedDate,
+            strong: (chunks) => (
+              <strong className="font-semibold text-fg-primary">
+                {chunks}
+              </strong>
+            ),
+          })}
+        </p>
+        <div className="mt-s flex flex-wrap items-center justify-center gap-s">
+          <Button
+            asChild
+            className="h-11 bg-brand text-on-brand font-semibold hover:bg-brand-dim"
+          >
+            <Link href="/events">{t("ctaPrimary")}</Link>
+          </Button>
+          <SignOutButton
+            label={t("ctaSecondary")}
+            errorLabel={tAccount("signOutError")}
+            className="h-11"
+          />
+        </div>
+      </GateShell>
+    )
+  }
+
+  const t = await getTranslations({ locale, namespace: "account.creatorGate" })
+
+  // ── Sub-estado 3 — Application REJECTED ──────────────────────────────
+  if (application && application.status === "REJECTED") {
+    return (
+      <GateShell>
+        <Eyebrow accent="brand" as="p">
+          {t("rejected.eyebrow")}
+        </Eyebrow>
+        <h1 className="text-display-m font-display leading-tight text-fg-primary">
+          {t("rejected.title")}
+        </h1>
+        <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+          {t("rejected.body")}
+        </p>
+        <div className="mt-s flex flex-wrap items-center justify-center gap-s">
+          <Button
+            asChild
+            className="h-11 bg-brand text-on-brand font-semibold hover:bg-brand-dim"
+          >
+            <Link href="/apply">{t("rejected.ctaReapply")}</Link>
+          </Button>
+          <Button asChild variant="outline" className="h-11">
+            <Link href="/contact">{t("rejected.ctaContact")}</Link>
+          </Button>
+        </div>
+      </GateShell>
+    )
+  }
+
+  // ── Sub-estado 1 — nunca aplicó (no hay Application) ─────────────────
+  return (
+    <GateShell>
+      <Eyebrow accent="brand" as="p">
+        {t("notCreator.eyebrow")}
+      </Eyebrow>
+      <h1 className="text-display-m font-display leading-tight text-fg-primary">
+        {t("notCreator.title")}
+      </h1>
+      <p className="text-body-l leading-relaxed text-fg-secondary max-w-[44ch]">
+        {t("notCreator.body")}
+      </p>
+      <div className="mt-s flex flex-wrap items-center justify-center gap-s">
+        <Button
+          asChild
+          className="h-11 bg-brand text-on-brand font-semibold hover:bg-brand-dim"
+        >
+          <Link href="/apply">{t("notCreator.ctaApply")}</Link>
+        </Button>
+        <Button asChild variant="outline" className="h-11">
+          <Link href="/">{t("notCreator.ctaHome")}</Link>
+        </Button>
+      </div>
+    </GateShell>
+  )
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,15 +30,22 @@ export const auth = betterAuth({
     user: {
       create: {
         after: async (user) => {
-          // Decisión de producto cerrada: cuenta nace PENDING para que
-          // el flow de `/user-pending` se active de verdad. Excepciones:
-          //  - Cuenta con Application APPROVED previa (sign-up post
-          //    aprobación) → activar y subir a creator inmediatamente.
-          //  - Cuenta con `role: admin` (seed manual o creación interna
-          //    desde código) → respetar y dejar ACTIVE. Sign-up público
-          //    no puede asignar role admin (Better Auth `defaultRole:
-          //    "user"` lo bloquea), pero el check defensivo evita
-          //    bloquear al primer admin del seed si lo creamos via DB.
+          // Modelo de cuenta (decisión cerrada — ver
+          // `feat/public-signup-creator-flow`): `UserProfile.status`
+          // representa el estado de la CUENTA, no del rol. Toda cuenta
+          // nueva nace `ACTIVE` — el signup es público e inmediato. El
+          // "pending" de "todavía no sos creator" no vive acá, vive en
+          // `Application.status`.
+          //
+          // Tres caminos:
+          //  - `role: admin` → ACTIVE (seed manual / creación interna).
+          //  - Application APPROVED previa por email → ACTIVE + sube
+          //    role a `creator` (alguien aplicó, fue aprobado, y recién
+          //    después crea la cuenta).
+          //  - Default → ACTIVE + role `user`. Navega el sitio público;
+          //    si quiere publicar eventos, aplica como creator vía
+          //    `/apply` y la `Application` queda PENDING hasta que un
+          //    admin la apruebe.
           if (user.role === "admin") {
             await prisma.userProfile.create({
               data: { userId: user.id, status: "ACTIVE" },
@@ -51,7 +58,7 @@ export const auth = betterAuth({
           })
 
           if (approvedApplication) {
-            // Cuenta nace ACTIVE + creator solo si ya hubo aprobación
+            // Cuenta nace ACTIVE + creator porque ya hubo aprobación
             // previa de su Application — el matching es por email
             // porque Application no tiene FK a User.
             //
@@ -70,14 +77,14 @@ export const auth = betterAuth({
               }),
             ])
           } else {
-            // Caso default: cuenta nueva sin Application aprobada nace
-            // PENDING. El usuario puede browsear el sitio público; al
-            // intentar entrar a `/dashboard`, `requireActive()` lo
-            // redirige a `/user-pending`. Pasa a ACTIVE cuando admin
-            // aprueba una Application con su mismo email (ver
-            // `src/app/api/apply/[id]/route.ts`).
+            // Caso default: cuenta nueva nace ACTIVE + role `user`
+            // (heredado del `defaultRole: "user"` de Better Auth). El
+            // usuario tiene acceso normal al sitio público. Al intentar
+            // entrar a `/dashboard`, el layout le muestra la pantalla
+            // intermedia de creator-gate (`CreatorGate`) en lugar del
+            // panel — desde ahí puede aplicar como creator.
             await prisma.userProfile.create({
-              data: { userId: user.id, status: "PENDING" },
+              data: { userId: user.id, status: "ACTIVE" },
             })
           }
         },

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -551,7 +551,7 @@
       "heroAriaLabel": "Manifest und Agenda",
       "eyebrow": "WILLKOMMEN ZURÜCK",
       "title": "Melde dich an.",
-      "subtitle": "Nur zum Stöbern hier? Du brauchst kein Konto, um Shows zu sehen. Das hier ist für Künstler und Veranstalter.",
+      "subtitle": "Du brauchst kein Konto, um Shows zu sehen. Melde dich an, um zu deinem Konto zurückzukehren.",
       "continueWith": "Mit {provider} fortfahren",
       "orEmail": "ODER MIT E-MAIL",
       "emailLabel": "E-Mail",
@@ -561,7 +561,7 @@
       "forgot": "Passwort vergessen?",
       "submit": "Anmelden →",
       "submitting": "Anmeldung läuft...",
-      "footer": "Zum ersten Mal hier? <createAccount>Konto erstellen</createAccount> oder <applyAsArtist>als Künstler bewerben →</applyAsArtist>",
+      "footer": "Zum ersten Mal hier? <createAccount>Konto erstellen</createAccount> oder <applyAsArtist>als Creator bewerben →</applyAsArtist>",
       "errors": {
         "credentials": "E-Mail oder Passwort falsch.",
         "email_required": "E-Mail ist erforderlich.",
@@ -584,7 +584,7 @@
       "heroAriaLabel": "Schritte des Ablaufs",
       "eyebrow": "KONTO ERSTELLEN",
       "title": "Fang an zu <accent>veröffentlichen.</accent>",
-      "subtitle": "Konto erstellen ist der erste Schritt. Dann bewirbst du dich als Creator und wir prüfen dein Profil — meistens 1-2 Tage.",
+      "subtitle": "Ein Konto zu erstellen ist kostenlos und sofort. Wenn du später Events veröffentlichen willst, bewirbst du dich als Creator — das prüfen wir, meistens 1-2 Tage.",
       "continueWith": "Mit {provider} fortfahren",
       "orEmail": "ODER MIT E-MAIL",
       "nameLabel": "Name",
@@ -611,7 +611,7 @@
         "generic": "Wir konnten dein Konto nicht erstellen. Versuche es erneut."
       },
       "hero": {
-        "eyebrow": "DREI SCHRITTE · ANDERTHALB TAGE",
+        "eyebrow": "DREI SCHRITTE ZUM VERÖFFENTLICHEN",
         "title": "Vom neuen Konto zum Live-Event <accent>in Tagen</accent>.",
         "step1Title": "Konto erstellen",
         "step1Time": "Jetzt sofort · 1 Min.",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -646,6 +646,22 @@
       "canSee": "Du kannst weiterhin alle öffentlichen Events der Seite sehen.",
       "canBrowse": "Du kannst weiterhin Künstlerprofile ansehen.",
       "cannot": "Du kannst nicht veröffentlichen, bearbeiten oder auf das Creator-Panel zugreifen."
+    },
+    "creatorGate": {
+      "notCreator": {
+        "eyebrow": "CREATOR-PANEL",
+        "title": "Dein Konto ist noch kein Creator-Konto.",
+        "body": "Um Events auf La Huella zu veröffentlichen, musst du dich zuerst als Creator bewerben. Wir prüfen jede Anfrage — meistens dauert es 1-2 Tage.",
+        "ctaApply": "Als Creator bewerben →",
+        "ctaHome": "Zur Startseite"
+      },
+      "rejected": {
+        "eyebrow": "ANFRAGE GEPRÜFT",
+        "title": "Deine Anfrage wurde diesmal nicht genehmigt.",
+        "body": "Du kannst dich jederzeit erneut bewerben. Wenn du Fragen zum Warum hast, schreib uns.",
+        "ctaReapply": "Erneut bewerben →",
+        "ctaContact": "Schreib uns"
+      }
     }
   },
   "common": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -551,7 +551,7 @@
       "heroAriaLabel": "Manifesto and agenda",
       "eyebrow": "WELCOME BACK",
       "title": "Sign in.",
-      "subtitle": "Just here to browse? You don't need an account to see shows. This is for artists and organizers.",
+      "subtitle": "You don't need an account to see shows. Sign in to get back into yours.",
       "continueWith": "Continue with {provider}",
       "orEmail": "OR WITH EMAIL",
       "emailLabel": "Email",
@@ -561,7 +561,7 @@
       "forgot": "Forgot your password?",
       "submit": "Sign in →",
       "submitting": "Signing in...",
-      "footer": "First time here? <createAccount>Create account</createAccount> or <applyAsArtist>apply as an artist →</applyAsArtist>",
+      "footer": "First time here? <createAccount>Create account</createAccount> or <applyAsArtist>apply as a creator →</applyAsArtist>",
       "errors": {
         "credentials": "Wrong email or password.",
         "email_required": "Email is required.",
@@ -584,7 +584,7 @@
       "heroAriaLabel": "Process steps",
       "eyebrow": "CREATE ACCOUNT",
       "title": "Start <accent>publishing.</accent>",
-      "subtitle": "Creating an account is step one. Then you apply as a creator and we review your profile — usually 1-2 days.",
+      "subtitle": "Creating an account is free and instant. If you later want to publish events, you apply as a creator — that part we review, usually 1-2 days.",
       "continueWith": "Continue with {provider}",
       "orEmail": "OR WITH EMAIL",
       "nameLabel": "Name",
@@ -611,7 +611,7 @@
         "generic": "We couldn't create your account. Try again."
       },
       "hero": {
-        "eyebrow": "THREE STEPS · ONE AND A HALF DAYS",
+        "eyebrow": "THREE STEPS TO PUBLISH",
         "title": "From new account to live event <accent>in days</accent>.",
         "step1Title": "Create the account",
         "step1Time": "Right now · 1 min.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -646,6 +646,22 @@
       "canSee": "You can still see all the public events on the site.",
       "canBrowse": "You can still browse artist profiles.",
       "cannot": "You can't publish, edit or access the creator panel."
+    },
+    "creatorGate": {
+      "notCreator": {
+        "eyebrow": "CREATOR PANEL",
+        "title": "Your account isn't a creator account yet.",
+        "body": "To publish events on La Huella, you first need to apply as a creator. We review every request — it usually takes 1-2 days.",
+        "ctaApply": "Apply as a creator →",
+        "ctaHome": "Back to home"
+      },
+      "rejected": {
+        "eyebrow": "REQUEST REVIEWED",
+        "title": "Your request wasn't approved this time.",
+        "body": "You can apply again whenever you want. If you have questions about why, get in touch.",
+        "ctaReapply": "Apply again →",
+        "ctaContact": "Get in touch"
+      }
     }
   },
   "common": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -551,7 +551,7 @@
       "heroAriaLabel": "Manifiesto y agenda",
       "eyebrow": "BIENVENIDO DE VUELTA",
       "title": "Iniciá sesión.",
-      "subtitle": "¿Sos público? No necesitás cuenta para ver shows. Esto es para artistas y organizadores.",
+      "subtitle": "No necesitás cuenta para ver shows. Iniciá sesión para volver a la tuya.",
       "continueWith": "Continuar con {provider}",
       "orEmail": "O CON EMAIL",
       "emailLabel": "Email",
@@ -561,7 +561,7 @@
       "forgot": "¿Olvidaste tu contraseña?",
       "submit": "Iniciar sesión →",
       "submitting": "Iniciando sesión...",
-      "footer": "¿Primera vez por acá? <createAccount>Crear cuenta</createAccount> o <applyAsArtist>aplicá como artista →</applyAsArtist>",
+      "footer": "¿Primera vez por acá? <createAccount>Crear cuenta</createAccount> o <applyAsArtist>aplicá como creator →</applyAsArtist>",
       "errors": {
         "credentials": "Email o contraseña incorrectos.",
         "email_required": "El email es obligatorio.",
@@ -584,7 +584,7 @@
       "heroAriaLabel": "Pasos del proceso",
       "eyebrow": "CREAR CUENTA",
       "title": "Empezá a <accent>publicar.</accent>",
-      "subtitle": "Crear cuenta es el primer paso. Después aplicás como creator y revisamos tu perfil — suele tomar 1-2 días.",
+      "subtitle": "Crear cuenta es gratis e inmediato. Si después querés publicar eventos, aplicás como creator — eso lo revisamos, suele tomar 1-2 días.",
       "continueWith": "Continuar con {provider}",
       "orEmail": "O CON EMAIL",
       "nameLabel": "Nombre",
@@ -611,7 +611,7 @@
         "generic": "No pudimos crear tu cuenta. Probá de nuevo."
       },
       "hero": {
-        "eyebrow": "TRES PASOS · UN DÍA Y MEDIO",
+        "eyebrow": "TRES PASOS PARA PUBLICAR",
         "title": "De cuenta nueva a evento <accent>en vivo</accent>.",
         "step1Title": "Creás la cuenta",
         "step1Time": "Ahora mismo · 1 min.",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -646,6 +646,22 @@
       "canSee": "Podés ver todos los eventos públicos del sitio.",
       "canBrowse": "Podés seguir consultando perfiles de artistas.",
       "cannot": "No podés publicar, editar ni acceder al panel creator."
+    },
+    "creatorGate": {
+      "notCreator": {
+        "eyebrow": "PANEL DE CREATOR",
+        "title": "Tu cuenta todavía no es de creator.",
+        "body": "Para publicar eventos en La Huella, primero tenés que aplicar como creator. Revisamos cada solicitud — suele tomar 1-2 días.",
+        "ctaApply": "Aplicar como creator →",
+        "ctaHome": "Volver al inicio"
+      },
+      "rejected": {
+        "eyebrow": "SOLICITUD REVISADA",
+        "title": "Tu solicitud no fue aprobada esta vez.",
+        "body": "Podés volver a aplicar cuando quieras. Si tenés dudas sobre por qué, escribinos.",
+        "ctaReapply": "Volver a aplicar →",
+        "ctaContact": "Escribinos"
+      }
     }
   },
   "common": {


### PR DESCRIPTION
## Resumen

Separa el **status de la cuenta** del **rol creator** — antes estaban mezclados y bloqueaban todo.

**Antes**: el hook `user.create.after` creaba cuentas con `UserProfile.status: PENDING`. Cualquier signup quedaba bloqueado esperando aprobación admin, incluso para alguien que solo quiere navegar el sitio.

**Ahora**:
- `UserProfile.status` = estado de la **cuenta**. Toda cuenta nueva nace `ACTIVE`. Solo `BLOCKED` si un admin la bloquea.
- `Application.status` = estado de la **solicitud para ser creator** (`PENDING`/`APPROVED`/`REJECTED`).
- `User.role` = `user` por default → sube a `creator` cuando admin aprueba una Application.

**El "pending" vive en `Application.status`, no en `UserProfile.status`.** Signup público inmediato; solo quien quiere publicar eventos aplica como creator y eso sí requiere review.

## Paso 0 — inspección de producción (ejecutado, OK del dev)

`UserProfile` por status: **7 ACTIVE, 0 PENDING, 0 BLOCKED**. La migración SQL (Objetivo 6) es **no-op** — 0 filas. Se deja el SQL documentado como red de seguridad.

## Cambios

| Commit | Qué |
|---|---|
| `579ab37` | Hook `user.create.after` → cuentas nacen `ACTIVE` + `role: user`. Schema `UserProfile.status @default(ACTIVE)`. Excepciones intactas (admin, Application APPROVED previa). |
| `4b834b9` | Componente nuevo `CreatorGate` — pantalla intermedia en `/dashboard` para no-creators, 3 sub-estados (nunca aplicó / esperando / rechazado). El layout la renderiza en lugar del redirect abrupto. i18n `account.creatorGate.*` en ES/EN/DE. |
| `8c19e30` | Copy de sign-in/sign-up — sacar "te revisamos 1-2 días" como universal. 4 keys × 3 idiomas. |
| `33738c7` | SQL manual `UserProfile PENDING→ACTIVE` (no-op, 0 filas). Red de seguridad documentada. |
| `2fd6861` | Fixes del architecture-reviewer interno (ver abajo). |

## Pantalla intermedia `CreatorGate` — 3 sub-estados

Cuando un `role: user` entra a `/dashboard`, en lugar de redirect abrupto ve `CreatorGate` (renderizado en `dashboard/layout.tsx` para cubrir todo `/dashboard/**`):

1. **Sin Application** → "tu cuenta todavía no es de creator" + CTA "Aplicar como creator →".
2. **Application PENDING** → pantalla "en revisión" (reusa `StatusHero` + copy `account.pending.*` + fecha real).
3. **Application REJECTED** → "tu solicitud no fue aprobada" + CTA "Volver a aplicar →" (decisión cerrada: se puede re-aplicar).

## Objetivos 2 y 4 — ya estaban correctos de PR #23

- **Middleware** (`src/proxy.ts`): no necesita cambios. Un `user` autenticado pasa el guard de `/dashboard`; el layout decide mostrar el gate.
- **Admin approve** (`/api/apply/[id]`): ya hace `role → creator` al aprobar. (Nota: también toca `UserProfile.status: ACTIVE` — con el modelo nuevo es un no-op idempotente / self-heal, inofensivo.)

## Architecture review interno (commit `2fd6861`)

0 CRITICAL, 1 MAJOR, 3 MINOR. Aplicados:
- **MAJOR**: `CreatorGate` montaba su propio header → doble chrome con el Header/Footer del `(protected)/layout.tsx`. Ahora solo aporta el `<main>` centrado.
- **MINOR**: comentario explícito del invariante "el branch no renderiza children".
- Edge-case "Application APPROVED a medias" ahora loggea `console.warn` en vez de quedar oculto.

Quedan para backlog (MINOR, no bloqueantes): limpiar el estado `PENDING` muerto (post-deploy); extraer componente compartido del sub-estado "en revisión" (CreatorGate y `/user-pending` lo duplican).

## Orden de operaciones en producción (post-merge)

1. Mergear PR.
2. Deploy del código (`deploy.sh`).
3. Recién entonces: aplicar la migración SQL `prisma/migrations-manual/2026-05-20_*.sql` (no-op, 0 filas) + `prisma db push` sincroniza el `@default`.
4. Verificar los checks funcionales.

## Test plan

- [ ] Crear cuenta nueva → nace ACTIVE + user → navega el sitio, NO entra a `/dashboard`.
- [ ] Como user nuevo, ir a `/dashboard` → ve `CreatorGate` sub-estado 1 (CTA aplicar).
- [ ] Aplicar como creator → volver a `/dashboard` → sub-estado 2 (esperando, con fecha).
- [ ] Como admin, aprobar la application → el user pasa a `creator`.
- [ ] El user recién aprobado entra a `/dashboard` → ve el panel real.
- [ ] Como admin, rechazar otra application → el user ve sub-estado 3 (rechazado, puede reaplicar).
- [ ] Cuenta admin → entra a `/admin` y `/dashboard` normal, sin gate.
- [ ] Escribir a mano `/dashboard/events/create` como user no-creator → ve el gate, no el shell.
- [ ] `npm run build` sin errores. ✅ (verificado)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard access gate that shows creator application status (not applied, pending, rejected) with appropriate CTAs.

* **Behavioral Changes**
  * New user accounts are now active by default; creator permissions remain subject to application review.
  * Non-creators visiting the dashboard see the gate screen instead of an immediate redirect.

* **Chores**
  * One-time migration to normalize existing account statuses and align defaults.

* **Documentation**
  * Updated sign-in/sign-up copy and added creator-gate messaging across supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->