### PR TITLE
fix: correct creator vs artist naming in dashboard onboarding

### DIFF
--- a/src/components/dashboard/OnboardingChecklist.tsx
+++ b/src/components/dashboard/OnboardingChecklist.tsx
@@ -1,8 +1,14 @@
 /**
  * OnboardingChecklist — los 3 StepCards del primer ingreso al dashboard del
- * creator: (1) crear perfil de artista, (2) publicar evento, (3) compartir
+ * creator: (1) crear el primer artista, (2) publicar evento, (3) compartir
  * link. Recibe el estado de cada paso (`hasArtist`, `hasEvent`) y resuelve
  * los textos vía i18n.
+ *
+ * Nota de naming: el paso 1 da de alta una entidad `Artist` (el músico /
+ * banda que el creator presenta), NO el perfil del creator mismo. El
+ * `profile` en `labels`/`hrefs` es un nombre de slot legacy — el copy
+ * visible ya dice "artista". (Renombrar el slot tocaría el caller; queda
+ * fuera del scope "solo copy" de este fix.)
  *
  * Estados de cada paso:
  *  - Pendiente: card en su estado completo (eyebrow número + título + descr.

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -307,16 +307,16 @@
     },
     "welcome": {
       "eyebrow": "Willkommen bei La Huella",
-      "title": "Drei Schritte, damit deine Musik sichtbar wird.",
+      "title": "Drei Schritte, um dein erstes Event zu veröffentlichen.",
       "body": "Dein Konto wurde freigegeben — willkommen bei la huella. Wir begleiten dich bis zur ersten veröffentlichten Veranstaltung."
     },
     "steps": {
       "pending": "Offen",
       "done": "Erledigt",
       "profile": {
-        "title": "Erstelle dein Künstlerprofil",
-        "body": "Foto, Bio, Links zu Instagram und Spotify. Das ist die Seite, die erscheint, wenn jemand auf deine Veranstaltung klickt.",
-        "cta": "Profil erstellen"
+        "title": "Erstelle deinen ersten Künstler",
+        "body": "Ein Künstler ist der Musiker oder die Band, die du präsentierst — Foto, Bio, Links zu Instagram und Spotify. Das ist die Seite, die sich öffnet, wenn jemand auf dein Event tippt.",
+        "cta": "Künstler erstellen"
       },
       "event": {
         "title": "Veröffentliche deine erste Veranstaltung",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -307,16 +307,16 @@
     },
     "welcome": {
       "eyebrow": "Welcome to La Huella",
-      "title": "Three steps to get your music out there.",
+      "title": "Three steps to publish your first event.",
       "body": "Your account was approved — welcome to la huella. We'll walk you through publishing your first event."
     },
     "steps": {
       "pending": "Pending",
       "done": "Done",
       "profile": {
-        "title": "Create your artist profile",
-        "body": "Photo, bio, links to Instagram, Spotify. It's the page that shows up when someone clicks your event.",
-        "cta": "Create profile"
+        "title": "Create your first artist",
+        "body": "An artist is the musician or band you present — photo, bio, links to Instagram and Spotify. It's the page that opens when someone taps your event.",
+        "cta": "Create artist"
       },
       "event": {
         "title": "Publish your first event",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -307,16 +307,16 @@
     },
     "welcome": {
       "eyebrow": "Te damos la bienvenida",
-      "title": "Tres pasos para que tu música aparezca.",
+      "title": "Tres pasos para publicar tu primer evento.",
       "body": "Tu cuenta fue aprobada — qué bueno tenerte en la huella. Te acompañamos hasta publicar tu primer evento."
     },
     "steps": {
       "pending": "Pendiente",
       "done": "Hecho",
       "profile": {
-        "title": "Creá tu perfil de artista",
-        "body": "Foto, biografía, links de Instagram, Spotify. Es la página que aparece cuando alguien hace clic en tu evento.",
-        "cta": "Crear perfil"
+        "title": "Creá tu primer artista",
+        "body": "El artista es el músico o banda que presentás — foto, bio, links a Instagram y Spotify. Es la ficha que se abre cuando alguien toca tu evento.",
+        "cta": "Crear artista"
       },
       "event": {
         "title": "Publicá tu primer evento",


### PR DESCRIPTION
## Resumen

PR cosmético — solo copy. Corrige la confusión "artista" vs "creator" en el onboarding del dashboard.

## Investigación (reportada al dev antes de cambiar copy)

El paso 01 del onboarding (`dashboard.steps.profile`) decía **"Creá tu perfil de artista"** y su CTA lleva a **`/dashboard/artists/create`** → da de alta una **entidad `Artist`** (el músico/banda que el creator presenta), NO el perfil del creator.

Dos problemas:
1. "tu perfil de artista" sugería el perfil personal del creator. La acción real es "crear un artista" (otra entidad).
2. Todo el onboarding asumía que **el creator es músico** — `welcome.title` decía "Tres pasos para que **tu música** aparezca", falso para un organizador/promotor que no toca.

**Constraint**: el "fix profundo" (paso 01 = completar el perfil del organizador) requeriría un modelo `CreatorProfile` que no existe — es un item de backlog (`/creators`). Por eso el fix viable es **solo copy**.

## Decisiones cerradas con el dev

- **Término**: `creator` (consistente con el role, `CreatorGate`, el accent y el namespace ya usados en el código).
- **Alcance**: paso 01 + welcome neutral.

## Cambios (ES/EN/DE)

| Key | Antes | Ahora |
|---|---|---|
| `dashboard.welcome.title` | "Tres pasos para que tu música aparezca." | "Tres pasos para publicar tu primer evento." |
| `dashboard.steps.profile.title` | "Creá tu perfil de artista" | "Creá tu primer artista" |
| `dashboard.steps.profile.body` | "Foto, biografía, links..." | aclara que el artista es el músico/banda presentado |
| `dashboard.steps.profile.cta` | "Crear perfil" | "Crear artista" |

JSDoc de `OnboardingChecklist` actualizado con una nota: el slot `profile` es nombre legacy — el paso crea un `Artist`. Renombrar el slot tocaría el caller → fuera del scope "solo copy".

## Fuera de alcance (verificado)

- La nav del dashboard ("Mi perfil" → `/dashboard/profile`, "Mis artistas" → `/dashboard/artists`) **ya estaba correcta** — no se tocó.
- Lógica de los StepCards, rutas, schema, entidad `Artist`: intactos.

## Test plan

- [ ] `npm run build` sin errores. ✅ (verificado)
- [ ] Onboarding del dashboard (creator recién aprobado, sin contenido) muestra "Creá tu primer artista" en el paso 01.
- [ ] El welcome ya no dice "tu música".
- [ ] Cambio de idioma ES/EN/DE — copy traducido coherente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding checklist documentation to clarify the artist creation step.
  * Refined onboarding messaging in English, German, and Spanish to emphasize publishing your first event and creating your first artist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->