### PR TITLE
feat: post-signup redirect and signup emails (welcome + admin notification)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -17,9 +17,13 @@ CLOUDINARY_API_SECRET=
 RESEND_API_KEY=
 
 # Email destino de los mensajes que llegan desde /contact (form de contacto
-# público). Si no se define, cae a info@lahuelladelcaminante.de (mismo
-# destino que las notificaciones de /apply).
+# público). Si no se define, cae a info@lahuelladelcaminante.de.
 CONTACT_RECIPIENT_EMAIL=info@example.com
+
+# Email interno del equipo: notificaciones del sistema (nuevos signups y
+# nuevas applications de creator desde /apply). Separado de
+# CONTACT_RECIPIENT_EMAIL. Si no se define, cae a info@lahuelladelcaminante.de.
+ADMIN_NOTIFICATION_EMAIL=info@example.com
 
 # Trigger.dev
 TRIGGER_SECRET_KEY=

--- a/src/app/[locale]/(auth)/sign-in/page.tsx
+++ b/src/app/[locale]/(auth)/sign-in/page.tsx
@@ -22,6 +22,7 @@ import SignInForm from "@/components/auth/SignInForm"
 import Eyebrow from "@/components/ui/Eyebrow"
 import FlyerImage from "@/components/ui/FlyerImage"
 import { getFeaturedEvents, getUpcomingStats } from "@/services/events"
+import { sanitizeReturnTo } from "@/lib/safe-redirect"
 
 export async function generateMetadata({
   params,
@@ -35,11 +36,29 @@ export async function generateMetadata({
 
 export default async function SignInPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>
+  searchParams: Promise<{ returnTo?: string | string[] }>
 }) {
   const { locale } = await params
   setRequestLocale(locale)
+
+  // `returnTo`: ruta interna a la que volver tras el login, propagada por
+  // el `proxy.ts` cuando intercepta un acceso no autenticado a una ruta
+  // protegida. Se valida acá (trust boundary) — `sanitizeReturnTo`
+  // descarta URLs externas y similares (anti open-redirect). `undefined`
+  // si no es válida → el form cae a su default (`/dashboard`).
+  const { returnTo: rawReturnTo } = await searchParams
+  const returnTo =
+    sanitizeReturnTo(
+      typeof rawReturnTo === "string" ? rawReturnTo : undefined
+    ) ?? undefined
+  // El link "crear cuenta" debe arrastrar el `returnTo` para que, si la
+  // persona se registra en vez de loguearse, igual vuelva a destino.
+  const signUpHref = returnTo
+    ? { pathname: "/sign-up", query: { returnTo } }
+    : "/sign-up"
 
   const t = await getTranslations({ locale, namespace: "auth.signIn" })
   const tHero = await getTranslations({ locale, namespace: "auth.signIn.hero" })
@@ -111,13 +130,13 @@ export default async function SignInPage({
           {t("subtitle")}
         </p>
 
-        <SignInForm locale={locale} />
+        <SignInForm locale={locale} returnTo={returnTo} />
 
         <p className="text-body-s text-fg-secondary">
           {t.rich("footer", {
             createAccount: (chunks) => (
               <Link
-                href="/sign-up"
+                href={signUpHref}
                 className="font-semibold text-fg-primary underline-offset-4 hover:underline"
               >
                 {chunks}

--- a/src/app/[locale]/(auth)/sign-up/page.tsx
+++ b/src/app/[locale]/(auth)/sign-up/page.tsx
@@ -19,6 +19,7 @@ import { Link } from "@/i18n/navigation"
 import AuthShell from "@/components/auth/AuthShell"
 import SignUpForm from "@/components/auth/SignUpForm"
 import Eyebrow from "@/components/ui/Eyebrow"
+import { sanitizeReturnTo } from "@/lib/safe-redirect"
 
 export async function generateMetadata({
   params,
@@ -42,11 +43,29 @@ const STEPS = [
 
 export default async function SignUpPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>
+  searchParams: Promise<{ returnTo?: string | string[] }>
 }) {
   const { locale } = await params
   setRequestLocale(locale)
+
+  // `returnTo`: ruta interna a la que volver tras el signup, propagada
+  // por el `proxy.ts` cuando intercepta un acceso no autenticado a una
+  // ruta protegida. Se valida acá (trust boundary) — `sanitizeReturnTo`
+  // descarta URLs externas y similares (anti open-redirect). `undefined`
+  // si no es válida → el form cae a su default (la home).
+  const { returnTo: rawReturnTo } = await searchParams
+  const returnTo =
+    sanitizeReturnTo(
+      typeof rawReturnTo === "string" ? rawReturnTo : undefined
+    ) ?? undefined
+  // Si la persona llegó acá desde una ruta protegida, el link a sign-in
+  // debe arrastrar el `returnTo` para no perderlo en el cruce.
+  const signInHref = returnTo
+    ? { pathname: "/sign-in", query: { returnTo } }
+    : "/sign-in"
 
   const t = await getTranslations({ locale, namespace: "auth.signUp" })
   const tHero = await getTranslations({ locale, namespace: "auth.signUp.hero" })
@@ -122,13 +141,13 @@ export default async function SignUpPage({
           {t("subtitle")}
         </p>
 
-        <SignUpForm locale={locale} />
+        <SignUpForm locale={locale} returnTo={returnTo} />
 
         <p className="text-body-s text-fg-secondary">
           {t.rich("footer", {
             signInLink: (chunks) => (
               <Link
-                href="/sign-in"
+                href={signInHref}
                 className="font-semibold text-fg-primary underline-offset-4 hover:underline"
               >
                 {chunks}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -4,8 +4,10 @@
  * SignInForm — form client de `/sign-in`. Maneja:
  *  - Validación cliente con zod (`signInSchema`) via react-hook-form.
  *  - OAuth Google via Better Auth `signIn.social` (redirect del browser).
- *  - Email/password via Better Auth `signIn.email`. En éxito, navigate a
- *    `/dashboard` (preserva locale via i18n-aware `useRouter`).
+ *  - Email/password via Better Auth `signIn.email`. En éxito navega a la
+ *    ruta `returnTo` si la persona llegó desde una ruta protegida (el
+ *    `proxy.ts` propaga ese param), o a `/dashboard` por default.
+ *    Preserva el locale via el `useRouter` i18n-aware.
  *  - Mapeo de errores de Better Auth a copy amigable i18n (no exponer
  *    mensajes técnicos en inglés del SDK al user final).
  *
@@ -23,6 +25,7 @@ import { toast } from "sonner"
 import { useRouter } from "@/i18n/navigation"
 import { Link } from "@/i18n/navigation"
 import { signIn } from "@/lib/auth-client"
+import { withLocale } from "@/lib/safe-redirect"
 import { signInSchema, type SignInInput } from "@/lib/validators/auth"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -80,9 +83,13 @@ export interface SignInFormProps {
   /** Locale activo del request — usado para el `callbackURL` de OAuth y
    * para resolver redirects post-login. */
   locale: string
+  /** Ruta interna (locale-less, ej. `/dashboard`) a la que volver tras el
+   * login. La pasa la page ya validada con `sanitizeReturnTo`. Si no
+   * viene, el login cae a `/dashboard`. */
+  returnTo?: string
 }
 
-export default function SignInForm({ locale }: SignInFormProps) {
+export default function SignInForm({ locale, returnTo }: SignInFormProps) {
   const t = useTranslations("auth.signIn")
   const tErrors = useTranslations("auth.signIn.errors")
   const router = useRouter()
@@ -119,7 +126,8 @@ export default function SignInForm({ locale }: SignInFormProps) {
       return
     }
 
-    router.push("/dashboard")
+    // `router` es locale-aware: `/dashboard` → `/es/dashboard`.
+    router.push(returnTo ?? "/dashboard")
   }
 
   function handleGoogleClick() {
@@ -127,11 +135,11 @@ export default function SignInForm({ locale }: SignInFormProps) {
     // devuelve. Try/catch defensivo por si el SDK rechaza síncronamente
     // (config inválida, popup bloqueado, etc.) — sin esto el botón
     // queda en disabled silencioso. `callbackURL` debe incluir el
-    // locale para volver a la versión correcta del dashboard.
+    // locale (Better Auth redirige el browser sin pasar por next-intl).
     try {
       signIn.social({
         provider: "google",
-        callbackURL: `/${locale}/dashboard`,
+        callbackURL: withLocale(locale, returnTo ?? "/dashboard"),
       })
     } catch {
       toast.error(errorMessageFor("generic"))

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -12,11 +12,12 @@
  *  - OAuth Google (decisión consistente con sign-in: mantener el flow
  *    OAuth disponible en ambos lados).
  *
- * En éxito: redirige a `/dashboard`. Ahí `requireActive()` decide qué
- * mostrar según el `UserProfile.status` (PENDING → `/user-pending`,
- * BLOCKED → `/user-blocked`, ACTIVE → render del dashboard). No
- * deciden acá — toda la lógica de routing post-auth es responsabilidad
- * del guard de auth.
+ * En éxito redirige a la home (`/`, respetando el locale activo), o a la
+ * ruta `returnTo` si la persona llegó al sign-up desde una ruta protegida
+ * (el `proxy.ts` propaga ese param a sign-in/sign-up). Decisión de
+ * producto: la mayoría de los signups NO buscan el panel creator, así
+ * que el default es la home y no `/dashboard`. El `returnTo` ya llega
+ * validado como ruta interna desde la page (anti open-redirect).
  */
 
 import { useTranslations } from "next-intl"
@@ -25,6 +26,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { toast } from "sonner"
 import { useRouter, Link } from "@/i18n/navigation"
 import { signUp, signIn } from "@/lib/auth-client"
+import { withLocale } from "@/lib/safe-redirect"
 import { signUpSchema, type SignUpInput } from "@/lib/validators/auth"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -75,9 +77,13 @@ function mapAuthErrorToCode(error?: {
 
 export interface SignUpFormProps {
   locale: string
+  /** Ruta interna (locale-less, ej. `/dashboard`) a la que volver tras el
+   * signup. La pasa la page ya validada con `sanitizeReturnTo`. Si no
+   * viene, el signup directo cae a la home. */
+  returnTo?: string
 }
 
-export default function SignUpForm({ locale }: SignUpFormProps) {
+export default function SignUpForm({ locale, returnTo }: SignUpFormProps) {
   const t = useTranslations("auth.signUp")
   const tErrors = useTranslations("auth.signUp.errors")
   const router = useRouter()
@@ -115,7 +121,8 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
       return
     }
 
-    router.push("/dashboard")
+    // `router` es locale-aware: `/` → `/es`, `/dashboard` → `/es/dashboard`.
+    router.push(returnTo ?? "/")
   }
 
   function handleGoogleClick() {
@@ -125,7 +132,9 @@ export default function SignUpForm({ locale }: SignUpFormProps) {
     try {
       signIn.social({
         provider: "google",
-        callbackURL: `/${locale}/dashboard`,
+        // `callbackURL` necesita el locale explícito: Better Auth hace un
+        // redirect directo del browser, no pasa por el router de next-intl.
+        callbackURL: withLocale(locale, returnTo ?? "/"),
       })
     } catch {
       toast.error(errorMessageFor("generic"))

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,55 @@ import { betterAuth } from "better-auth"
 import { prismaAdapter } from "better-auth/adapters/prisma"
 import { admin } from "better-auth/plugins"
 import { prisma } from "./prisma"
+import { routing } from "@/i18n/routing"
+import {
+  triggerSignupWelcome,
+  triggerSignupAdminNotification,
+} from "./trigger"
+
+/**
+ * Detecta el locale del signup a partir de los headers del request que
+ * disparó la creación del user. Se usa para enviar el email de bienvenida
+ * en el idioma que la persona tenía activo en el sitio.
+ *
+ *  1. Cookie `NEXT_LOCALE` — la setea el middleware de next-intl y
+ *     persiste entre navegaciones. Funciona tanto para el signup
+ *     email/password como para el callback de Google OAuth (en OAuth el
+ *     request final lo origina nuestro dominio, así que la cookie viaja).
+ *  2. Header `Referer` — la página de signup es `/<locale>/sign-up`.
+ *     Respaldo para email/password si faltara la cookie; en OAuth el
+ *     referer es de Google y no matchea.
+ *  3. Fallback: `es` (default del sitio — decisión cerrada del spec).
+ */
+function detectSignupLocale(headers: Headers | null): string {
+  const fallback = routing.defaultLocale
+  if (!headers) return fallback
+  const supported = routing.locales as readonly string[]
+
+  const cookie = headers.get("cookie")
+  if (cookie) {
+    // next-intl escribe `NEXT_LOCALE` con el código de locale crudo
+    // (`es`/`en`/`de`) — sin URL-encoding, así que no hace falta (ni
+    // conviene) `decodeURIComponent`, que podría tirar `URIError` ante
+    // un valor de cookie malformado.
+    const match = cookie.match(/(?:^|;\s*)NEXT_LOCALE=([^;]+)/)
+    if (match && supported.includes(match[1])) {
+      return match[1]
+    }
+  }
+
+  const referer = headers.get("referer")
+  if (referer) {
+    try {
+      const segment = new URL(referer).pathname.split("/")[1]?.toLowerCase()
+      if (segment && supported.includes(segment)) return segment
+    } catch {
+      // Referer malformado — ignorar y caer al fallback.
+    }
+  }
+
+  return fallback
+}
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, { provider: "postgresql" }),
@@ -29,7 +78,7 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        after: async (user) => {
+        after: async (user, context) => {
           // Modelo de cuenta (decisión cerrada — ver
           // `feat/public-signup-creator-flow`): `UserProfile.status`
           // representa el estado de la CUENTA, no del rol. Toda cuenta
@@ -50,43 +99,72 @@ export const auth = betterAuth({
             await prisma.userProfile.create({
               data: { userId: user.id, status: "ACTIVE" },
             })
-            return
-          }
-
-          const approvedApplication = await prisma.application.findFirst({
-            where: { email: user.email, status: "APPROVED" },
-          })
-
-          if (approvedApplication) {
-            // Cuenta nace ACTIVE + creator porque ya hubo aprobación
-            // previa de su Application — el matching es por email
-            // porque Application no tiene FK a User.
-            //
-            // Las dos writes van en una transacción para que el
-            // onboarding sea atómico: si falla la promoción a creator
-            // tras crear el profile, no quedamos con UserProfile
-            // ACTIVE pero role "user" (caso silencioso donde el user
-            // tiene panel destrabado pero sin permisos de creación).
-            await prisma.$transaction([
-              prisma.userProfile.create({
-                data: { userId: user.id, status: "ACTIVE" },
-              }),
-              prisma.user.update({
-                where: { id: user.id },
-                data: { role: "creator" },
-              }),
-            ])
           } else {
-            // Caso default: cuenta nueva nace ACTIVE + role `user`
-            // (heredado del `defaultRole: "user"` de Better Auth). El
-            // usuario tiene acceso normal al sitio público. Al intentar
-            // entrar a `/dashboard`, el layout le muestra la pantalla
-            // intermedia de creator-gate (`CreatorGate`) en lugar del
-            // panel — desde ahí puede aplicar como creator.
-            await prisma.userProfile.create({
-              data: { userId: user.id, status: "ACTIVE" },
+            const approvedApplication = await prisma.application.findFirst({
+              where: { email: user.email, status: "APPROVED" },
             })
+
+            if (approvedApplication) {
+              // Cuenta nace ACTIVE + creator porque ya hubo aprobación
+              // previa de su Application — el matching es por email
+              // porque Application no tiene FK a User.
+              //
+              // Las dos writes van en una transacción para que el
+              // onboarding sea atómico: si falla la promoción a creator
+              // tras crear el profile, no quedamos con UserProfile
+              // ACTIVE pero role "user" (caso silencioso donde el user
+              // tiene panel destrabado pero sin permisos de creación).
+              await prisma.$transaction([
+                prisma.userProfile.create({
+                  data: { userId: user.id, status: "ACTIVE" },
+                }),
+                prisma.user.update({
+                  where: { id: user.id },
+                  data: { role: "creator" },
+                }),
+              ])
+            } else {
+              // Caso default: cuenta nueva nace ACTIVE + role `user`
+              // (heredado del `defaultRole: "user"` de Better Auth). El
+              // usuario tiene acceso normal al sitio público. Al intentar
+              // entrar a `/dashboard`, el layout le muestra la pantalla
+              // intermedia de creator-gate (`CreatorGate`) en lugar del
+              // panel — desde ahí puede aplicar como creator.
+              await prisma.userProfile.create({
+                data: { userId: user.id, status: "ACTIVE" },
+              })
+            }
           }
+
+          // Emails de signup — bienvenida al user (en su idioma) + aviso
+          // interno al admin. Fire-and-forget: el `.catch` evita que una
+          // falla de Resend tumbe la creación de la cuenta, y no se
+          // `await`-ean para no sumar latencia al signup. El server es un
+          // proceso Node persistente (PM2): las promesas pendientes
+          // terminan aunque el handler ya haya respondido.
+          //
+          // Se envían para TODO signup, incluido el camino creator
+          // (Application aprobada) y el seed de admin — el spec pide "uno
+          // por cada signup". El nudge "aplicá como creator" del email de
+          // bienvenida es info inocua incluso para quien ya es creator.
+          const locale = detectSignupLocale(context?.request?.headers ?? null)
+          triggerSignupWelcome({
+            email: user.email,
+            name: user.name,
+            locale,
+          }).catch(() => {
+            // Breadcrumb sin PII para los logs de PM2 — el signup nunca
+            // debe fallar por un problema de envío de email.
+            console.error("signup_welcome_email_failed")
+          })
+          triggerSignupAdminNotification({
+            email: user.email,
+            name: user.name,
+            locale,
+            createdAt: user.createdAt,
+          }).catch(() => {
+            console.error("signup_admin_email_failed")
+          })
         },
       },
     },

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -22,6 +22,19 @@ const envSchema = z.object({
     .email()
     .optional()
     .default("info@lahuelladelcaminante.de"),
+  /**
+   * Email interno del equipo al que llegan las notificaciones del
+   * sistema: nuevas applications de creator (`/apply`) y nuevos signups.
+   * Separado a propósito de `CONTACT_RECIPIENT_EMAIL` (mensajes públicos
+   * de `/contact`) para poder rutear, a futuro, las notificaciones
+   * internas y los mensajes de contacto a inboxes distintas sin tocar
+   * código. Si no está definida, cae a `info@lahuelladelcaminante.de`.
+   */
+  ADMIN_NOTIFICATION_EMAIL: z
+    .string()
+    .email()
+    .optional()
+    .default("info@lahuelladelcaminante.de"),
 })
 
 export const env = envSchema.parse(process.env)

--- a/src/lib/safe-redirect.ts
+++ b/src/lib/safe-redirect.ts
@@ -1,0 +1,90 @@
+/**
+ * Helpers para los redirects post-auth (sign-up / sign-in).
+ *
+ * El flujo `returnTo`: cuando el `proxy.ts` intercepta un acceso no
+ * autenticado a una ruta protegida, redirige a `/sign-in` agregando un
+ * `?returnTo=<ruta>`. Los forms de auth leen ese param y, tras
+ * autenticarse, mandan al user de vuelta a donde quería ir. Si no hay
+ * `returnTo`, el signup cae a la home y el sign-in al dashboard.
+ *
+ * El `returnTo` que produce el proxy es SIN prefijo de locale (ej.
+ * `/dashboard`) — el router locale-aware de next-intl le re-agrega el
+ * locale activo. Por eso estos helpers trabajan con rutas locale-less.
+ *
+ * Módulo puro (sin imports): se usa tanto en server components (las
+ * pages de auth, donde se valida el param) como en client components
+ * (los forms, para el `callbackURL` de OAuth).
+ */
+
+/** Tope de longitud defensivo para el `returnTo`. Una ruta interna real
+ * nunca se acerca a esto; un valor más largo es input basura/hostil. */
+const MAX_RETURN_TO_LENGTH = 512
+
+/** True si `value` contiene algún carácter de control ASCII (U+0000–
+ * U+001F) o DEL (U+007F). Se chequea con códigos en vez de un regex con
+ * escapes de control para no meter bytes crudos en el fuente. */
+function hasControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f) return true
+  }
+  return false
+}
+
+/**
+ * Valida un `returnTo` (untrusted — viene de un query param) y devuelve
+ * una ruta interna segura, o `null` si no lo es.
+ *
+ * Defensa contra open-redirect: sin esta validación un atacante podría
+ * pasar `?returnTo=https://evil.com` o `?returnTo=//evil.com` y, al
+ * usarlo en el redirect post-auth, mandaríamos al user a un dominio
+ * externo (vector de phishing). Solo aceptamos rutas internas absolutas.
+ *
+ * Reglas (todas deben cumplirse):
+ *  - Es un string no vacío y no supera `MAX_RETURN_TO_LENGTH`.
+ *  - Empieza con `/` (ruta absoluta).
+ *  - No contiene `//` en NINGUNA posición — `//evil.com` es una URL
+ *    protocol-relative; un `//` interno (`/x//evil.com`) podría
+ *    reinterpretarse como host si una capa downstream normaliza la ruta.
+ *  - No contiene `\` — algunos browsers normalizan `\` a `/`, así que
+ *    `/\evil.com` o `/x\@evil.com` podrían escapar.
+ *  - No contiene `..` — path traversal: `/es/../evil` normaliza fuera
+ *    del prefijo de locale. Una ruta interna real nunca trae `..`.
+ *  - No contiene caracteres de control ni whitespace — evita
+ *    contrabandear una segunda URL o romper el redirect.
+ */
+export function sanitizeReturnTo(
+  value: string | null | undefined
+): string | null {
+  if (!value) return null
+  if (value.length > MAX_RETURN_TO_LENGTH) return null
+  if (!value.startsWith("/")) return null
+  if (value.includes("//")) return null
+  if (value.includes("\\")) return null
+  if (value.includes("..")) return null
+  if (hasControlChar(value)) return null
+  if (/\s/.test(value)) return null
+  return value
+}
+
+/**
+ * Construye una URL interna locale-prefijada y segura. Se usa para el
+ * `callbackURL` de OAuth (Better Auth hace un redirect directo del
+ * browser, no pasa por el router de next-intl, así que necesita la ruta
+ * con el locale ya incluido).
+ *
+ * Pasa `path` por `sanitizeReturnTo`: si no es una ruta interna válida,
+ * cae a la home del locale. Así el resultado SIEMPRE es una ruta interna
+ * de nuestro dominio — la función es segura aunque un caller futuro le
+ * pase un `path` sin sanear (defensa en profundidad, no depende de la
+ * disciplina del caller).
+ *
+ * `withLocale("es", "/")` → `/es`
+ * `withLocale("es", "/dashboard")` → `/es/dashboard`
+ * `withLocale("es", "https://evil.com")` → `/es` (input inválido → home)
+ */
+export function withLocale(locale: string, path: string): string {
+  const safe = sanitizeReturnTo(path)
+  if (!safe || safe === "/") return `/${locale}`
+  return `/${locale}${safe}`
+}

--- a/src/lib/trigger.ts
+++ b/src/lib/trigger.ts
@@ -1,3 +1,6 @@
+import { createTranslator } from "next-intl"
+import { env } from "./env"
+
 async function sendEmail(
   to: string,
   subject: string,
@@ -251,8 +254,231 @@ export async function triggerApplicationNotification(payload: {
 </html>`
 
   await sendEmail(
-    "info@lahuelladelcaminante.de",
+    env.ADMIN_NOTIFICATION_EMAIL,
     `Nueva solicitud: ${payload.name} quiere publicar eventos`,
+    html
+  )
+}
+
+// Locales soportados para el email de bienvenida. El copy de los 3 vive
+// en `src/messages/{es,en,de}.json` bajo `emails.welcomeUser`. Debe
+// mantenerse en sincronía con `routing.locales` (`src/i18n/routing.ts`):
+// si se agrega un idioma al sitio, sumarlo acá y al `switch` de
+// `loadEmailMessages`.
+const EMAIL_LOCALES = ["es", "en", "de"] as const
+type EmailLocale = (typeof EMAIL_LOCALES)[number]
+
+/** Normaliza un locale arbitrario al set soportado. Fallback: `es`
+ * (default del sitio) — decisión cerrada del spec. */
+function normalizeEmailLocale(locale: string): EmailLocale {
+  return (EMAIL_LOCALES as readonly string[]).includes(locale)
+    ? (locale as EmailLocale)
+    : "es"
+}
+
+/** Etiqueta legible del idioma para el email interno al admin. */
+const LOCALE_LABEL: Record<EmailLocale, string> = {
+  es: "Español",
+  en: "English",
+  de: "Deutsch",
+}
+
+/**
+ * Carga el JSON de mensajes de un locale. Import dinámico con string
+ * estático (un chunk por idioma) — mismo enfoque que `src/i18n/request.ts`.
+ * El `createTranslator` de next-intl resuelve el copy sin depender de un
+ * request scope, así que sirve dentro del hook de Better Auth.
+ */
+async function loadEmailMessages(locale: EmailLocale) {
+  switch (locale) {
+    case "en":
+      return (await import("../messages/en.json")).default
+    case "de":
+      return (await import("../messages/de.json")).default
+    default:
+      return (await import("../messages/es.json")).default
+  }
+}
+
+/**
+ * Email de bienvenida al usuario que acaba de registrarse. Se envía en
+ * el idioma que tenía activo en el sitio al momento del signup (ES/EN/DE,
+ * fallback ES). Tono editorial y corto.
+ *
+ * IMPORTANTE: el signup es inmediato — la cuenta nace activa. Este email
+ * NO promete "revisión en 1-2 días" (eso es solo para el flujo creator
+ * de `/apply`). La mención del camino creator es informativa, no un CTA
+ * que presione.
+ */
+export async function triggerSignupWelcome(payload: {
+  email: string
+  name: string
+  locale: string
+}) {
+  const locale = normalizeEmailLocale(payload.locale)
+  const messages = await loadEmailMessages(locale)
+  const t = createTranslator({
+    locale,
+    messages,
+    namespace: "emails.welcomeUser",
+  })
+
+  const safeName = payload.name.trim()
+  // El nombre es lo único interpolado de fuente no controlada. Se escapa
+  // e interpola directo en el template literal del HTML — igual que en
+  // `triggerSignupAdminNotification` y `triggerContactNotification` — en
+  // vez de pasarlo por `t()`. Así el escape es una sola capa explícita,
+  // sin depender de cómo trate `createTranslator` los valores ICU. La
+  // key `greeting` es solo la palabra ("Hola"/"Hi"/"Hallo").
+  const greeting = safeName
+    ? `${t("greeting")} ${escapeHtml(safeName)},`
+    : `${t("greeting")},`
+  const eventsUrl = `https://lahuelladelcaminante.de/${locale}/events`
+  const applyUrl = `https://lahuelladelcaminante.de/${locale}/apply`
+
+  const html = `<!DOCTYPE html>
+<html lang="${locale}">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#0e0407;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#0e0407;padding:40px 20px">
+    <tr><td align="center">
+      <table width="100%" style="max-width:580px;background:#130609;border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,0.08)">
+
+        <tr><td style="background:linear-gradient(135deg,#7a1a0e 0%,#c0392b 50%,#7a1a0e 100%);padding:40px 32px;text-align:center">
+          <p style="color:rgba(255,255,255,0.6);font-size:11px;font-weight:700;letter-spacing:0.2em;text-transform:uppercase;margin:0 0 12px">La Huella del Caminante</p>
+          <h1 style="color:#ffffff;font-size:26px;font-weight:900;margin:0;line-height:1.2">${t("heading")}</h1>
+        </td></tr>
+
+        <tr><td style="padding:36px 32px">
+          <p style="color:#e8d5d0;font-size:16px;margin:0 0 20px;line-height:1.6">${greeting}</p>
+          <p style="color:#c4a9a4;font-size:15px;margin:0 0 16px;line-height:1.7">${t("intro")}</p>
+          <p style="color:#c4a9a4;font-size:15px;margin:0 0 28px;line-height:1.7">${t("body")}</p>
+
+          <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 28px">
+            <tr><td align="center">
+              <a href="${eventsUrl}"
+                 style="display:inline-block;background:#c0392b;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none;padding:14px 36px;border-radius:50px;letter-spacing:0.02em">
+                ${t("exploreCta")} →
+              </a>
+            </td></tr>
+          </table>
+
+          <table width="100%" cellpadding="0" cellspacing="0" style="background:#0e0407;border-radius:10px;padding:20px 24px">
+            <tr><td>
+              <p style="color:#c4a9a4;font-size:14px;margin:0 0 10px;line-height:1.6">${t("creatorNudge")}</p>
+              <p style="margin:0">
+                <a href="${applyUrl}" style="color:#c0392b;font-size:14px;font-weight:700;text-decoration:none">${t("creatorCta")} →</a>
+              </p>
+            </td></tr>
+          </table>
+        </td></tr>
+
+        <tr><td style="border-top:1px solid rgba(255,255,255,0.06);padding:20px 32px;text-align:center">
+          <p style="color:rgba(255,255,255,0.2);font-size:12px;margin:0">
+            © ${new Date().getFullYear()} La Huella del Caminante · Berlín
+          </p>
+        </td></tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+
+  await sendEmail(payload.email, t("subject"), html)
+}
+
+/**
+ * Email interno al admin avisando que hubo un signup nuevo. Uno por cada
+ * registro (decisión del spec — sin agrupamiento). Siempre en castellano
+ * (lo lee el founder). Destinatario: `env.ADMIN_NOTIFICATION_EMAIL`.
+ *
+ * Solo incluye lo necesario para que el admin sepa que hubo un alta:
+ * nombre, email, idioma usado y fecha. Sin datos sensibles extra.
+ */
+export async function triggerSignupAdminNotification(payload: {
+  email: string
+  name: string
+  locale: string
+  createdAt: Date
+}) {
+  const locale = normalizeEmailLocale(payload.locale)
+  // Defensa en profundidad: colapsar CRLF antes de que `name` toque el
+  // `Subject:` MIME header (mismo tratamiento que triggerContactNotification).
+  const safeSubjectName = payload.name
+    .replace(/[\r\n]+/g, " ")
+    .trim()
+    .slice(0, 100)
+  const fecha = new Intl.DateTimeFormat("es-ES", {
+    dateStyle: "long",
+    timeStyle: "short",
+    timeZone: "Europe/Berlin",
+  }).format(payload.createdAt)
+
+  const html = `<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#0e0407;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#0e0407;padding:40px 20px">
+    <tr><td align="center">
+      <table width="100%" style="max-width:580px;background:#130609;border-radius:16px;overflow:hidden;border:1px solid rgba(255,255,255,0.08)">
+
+        <tr><td style="background:#1a0c10;padding:28px 32px;border-bottom:1px solid rgba(255,255,255,0.06)">
+          <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.2em;text-transform:uppercase;margin:0 0 6px">La Huella del Caminante</p>
+          <h1 style="color:#ffffff;font-size:20px;font-weight:800;margin:0">Nuevo registro en la plataforma</h1>
+        </td></tr>
+
+        <tr><td style="padding:32px">
+          <p style="color:#c4a9a4;font-size:14px;margin:0 0 24px">
+            Una persona creó una cuenta nueva:
+          </p>
+
+          <table width="100%" cellpadding="0" cellspacing="0" style="background:#0e0407;border-radius:10px;overflow:hidden">
+            <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Nombre</p>
+              <p style="color:#ffffff;font-size:15px;font-weight:600;margin:0">${escapeHtml(payload.name)}</p>
+            </td></tr>
+            <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Email</p>
+              <p style="color:#c0392b;font-size:15px;font-weight:600;margin:0">
+                <a href="mailto:${escapeHtml(payload.email)}" style="color:#c0392b;text-decoration:none">${escapeHtml(payload.email)}</a>
+              </p>
+            </td></tr>
+            <tr><td style="padding:14px 20px;border-bottom:1px solid rgba(255,255,255,0.06)">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Idioma</p>
+              <p style="color:#e8d5d0;font-size:15px;margin:0">${LOCALE_LABEL[locale]} (${locale})</p>
+            </td></tr>
+            <tr><td style="padding:14px 20px">
+              <p style="color:rgba(255,255,255,0.4);font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;margin:0 0 4px">Fecha</p>
+              <p style="color:#e8d5d0;font-size:15px;margin:0">${escapeHtml(fecha)}</p>
+            </td></tr>
+          </table>
+
+          <table width="100%" cellpadding="0" cellspacing="0" style="margin:24px 0 0">
+            <tr><td align="center">
+              <a href="https://lahuelladelcaminante.de/es/admin/users"
+                 style="display:inline-block;background:#c0392b;color:#ffffff;font-size:14px;font-weight:700;text-decoration:none;padding:12px 28px;border-radius:50px">
+                Gestionar usuarios →
+              </a>
+            </td></tr>
+          </table>
+        </td></tr>
+
+        <tr><td style="border-top:1px solid rgba(255,255,255,0.06);padding:18px 32px;text-align:center">
+          <p style="color:rgba(255,255,255,0.2);font-size:12px;margin:0">
+            © ${new Date().getFullYear()} La Huella del Caminante · Berlín
+          </p>
+        </td></tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+
+  await sendEmail(
+    env.ADMIN_NOTIFICATION_EMAIL,
+    `Nuevo registro en La Huella: ${safeSubjectName || payload.email}`,
     html
   )
 }

--- a/src/lib/trigger.ts
+++ b/src/lib/trigger.ts
@@ -403,12 +403,19 @@ export async function triggerSignupAdminNotification(payload: {
   createdAt: Date
 }) {
   const locale = normalizeEmailLocale(payload.locale)
-  // Defensa en profundidad: colapsar CRLF antes de que `name` toque el
-  // `Subject:` MIME header (mismo tratamiento que triggerContactNotification).
+  // Defensa en profundidad: colapsar CRLF antes de que `name` o `email`
+  // toquen el `Subject:` MIME header (mismo tratamiento que
+  // `triggerContactNotification`). El email se usa como fallback del
+  // subject cuando no hay nombre — Better Auth ya valida su formato,
+  // pero lo saneamos igual por consistencia con `safeSubjectName`.
   const safeSubjectName = payload.name
     .replace(/[\r\n]+/g, " ")
     .trim()
     .slice(0, 100)
+  const safeSubjectEmail = payload.email
+    .replace(/[\r\n]+/g, " ")
+    .trim()
+    .slice(0, 120)
   const fecha = new Intl.DateTimeFormat("es-ES", {
     dateStyle: "long",
     timeStyle: "short",
@@ -478,7 +485,7 @@ export async function triggerSignupAdminNotification(payload: {
 
   await sendEmail(
     env.ADMIN_NOTIFICATION_EMAIL,
-    `Nuevo registro en La Huella: ${safeSubjectName || payload.email}`,
+    `Nuevo registro en La Huella: ${safeSubjectName || safeSubjectEmail}`,
     html
   )
 }

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -685,5 +685,17 @@
     "artistCreated": "Künstler erstellt",
     "eventDeleted": "Veranstaltung gelöscht",
     "notFound": "Seite nicht gefunden"
+  },
+  "emails": {
+    "welcomeUser": {
+      "subject": "Willkommen bei La Huella del Caminante",
+      "heading": "Willkommen auf dem Weg",
+      "greeting": "Hallo",
+      "intro": "La Huella del Caminante ist die Heimat der lateinamerikanischen Live-Musik in Deutschland.",
+      "body": "Dein Konto ist jetzt aktiv. Entdecke den Konzertkalender und Künstler aus der gesamten Szene.",
+      "exploreCta": "Veranstaltungen entdecken",
+      "creatorNudge": "Organisierst du Veranstaltungen? Du kannst dich als Creator bewerben, um deine eigenen zu veröffentlichen.",
+      "creatorCta": "Als Creator bewerben"
+    }
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -685,5 +685,17 @@
     "artistCreated": "Artist created",
     "eventDeleted": "Event deleted",
     "notFound": "Page not found"
+  },
+  "emails": {
+    "welcomeUser": {
+      "subject": "Welcome to La Huella del Caminante",
+      "heading": "Welcome to the journey",
+      "greeting": "Hi",
+      "intro": "La Huella del Caminante is the home of live Latin American music in Germany.",
+      "body": "Your account is now active. Explore the concert calendar and discover artists from across the scene.",
+      "exploreCta": "Explore events",
+      "creatorNudge": "Do you organize events? You can apply as a creator to publish your own on the platform.",
+      "creatorCta": "Apply as a creator"
+    }
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -685,5 +685,17 @@
     "artistCreated": "Artista creado",
     "eventDeleted": "Evento eliminado",
     "notFound": "Página no encontrada"
+  },
+  "emails": {
+    "welcomeUser": {
+      "subject": "Bienvenido a La Huella del Caminante",
+      "heading": "Bienvenido al camino",
+      "greeting": "Hola",
+      "intro": "La Huella del Caminante es el portal de la música latinoamericana en vivo en Alemania.",
+      "body": "Tu cuenta ya está activa. Podés explorar la agenda de conciertos y descubrir artistas de toda la escena.",
+      "exploreCta": "Explorar eventos",
+      "creatorNudge": "¿Organizás eventos? Podés aplicar como creator para publicar los tuyos en la plataforma.",
+      "creatorCta": "Aplicar como creator"
+    }
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,7 +46,19 @@ export async function proxy(request: NextRequest) {
     )
 
     if (!session) {
-      return NextResponse.redirect(new URL(`/${locale}/sign-in`, request.url))
+      // El user intentó entrar a una ruta protegida sin sesión. Lo
+      // mandamos a sign-in con un `returnTo` para que, tras autenticarse,
+      // vuelva a donde quería ir. `returnTo` va SIN prefijo de locale
+      // (`/dashboard`, no `/es/dashboard`) — el router locale-aware de
+      // los forms de auth le re-agrega el locale. Se incluye la query
+      // original por si era un deep link. El valor lo valida
+      // `sanitizeReturnTo` en la página que lo consume (anti open-redirect).
+      const signInUrl = new URL(`/${locale}/sign-in`, request.url)
+      signInUrl.searchParams.set(
+        "returnTo",
+        pathWithoutLocale + request.nextUrl.search
+      )
+      return NextResponse.redirect(signInUrl)
     }
 
     if (isAdmin && session.user.role !== "admin") {


### PR DESCRIPTION
## Contexto

Tras el deploy del signup público (PR #29), surgieron dos ajustes y una mejora de higiene:

1. **Redirect post-signup mal apuntado** — el signup mandaba a `/dashboard`, donde el usuario veía el `CreatorGate`. La mayoría de los signups no buscan el panel creator.
2. **No había emails de signup** — solo se enviaba email al aplicar como creator. Faltaba la bienvenida al usuario y el aviso al admin.
3. **Destinatario admin hardcodeado** — `triggerApplicationNotification` tenía `info@…` hardcodeado.

## Cambios

### 1 · Redirect post-signup → home (con `returnTo`)
- El signup directo cae a la home (`/`, respetando el locale); el sign-in a `/dashboard`.
- `proxy.ts` agrega `?returnTo=<ruta>` (locale-less) al redirigir rutas protegidas no autenticadas a `/sign-in`. Si la persona llegó desde una ruta protegida, vuelve ahí tras autenticarse.
- Nuevo helper `src/lib/safe-redirect.ts` → `sanitizeReturnTo` (anti open-redirect: rechaza URLs externas, protocol-relative, `//`/`..`/backslash, control chars, whitespace) + `withLocale` (auto-defensivo).
- Aplica a email/password y a Google OAuth. El `returnTo` se propaga en los links cruzados sign-in ↔ sign-up.

### 2 · Email de bienvenida al usuario (i18n ES/EN/DE)
- `triggerSignupWelcome` — tono editorial, corto, con mención sutil del camino creator (`/apply`). **No** promete revisión en X días: el signup es inmediato.
- Copy en `messages/{es,en,de}.json` bajo `emails.welcomeUser`, resuelto con `createTranslator` de next-intl. Fallback a ES.

### 3 · Email al admin por cada signup
- `triggerSignupAdminNotification` — en español, con nombre/email/idioma/fecha del nuevo usuario. Uno por registro (sin agrupamiento).

### 4 · Env var `ADMIN_NOTIFICATION_EMAIL`
- Nueva env var dedicada (default `info@lahuelladelcaminante.de`), separada de `CONTACT_RECIPIENT_EMAIL`. Documentada en `.env.local.example`.
- El email de application existente ahora también lee de ahí (ya no hardcode).

Los emails se disparan desde el hook `databaseHooks.user.create.after` de Better Auth (fire-and-forget — no bloquean ni pueden tumbar el signup). El locale del email se detecta de la cookie `NEXT_LOCALE` / `Referer`.

## Notas
- Se revisó con los agentes internos de arquitectura y seguridad; los hallazgos MAJOR (doble escape del nombre en el email; open-redirect residual vía `//` interno en el `callbackURL` de OAuth) ya están resueltos en el diff.
- Decisión consciente: las dos notificaciones internas al admin leen `env.ADMIN_NOTIFICATION_EMAIL` directo dentro de `trigger.ts` (el spec pide que "ambas lean de esa env var"); `triggerContactNotification` mantiene su `to` por parámetro sin tocarse (fuera de scope).

## Test plan
- [ ] `npm run build` sin errores — ✅ verificado local.
- [ ] Signup directo (email/password) → redirige a la home, no a `/dashboard`.
- [ ] Entrar a `/dashboard` sin login → sign-in con `returnTo` → registrarse → vuelve a `/dashboard` (ve el CreatorGate, correcto en ese caso).
- [ ] Signup con Google OAuth → mismo comportamiento de redirect.
- [ ] Tras un signup, en el dashboard de Resend: email de bienvenida al user **Delivered** + aviso al admin **Delivered**.
- [ ] Signup con el sitio en alemán → el email de bienvenida llega en alemán.
- [ ] Aplicar como creator (`/apply`) → el email sigue funcionando, ahora leyendo de `ADMIN_NOTIFICATION_EMAIL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in and sign-up flows now preserve the user's intended destination and respect locale.
  * New localized welcome emails sent to users; admins receive signup notifications.
  * Pre-approved creator applications are automatically activated during signup.

* **Bug Fixes**
  * Improved validation of redirect targets to prevent unsafe navigation.

* **Chores**
  * Added admin notification email configuration and clarified contact fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->