### PR TITLE
fix: point new-application email to /admin/applications

### DIFF
--- a/src/lib/trigger.ts
+++ b/src/lib/trigger.ts
@@ -233,9 +233,13 @@ export async function triggerApplicationNotification(payload: {
 
           <table width="100%" cellpadding="0" cellspacing="0" style="margin:24px 0 0">
             <tr><td align="center">
-              <a href="https://lahuelladelcaminante.de/es/admin/users"
+              <!-- Apunta a /admin/applications (no /admin/users): aprobar la
+                   solicitud ahí sube el rol a creator y notifica a la
+                   persona. Cambiar el rol a mano en /admin/users no hace
+                   ninguna de esas dos cosas. -->
+              <a href="https://lahuelladelcaminante.de/es/admin/applications"
                  style="display:inline-block;background:#c0392b;color:#ffffff;font-size:14px;font-weight:700;text-decoration:none;padding:12px 28px;border-radius:50px">
-                Gestionar usuarios →
+                Revisar solicitud →
               </a>
             </td></tr>
           </table>


### PR DESCRIPTION
## Problema

El email interno de aviso *"Nueva solicitud"* (el que recibe el admin cuando alguien aplica en `/apply`) tenía un botón **"Gestionar usuarios"** que apuntaba a `/admin/users`.

`/admin/users` es solo gestión manual de usuarios: cambiar el rol ahí **no** marca la `Application` como aprobada **ni** notifica al aplicante. El admin seguía ese link, cambiaba el rol a `creator`, y creía haber aceptado a la persona — pero la `Application` quedaba `PENDING` y el aplicante nunca recibía el email de aprobación.

## Fix

El botón ahora apunta a **`/admin/applications`** y se llama **"Revisar solicitud"**. Aprobar la solicitud ahí ejecuta el flujo completo (ya existente en `apply/[id]/route.ts`): marca la `Application` como `APPROVED`, sube el rol del usuario a `creator`, activa el `UserProfile`, y dispara el email de aprobación al aplicante.

Cambio de un solo archivo (`src/lib/trigger.ts`): el `href` del botón + su label, más un comentario que explica por qué `/admin/applications` y no `/admin/users`.

## Test plan
- [ ] `tsc --noEmit` — ✅ verificado local.
- [ ] Aplicar como creator en `/apply` → el email de aviso al admin llega con el botón "Revisar solicitud" apuntando a `/admin/applications`.
- [ ] Desde `/admin/applications`, aprobar la solicitud → el aplicante recibe el email de aprobación y queda con rol `creator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin notification links in application emails to direct to the correct review page for applications instead of user management.
  * Updated call-to-action button text to more clearly indicate the intended action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->