### PR TITLE
feat: show past events on home, add padding to past events page

### DIFF
--- a/src/app/[locale]/(public)/events/past/page.tsx
+++ b/src/app/[locale]/(public)/events/past/page.tsx
@@ -12,7 +12,11 @@ export default async function PastEventsPage({
   const events = await getPastEvents()
 
   return (
-    <div className="space-y-6">
+    // Contenedor con las mismas clases de ancho / gutter / padding
+    // vertical que `/events` y `/artists` — la página venía sin aire,
+    // pegada a los bordes del viewport. (El header con banda de esas
+    // páginas queda fuera de scope: acá solo se agrega el aire.)
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-10 space-y-6">
       <h1 className="text-3xl font-bold">{t("past")}</h1>
       <EventList events={events} />
     </div>

--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -5,6 +5,7 @@ import {
   getFeaturedEvents,
   getHeroVariant,
   getUpcomingEventsWithin,
+  getPastEvents,
   getActiveGenres,
   type EventSummary,
 } from "@/services/events"
@@ -42,6 +43,7 @@ export default async function HomePage({
     upcomingAgenda,
     activeArtists,
     activeGenres,
+    pastEvents,
     user,
   ] = await Promise.all([
     getHeroVariant(),
@@ -51,6 +53,8 @@ export default async function HomePage({
     getUpcomingEventsWithin(365, 10),
     getActiveArtists(8),
     getActiveGenres(),
+    // 4 pasados más recientes para la sección de archivo del final.
+    getPastEvents(4),
     getCurrentUser(),
   ])
 
@@ -80,6 +84,10 @@ export default async function HomePage({
       ) : null}
 
       {!user ? <CtaSection /> : null}
+
+      {pastEvents.length > 0 ? (
+        <PastEventsSection events={pastEvents} locale={locale} />
+      ) : null}
     </div>
   )
 }
@@ -312,6 +320,50 @@ async function CtaSection() {
           >
             {t("button")} <span aria-hidden="true">→</span>
           </Link>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ── Past events ────────────────────────────────────────────────────────
+
+interface PastEventsSectionProps {
+  events: EventSummary[]
+  locale: string
+}
+
+/**
+ * Sección de archivo al final del home: los eventos pasados más
+ * recientes. Da impronta — un portal con historia se ve más vivo.
+ *
+ * Usa el `EventCard` default (mismo que `/events/past`), no la variante
+ * `featured` de la sección de destacados — eso, más el encabezado claro
+ * "ARCHIVO · Eventos pasados", evita confundir un evento pasado con uno
+ * próximo. El caller no la renderiza si `events` viene vacío.
+ */
+async function PastEventsSection({ events, locale }: PastEventsSectionProps) {
+  const t = await getTranslations({ locale, namespace: "home.past" })
+
+  return (
+    <section className={cn(SECTION_GAP_CLASS, "border-t border-border")}>
+      <div className="mx-auto flex flex-col gap-xl" style={CONTAINER_STYLE}>
+        <SectionHeader
+          eyebrow={t("eyebrow")}
+          title={t("title")}
+          action={
+            <Link
+              href="/events/past"
+              className="text-body-s font-semibold text-fg-primary hover:text-brand transition-colors"
+            >
+              {t("viewAll")}
+            </Link>
+          }
+        />
+        <div className="grid grid-cols-1 gap-l sm:grid-cols-2 lg:grid-cols-3">
+          {events.map((event) => (
+            <EventCard key={event.id} event={event} locale={locale} />
+          ))}
         </div>
       </div>
     </section>

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -47,6 +47,11 @@
       "eyebrow": "FÜR KÜNSTLER UND VERANSTALTER",
       "title": "Spielst du lateinamerikanische Musik? Werde Teil von la huella.",
       "button": "Für Künstler"
+    },
+    "past": {
+      "eyebrow": "ARCHIV",
+      "title": "Vergangene Events",
+      "viewAll": "Alle ansehen →"
     }
   },
   "apply": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -47,6 +47,11 @@
       "eyebrow": "FOR ARTISTS AND PROMOTERS",
       "title": "Play Latin music? Join la huella.",
       "button": "For artists"
+    },
+    "past": {
+      "eyebrow": "ARCHIVE",
+      "title": "Past events",
+      "viewAll": "View all →"
     }
   },
   "apply": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -47,6 +47,11 @@
       "eyebrow": "PARA ARTISTAS Y ORGANIZADORES",
       "title": "¿Tocás música latina? Sumate a la huella.",
       "button": "Para artistas"
+    },
+    "past": {
+      "eyebrow": "ARCHIVO",
+      "title": "Eventos pasados",
+      "viewAll": "Ver todos →"
     }
   },
   "apply": {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -340,7 +340,7 @@ export async function getUpcomingEvents(
 }
 
 const _getPastEvents = unstable_cache(
-  async (): Promise<EventSummary[]> => {
+  async (limit?: number): Promise<EventSummary[]> => {
     const events = await prisma.event.findMany({
       where: {
         isDeleted: false,
@@ -348,6 +348,7 @@ const _getPastEvents = unstable_cache(
       },
       include: eventInclude,
       orderBy: { createdAt: "desc" },
+      ...(limit ? { take: limit } : {}),
     })
     return events.map(mapToSummary)
   },
@@ -355,8 +356,17 @@ const _getPastEvents = unstable_cache(
   { revalidate: 600, tags: ["events"] }
 )
 
-export async function getPastEvents(): Promise<EventSummary[]> {
-  return (await _getPastEvents()).map(rehydrateEvent)
+/**
+ * Eventos pasados — no eliminados (`isDeleted: false`) cuyas fechas ya
+ * ocurrieron todas. Sin `limit` devuelve la lista completa
+ * (`/events/past`); con `limit`, los N más recientes — lo usa la sección
+ * de eventos pasados del home. Orden `createdAt` desc.
+ *
+ * NOTA: a diferencia de `getUpcomingEvents`, no filtra por `isActive`
+ * (comportamiento preexistente de `/events/past`, ver review del PR).
+ */
+export async function getPastEvents(limit?: number): Promise<EventSummary[]> {
+  return (await _getPastEvents(limit)).map(rehydrateEvent)
 }
 
 /**

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -348,7 +348,7 @@ const _getPastEvents = unstable_cache(
       },
       include: eventInclude,
       orderBy: { createdAt: "desc" },
-      ...(limit ? { take: limit } : {}),
+      ...(limit !== undefined ? { take: limit } : {}),
     })
     return events.map(mapToSummary)
   },


### PR DESCRIPTION
## Contexto

`/events/past` ya existía y funcionaba, pero no se llegaba desde el home y los eventos pasados no aparecían en la página principal. Mostrar el archivo al final del home le da impronta — un portal con historia se ve más vivo — y, mientras la agenda futura es chica, llena la página con prueba social.

## Cambios

### 1 · Sección de eventos pasados en el home
Sección nueva al final del home (después del CTA, antes del footer):
- Encabezado **"ARCHIVO · Eventos pasados"** (`SectionHeader`) — claro, distingue de los próximos eventos.
- 4 eventos pasados más recientes, con `EventCard` variant default (la misma que `/events/past` — no la `featured` de los destacados; eso + el encabezado evita confundir un pasado con un próximo).
- Link **"Ver todos →"** a `/events/past`.
- Se oculta si no hay eventos pasados.
- Reusa `EventCard`, `SectionHeader` y la query `getPastEvents`; a esta última se le agregó un parámetro opcional `limit` (sin `limit` se comporta igual que antes — lo sigue usando `/events/past`). No se duplicó la lógica de "qué es un evento pasado".
- Copy `home.past` en ES/EN/DE.

### 2 · Padding en `/events/past`
La página venía sin contenedor — el contenido pegado a los bordes del viewport. Se envuelve en las mismas clases de ancho/gutter/padding que `/events` y `/artists`. Solo padding, sin rediseñar.

## Verificación
- `tsc` + `npm run build` — ✅ verde.
- Runtime (server local): home renderiza la sección "Eventos pasados" en ES/EN/DE; `/events/past` con el padding aplicado; ambas 200.
- **architecture-reviewer**: 0 CRITICAL/MAJOR. 2 MINOR menores aplicados (docstring + comentario más precisos).

## ⚠️ Para decidir (lo marcó la review)
`getPastEvents` filtra `isDeleted: false` pero **no** `isActive: true` — a diferencia de `getUpcomingEvents`. Es comportamiento **preexistente** de `/events/past`, pero ahora esa misma query alimenta el home: un evento pasado `isActive: false` (moderado/bloqueado) podría aparecer públicamente. No lo cambié porque tocar la query alteraría el comportamiento de `/events/past` (fuera del scope de este PR). **¿Querés que agregue `isActive: true` a `getPastEvents` en un PR aparte?**

## Test plan
- [x] `tsc` + `build` verde.
- [ ] Home → al final aparece "Eventos pasados" con cards + "Ver todos".
- [ ] "Ver todos" → `/events/past`.
- [ ] `/events/past` respira, consistente con `/events`.
- [ ] Cambiar idioma → encabezado y link traducidos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home page now includes a "Past events" archive section displaying up to four recent past events with a link to view all.

* **Layout**
  * Past events page updated with a wider, centered container and consistent spacing for improved readability.

* **Localization**
  * Added German, English, and Spanish translations for the past events section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->