### PR TITLE
feat: add dashboard access in header for creators

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,7 +5,9 @@
  *  - Nav central con underline-on-active sangre (desktop).
  *  - LanguageSwitcher (pills siempre, compactas en mobile).
  *  - Estado de usuario: "Iniciar sesión" + "Para artistas" si no logueado;
- *    avatar/iniciales + "Sign out" si logueado.
+ *    avatar/iniciales + "Sign out" si logueado. Para creators/admins se
+ *    suma el link "Mi panel" (→ `/dashboard`) y el avatar pasa a linkear
+ *    al dashboard; admins ven además un link a `/admin`.
  *  - Drawer mobile con la misma nav + estado de usuario, accesible desde
  *    botón hamburguesa.
  *
@@ -149,7 +151,21 @@ function isNavItemActive(pathname: string, item: NavItem): boolean {
 }
 
 interface SessionLike {
-  user?: { name?: string | null } | null
+  user?: { name?: string | null; role?: string | null } | null
+}
+
+/**
+ * Acceso al panel derivado del rol de la sesión. Client-safe a propósito:
+ * `services/auth.ts` (donde viven `isCreatorOrAdmin`/`isAdmin`) es
+ * `server-only` y no se puede importar en este client component. El
+ * `role` llega del plugin `admin` de Better Auth vía `useSession()`.
+ */
+function getPanelAccess(session: SessionLike | null | undefined) {
+  const role = session?.user?.role?.toLowerCase()
+  return {
+    canSeeDashboard: role === "creator" || role === "admin",
+    canSeeAdmin: role === "admin",
+  }
 }
 
 interface UserSlotProps {
@@ -185,18 +201,59 @@ function UserSlot({ session, t, onSignOut }: UserSlotProps) {
   }
 
   const initials = getInitials(session.user?.name ?? null)
+  const { canSeeDashboard, canSeeAdmin } = getPanelAccess(session)
+
+  const avatarBase = cn(
+    "w-9 h-9 rounded-pill bg-bg-surface-2 border border-border",
+    "flex items-center justify-center text-caption font-semibold text-fg-primary"
+  )
 
   return (
-    <div className="flex items-center gap-s">
-      <div
-        aria-hidden="true"
-        className={cn(
-          "w-9 h-9 rounded-pill bg-bg-surface-2 border border-border",
-          "flex items-center justify-center text-caption font-semibold text-fg-primary"
-        )}
-      >
-        {initials ?? "·"}
-      </div>
+    <div className="flex items-center gap-m">
+      {canSeeDashboard && (
+        <Link
+          href="/dashboard"
+          className={cn(
+            "text-body-s font-medium text-creator hover:text-fg-primary",
+            "transition-colors duration-200 ease-out rounded-s px-xs",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+          )}
+        >
+          {t("dashboard")}
+        </Link>
+      )}
+      {canSeeAdmin && (
+        <Link
+          href="/admin/applications"
+          className={cn(
+            "text-body-s text-fg-secondary hover:text-fg-primary",
+            "transition-colors duration-200 ease-out rounded-s px-xs",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+          )}
+        >
+          {t("admin")}
+        </Link>
+      )}
+      {canSeeDashboard ? (
+        <Link
+          href="/dashboard"
+          aria-label={t("dashboard")}
+          className={cn(
+            avatarBase,
+            "hover:border-creator transition-colors duration-200 ease-out",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+            "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+          )}
+        >
+          {initials ?? "·"}
+        </Link>
+      ) : (
+        <div aria-hidden="true" className={avatarBase}>
+          {initials ?? "·"}
+        </div>
+      )}
       <button
         type="button"
         onClick={onSignOut}
@@ -274,6 +331,7 @@ function MobileDrawer({
   onSignOut,
 }: MobileDrawerProps) {
   const firstLinkRef = useRef<HTMLAnchorElement | null>(null)
+  const { canSeeDashboard, canSeeAdmin } = getPanelAccess(session)
 
   // Lock body scroll cuando el drawer está abierto + cerrar con Escape +
   // gestionar foco (al abrir, mover al primer link; al cerrar, restaurar
@@ -385,17 +443,47 @@ function MobileDrawer({
               </Link>
             </div>
           ) : (
-            <div className="flex items-center justify-between gap-m">
-              <span className="text-body-s text-fg-secondary">
-                {session.user?.name ?? ""}
-              </span>
-              <button
-                type="button"
-                onClick={onSignOut}
-                className="text-body-s text-fg-secondary hover:text-fg-primary py-s"
-              >
-                {t("signOut")}
-              </button>
+            <div className="flex flex-col gap-xs">
+              {canSeeDashboard && (
+                <Link
+                  href="/dashboard"
+                  onClick={onClose}
+                  className={cn(
+                    "text-body-l py-s rounded-m px-m transition-colors",
+                    "text-creator hover:bg-bg-surface-2",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+                    "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+                  )}
+                >
+                  {t("dashboard")}
+                </Link>
+              )}
+              {canSeeAdmin && (
+                <Link
+                  href="/admin/applications"
+                  onClick={onClose}
+                  className={cn(
+                    "text-body-l py-s rounded-m px-m transition-colors",
+                    "text-fg-secondary hover:bg-bg-surface-2 hover:text-fg-primary",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
+                    "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+                  )}
+                >
+                  {t("admin")}
+                </Link>
+              )}
+              <div className="flex items-center justify-between gap-m px-m pt-s">
+                <span className="text-body-s text-fg-secondary">
+                  {session.user?.name ?? ""}
+                </span>
+                <button
+                  type="button"
+                  onClick={onSignOut}
+                  className="text-body-s text-fg-secondary hover:text-fg-primary py-s"
+                >
+                  {t("signOut")}
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -2,7 +2,8 @@
   "nav": {
     "events": "Veranstaltungen",
     "artists": "Künstler",
-    "dashboard": "Dashboard",
+    "dashboard": "Mein Bereich",
+    "admin": "Admin",
     "signIn": "Anmelden",
     "signOut": "Abmelden",
     "thisWeek": "Diese Woche",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2,7 +2,8 @@
   "nav": {
     "events": "Events",
     "artists": "Artists",
-    "dashboard": "Dashboard",
+    "dashboard": "My panel",
+    "admin": "Admin",
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "thisWeek": "This week",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -2,7 +2,8 @@
   "nav": {
     "events": "Eventos",
     "artists": "Artistas",
-    "dashboard": "Panel",
+    "dashboard": "Mi panel",
+    "admin": "Admin",
     "signIn": "Iniciar sesión",
     "signOut": "Cerrar sesión",
     "thisWeek": "Esta semana",


### PR DESCRIPTION
## Summary

Un creator no tenía forma de descubrir `/dashboard` desde la navegación — no había acceso visible, y el avatar del header era puramente decorativo. Este PR agrega un acceso claro al dashboard en el `Header`, presente en todas las páginas.

- **Link "Mi panel" → `/dashboard`** visible solo para `creator` y `admin` (acento fucsia `--color-creator`). El `role: user` no-creator y los visitantes no logueados NO lo ven.
- **Link "Admin" → `/admin/applications`** adicional, solo para `admin`.
- **El avatar** pasa de `<div aria-hidden>` decorativo a `<Link>` a `/dashboard` para creator/admin; sigue decorativo para `role: user` (no existe página de cuenta para ese rol).
- Cubre desktop (`UserSlot`) y mobile (`MobileDrawer`).
- i18n ES/EN/DE: se reutiliza la key muerta `nav.dashboard` ("Mi panel"/"My panel"/"Mein Bereich") y se agrega `nav.admin`.

## Decisiones de producto (consultadas con el dev)

- **Avatar**: link simple a `/dashboard`, no menú dropdown. Un dropdown ARIA (estado, click-outside, focus management) era una caja de complejidad; el código del header ya difiere overlays a un PR dedicado.
- **Admin**: ve link a `/dashboard` Y a `/admin`. El destino es `/admin/applications` porque `/admin` no tiene page índice.

## Detección de rol

`getPanelAccess()` lee `session.user.role` de la sesión de Better Auth client-side. Es client-safe a propósito: `services/auth.ts` (`isCreatorOrAdmin`/`isAdmin`) es `server-only`. El header es solo descubribilidad de UI — la protección real de `/dashboard` y `/admin` sigue intacta (`proxy.ts`, `requireRole`, `isCreatorOrAdmin` en los layouts).

## Fuera de scope (sin tocar)

Middleware, lógica de roles, `CreatorGate`, dashboard, páginas fuera del header. Diff: solo `Header.tsx` + los 3 `messages/*.json`.

## Architecture review

Corrido el `architecture-reviewer` sobre el diff — sin hallazgos ALTO. Hallazgo MEDIO: la lógica de derivación de rol ya estaba duplicada (`services/auth.ts`, `DashboardNav.tsx`) y `getPanelAccess` es una copia más. Centralizarla en un módulo `roles.ts` client-safe **se deja como follow-up** porque tocar `services/auth.ts` y `DashboardNav.tsx` excede el scope explícito de este PR (lógica de roles / componentes fuera del header).

## Verificación

- [x] `npm run build` sin errores (type-check + compile).
- [x] Smoke-test del header no logueado contra el dev server (HTTP 200, sin cambios).
- [ ] **Estados logueados (creator / admin / user) no verificados en browser** — requiere cuentas de test reales; crear una dispararía los emails de signup y writes a Neon. Verificación funcional de esos estados queda para el dev con cuentas reales.

### Verificación funcional pendiente (dev)
1. Creator → header muestra "Mi panel" → `/dashboard`.
2. User no-creator → NO ve el link.
3. Sin login → header sin cambios.
4. Admin → ve "Mi panel" + "Admin", sigue accediendo a su panel.
5. Avatar → linkea al dashboard (creator/admin).
6. Teclado → tabular hasta los links y activar con Enter.
7. Cambiar idioma → el texto se traduce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented role-based access control for navigation - dashboard and admin links now conditionally display based on user permissions.
  * Avatar now links to dashboard only when user has access.

* **UI/UX**
  * Updated and personalized navigation labels for better clarity across German, English, and Spanish.
  * Added new Admin navigation option visible to authorized users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->