### PR TITLE
fix(home): show next 4 weeks instead of misleading "this week"

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -2,7 +2,6 @@ import { getTranslations } from "next-intl/server"
 import { Link } from "@/i18n/navigation"
 import { cn } from "@/lib/utils"
 import {
-  getFeaturedEvents,
   getHeroVariant,
   getUpcomingEventsWithin,
   getPastEvents,
@@ -39,7 +38,7 @@ export default async function HomePage({
 
   const [
     heroVariant,
-    featuredEvents,
+    nextWeeksEvents,
     upcomingAgenda,
     activeArtists,
     activeGenres,
@@ -47,7 +46,8 @@ export default async function HomePage({
     user,
   ] = await Promise.all([
     getHeroVariant(),
-    getFeaturedEvents(3),
+    // Próximos 3 dentro de las 4 semanas — sección "Próximas 4 semanas".
+    getUpcomingEventsWithin(28, 3),
     // Próximos 10 dentro del próximo año, suficiente para la agenda
     // compacta de la home sin traer toda la lista futura.
     getUpcomingEventsWithin(365, 10),
@@ -67,8 +67,8 @@ export default async function HomePage({
           Re-agregar cuando crezca: `git log` tiene el componente, el copy
           sigue en `messages.home.stats`. */}
 
-      {featuredEvents.length > 0 ? (
-        <FeaturedSection events={featuredEvents} locale={locale} />
+      {nextWeeksEvents.length > 0 ? (
+        <NextWeeksSection events={nextWeeksEvents} locale={locale} />
       ) : null}
 
       {upcomingAgenda.length > 0 ? (
@@ -136,15 +136,15 @@ async function HeroSection({ variant, locale }: HeroSectionProps) {
   )
 }
 
-// ── Featured ──────────────────────────────────────────────────────────
+// ── Próximas 4 semanas ────────────────────────────────────────────────
 
-interface FeaturedSectionProps {
+interface NextWeeksSectionProps {
   events: EventSummary[]
   locale: string
 }
 
-async function FeaturedSection({ events, locale }: FeaturedSectionProps) {
-  const t = await getTranslations({ locale, namespace: "home.featured" })
+async function NextWeeksSection({ events, locale }: NextWeeksSectionProps) {
+  const t = await getTranslations({ locale, namespace: "home.nextWeeks" })
 
   return (
     <section className={SECTION_GAP_CLASS}>

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -29,9 +29,9 @@
       "cities": "Städte",
       "dateRange": "Zeitraum"
     },
-    "featured": {
-      "eyebrow": "HIGHLIGHTS · DIESE WOCHE",
-      "title": "Nicht verpassen",
+    "nextWeeks": {
+      "eyebrow": "NÄCHSTE 4 WOCHEN",
+      "title": "Was bald läuft",
       "viewAll": "Alle ansehen →"
     },
     "upcoming": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -29,9 +29,9 @@
       "cities": "cities",
       "dateRange": "range"
     },
-    "featured": {
-      "eyebrow": "FEATURED · THIS WEEK",
-      "title": "Must-see",
+    "nextWeeks": {
+      "eyebrow": "NEXT 4 WEEKS",
+      "title": "What's coming up",
       "viewAll": "View all →"
     },
     "upcoming": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -29,9 +29,9 @@
       "cities": "ciudades",
       "dateRange": "rango"
     },
-    "featured": {
-      "eyebrow": "DESTACADOS · ESTA AGENDA",
-      "title": "Imperdibles",
+    "nextWeeks": {
+      "eyebrow": "PRÓXIMAS 4 SEMANAS",
+      "title": "Lo que se viene",
       "viewAll": "Ver todo →"
     },
     "upcoming": {


### PR DESCRIPTION
## Bug

La sección del home que decía **"FEATURED · THIS WEEK / Must-see"** (en) — equivalentes en es/de — usaba `getFeaturedEvents(3)`, una query **sin acotar**: traía los próximos 3 eventos por fecha sin importar a cuánto. Resultado: el copy claimaba "this week" pero mostraba eventos del 7 de junio (≈3 semanas adelante). Visible en mobile en la captura que pasaste.

## Fix

- **Query acotada a 28 días**: swap `getFeaturedEvents(3)` → `getUpcomingEventsWithin(28, 3)` (función ya en uso por la sección Agenda, sin código nuevo).
- **Copy honesto** en los 3 locales:
  - es: eyebrow "PRÓXIMAS 4 SEMANAS" · title "Lo que se viene"
  - en: eyebrow "NEXT 4 WEEKS" · title "What's coming up"
  - de: eyebrow "NÄCHSTE 4 WOCHEN" · title "Was bald läuft"
- **Namespace renombrado** `home.featured` → `home.nextWeeks` (la palabra "featured/destacados" se libera para una sección futura curada por admin — backlog).
- Componente `FeaturedSection` → `NextWeeksSection` en `page.tsx`.

`getFeaturedEvents` (la función) **NO se tocó** — la usa `(auth)/sign-in/page.tsx`.

La sección "Próximas semanas" (Agenda, 365d/10 eventos) **no se tocó** por decisión de producto: con pocos eventos hoy hay solapamiento aceptado; cuando haya volumen se resuelve solo.

## Reviews

**i18n-reviewer** (corrido sobre el diff):
- 1 MEDIA en DE: `"Was ansteht"` (mi propuesta inicial) sonaba burocrática como heading. Aplicado: `"Was bald läuft"` — hace eco con el tagline del hero alemán (`"Was in Berlin... läuft"`).
- 1 BAJA fuera de scope: nota que "Próximas 4 semanas" + "Próximas semanas" (contiguas) podrían leerse como duplicadas. Anotado para iterar el título de la Agenda cuando se quiera diferenciar más.
- Rename consistente verificado: no quedan referencias colgadas a `home.featured`.

## Verificación

- [x] `npm run build` sin errores.
- [x] JSON válido en los 3 locales.
- [x] Grep: `home.featured` (namespace) ya no se referencia en ningún `.ts/.tsx`.
- [ ] **Smoke test live** — no se hizo: el dev server actual está en estado roto (mismatch de versión next-server v16.2.3 vs node_modules 16.2.6, devuelve 404 en `/en|/es|/de`). Riesgo runtime bajo: build verde + JSON válido + namespace consumido por un solo archivo + la función nueva ya está en prod (la Agenda).

## Backlog (anotado, fuera de scope)

- Sección "Eventos destacados" curada por admin (libre el nombre `featured` ahora).
- Filtrar por semana cuando haya más volumen.
- Renombrar el título de la Agenda para evitar la lectura de duplicación con "Próximas 4 semanas".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home page now displays a new "Upcoming Events" section showcasing events happening over the next 4 weeks, replacing the previous featured events section to give users better visibility into upcoming content.

* **Documentation**
  * Updated German, English, and Spanish translations to reflect the new "Upcoming Events" section and its associated messaging across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->