### PR TITLE
chore(i18n): rebrand "For artists" CTA as "Become a creator"

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@
  *  - BrandLockup horizontal (link a la home del locale activo).
  *  - Nav central con underline-on-active sangre (desktop).
  *  - LanguageSwitcher (pills siempre, compactas en mobile).
- *  - Estado de usuario: "Iniciar sesión" + "Para artistas" si no logueado;
+ *  - Estado de usuario: "Iniciar sesión" + "Sumate como creador/a" si no logueado;
  *    avatar/iniciales + "Sign out" si logueado. Para creators/admins se
  *    suma el link "Mi panel" (→ `/dashboard`) y el avatar pasa a linkear
  *    al dashboard; admins ven además un link a `/admin`.
@@ -194,7 +194,7 @@ function UserSlot({ session, t, onSignOut }: UserSlotProps) {
             "focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
           )}
         >
-          {t("forArtists")}
+          {t("becomeCreator")}
         </Link>
       </div>
     )
@@ -439,7 +439,7 @@ function MobileDrawer({
                   "hover:bg-brand-dim transition-colors duration-200 ease-out"
                 )}
               >
-                {t("forArtists")}
+                {t("becomeCreator")}
               </Link>
             </div>
           ) : (

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -7,7 +7,7 @@
     "signIn": "Anmelden",
     "signOut": "Abmelden",
     "thisWeek": "Diese Woche",
-    "forArtists": "Für Künstler",
+    "becomeCreator": "Werde Creator",
     "openMenu": "Menü öffnen",
     "closeMenu": "Menü schließen",
     "languageSwitcherLabel": "Sprachauswahl"
@@ -47,7 +47,7 @@
     "cta": {
       "eyebrow": "FÜR KÜNSTLER UND VERANSTALTER",
       "title": "Spielst du lateinamerikanische Musik? Werde Teil von la huella.",
-      "button": "Für Künstler"
+      "button": "Als Creator bewerben"
     },
     "past": {
       "eyebrow": "ARCHIV",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -7,7 +7,7 @@
     "signIn": "Sign In",
     "signOut": "Sign Out",
     "thisWeek": "This week",
-    "forArtists": "For artists",
+    "becomeCreator": "Become a creator",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
     "languageSwitcherLabel": "Language switcher"
@@ -47,7 +47,7 @@
     "cta": {
       "eyebrow": "FOR ARTISTS AND PROMOTERS",
       "title": "Play Latin music? Join la huella.",
-      "button": "For artists"
+      "button": "Become a creator"
     },
     "past": {
       "eyebrow": "ARCHIVE",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -7,7 +7,7 @@
     "signIn": "Iniciar sesión",
     "signOut": "Cerrar sesión",
     "thisWeek": "Esta semana",
-    "forArtists": "Para artistas",
+    "becomeCreator": "Sumate como creador/a",
     "openMenu": "Abrir menú",
     "closeMenu": "Cerrar menú",
     "languageSwitcherLabel": "Selector de idioma"
@@ -47,7 +47,7 @@
     "cta": {
       "eyebrow": "PARA ARTISTAS Y ORGANIZADORES",
       "title": "¿Tocás música latina? Sumate a la huella.",
-      "button": "Para artistas"
+      "button": "Sumate como creador/a"
     },
     "past": {
       "eyebrow": "ARCHIVO",


### PR DESCRIPTION
## Por qué

El botón pill del header + el botón de la sección CTA del home decían **"Para artistas" / "For artists" / "Für Künstler"** pero los dos apuntan a `/apply` — donde te aplicás para convertirte en `creator` (rol del sistema). La copy no matcheaba ni con la URL ni con la terminología del resto del sitio (`apply`, `dashboard`, `creatorGate`).

## Qué cambia

- Rename `nav.forArtists` → `nav.becomeCreator` en los 3 locales.
- `home.cta.button` actualizado a la misma copy.
- `Header.tsx`: 2 `t("forArtists")` → `t("becomeCreator")` + JSDoc actualizado.

Copy:
- **es** (elegido por el dev): "Sumate como creador/a"
- **en**: "Become a creator"
- **de header**: "Werde Creator"
- **de home.cta.button**: "Als Creator bewerben" — diverge del header en DE para evitar la repetición "Werde Teil... Werde Creator" con el título de la sección, y alinea con el resto del namespace `apply` alemán

## Reviews

**i18n-reviewer** corrido sobre el diff. 2 MEDIO ambos aplicados:
- DE divergence en `home.cta.button` (sugerida arriba).
- JSDoc del Header tenía "Para artistas" desactualizado → reemplazado.

2 BAJO sin acción: EN "Become a creator" validada como buena; DE sin `/in` defensible por consistencia con el resto del sitio (anglicismo "Creator" tratado como neutro). Sin hallazgos ALTO.

## Verificación

- [x] `npm run build` sin errores.
- [x] JSON válido en los 3 locales.
- [x] `nav.forArtists` ya no se referencia en ningún `.ts/.tsx` (verificado por grep antes y después).
- [ ] Smoke test live no se hizo: el dev server actual está en estado roto (mismatch de versión, lo flageamos antes). Riesgo runtime bajo — solo rename de key + valores i18n.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated call-to-action labels from "For Artists" to "Become a Creator" across the header navigation and application sections in English, German, and Spanish languages for both desktop and mobile users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->