### PR TITLE
feat(home): show next show mini-card in mobile hero

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -58,9 +58,17 @@ export default async function HomePage({
     getCurrentUser(),
   ])
 
+  // El "próximo show" del mini-card mobile del hero = primera fila de
+  // la agenda (eventos ya ordenados por fecha asc). Una sola query.
+  // (El `limit` de `getUpcomingEventsWithin` se aplica en memoria, no
+  // en Prisma, así que pedir `(365, 1)` aparte traería los mismos
+  // events que `(365, 10)` con otro slice — dos cache entries
+  // equivalentes. Mejor derivar.)
+  const nextEvent = upcomingAgenda[0] ?? null
+
   return (
     <div>
-      <HeroSection variant={heroVariant} locale={locale} />
+      <HeroSection variant={heroVariant} nextEvent={nextEvent} locale={locale} />
 
       {/* StatsSection (shows/artistas/ciudades/rango) oculta por ahora —
           con la agenda todavía chica los contadores quedan flojos.
@@ -96,10 +104,11 @@ export default async function HomePage({
 
 interface HeroSectionProps {
   variant: "thisWeek" | "nextMonth" | "whatComes"
+  nextEvent: EventSummary | null
   locale: string
 }
 
-async function HeroSection({ variant, locale }: HeroSectionProps) {
+async function HeroSection({ variant, nextEvent, locale }: HeroSectionProps) {
   const tHero = await getTranslations({ locale, namespace: "home.hero" })
 
   // El copy del h1 tiene dos partes: prefijo neutro + sufijo coloreado.
@@ -132,6 +141,19 @@ async function HeroSection({ variant, locale }: HeroSectionProps) {
           {tHero("tagline")}
         </p>
       </div>
+      {/* Mini-card del próximo show — sibling de la grilla, no parte
+          de ella (la grilla pasa a 2 columnas en `lg` y el mini-card
+          tendría posición rara). Visible mientras el hero queda en
+          1 columna (mobile + tablet, <`lg`). A partir de `lg` se
+          oculta — el hero ya tiene info densa en sus 2 cols. */}
+      {nextEvent ? (
+        <div
+          className="mx-auto mt-xl lg:hidden"
+          style={CONTAINER_STYLE}
+        >
+          <EventRow event={nextEvent} locale={locale} />
+        </div>
+      ) : null}
     </section>
   )
 }


### PR DESCRIPTION
## Por qué

En la captura mobile que pasaste, el hero del home tiene **un hueco grande de aire** entre la tagline ("What's playing in Berlin...") y la siguiente sección. En desktop el hero se llena (grid de 2 cols con headline + tagline), pero en mobile/tablet la grilla colapsa a 1 col y queda esa banda vacía.

## Qué cambia

- Nuevo render en `HeroSection`: si hay un próximo show, se muestra una **mini-card** (`<EventRow>` ya existente) como **sibling** de la grilla del hero, dentro de la misma `<section>`.
- Visible **hasta `lg`** (mobile + tablet portrait, <1024px) — el breakpoint donde la grilla del hero se vuelve 2-cols. A partir de `lg` se oculta porque el hero ya está denso.
- Si no hay shows próximos (próximos 365 días), el bloque no se renderiza.

## Decisiones técnicas

- **Cero componentes nuevos**: reuso `EventRow` (el mismo que usa la sección Agenda). `EventRow` ya oculta thumbnail (`sm:`) y chip de género (`md:`) por breakpoint — degrada bien en mobile.
- **Cero query nueva** — el architecture-reviewer flageó que `getUpcomingEventsWithin(days, limit)` aplica el `limit` *en memoria*, no en Prisma. O sea pedir `(365, 1)` aparte traería los mismos eventos que el `(365, 10)` del Agenda con otro slice — dos cache entries equivalentes. Mejor derivar `nextEvent = upcomingAgenda[0]` (ya ordenado por fecha asc).
- **Cero i18n nueva** — la card muestra solo datos del evento (fecha, título, lugar/hora) que ya vienen de DB.
- **Mini-card como sibling de la grilla**, no como tercer hijo — para no mezclar layout-2-cols-desktop + stack-mobile-con-3-items en el mismo container.

## Reviews

**architecture-reviewer** corrido. 1 MEDIO + 1 BAJO, ambos aplicados:
- MEDIO: query duplicada `getUpcomingEventsWithin(365, 1)` vs `(365, 10)` → reemplazado por `upcomingAgenda[0]`.
- BAJO: mini-card como tercer hijo del grid mezclaba responsabilidades → movido afuera del grid como sibling.

## Aceptado en el diseño

- **Redundancia visual**: el mismo evento aparece como mini-card en el hero **y** como primera fila del Agenda más abajo. Es intencional — el mini-card actúa como teaser ("hay algo próximo, tap"), el Agenda es la lista completa. Misma lógica que ya aceptaste para el solapamiento "Próximas 4 semanas" + "Próximas semanas".

## Verificación

- [x] `npm run build` sin errores.
- [x] Diff acotado a un archivo (`page.tsx`), +24/-2.
- [ ] Smoke test live no se hizo: el dev server local está en estado roto (mismatch de versión, ya flageado). Riesgo runtime mínimo — usa solo un componente ya en uso y un campo ya disponible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile users now see an upcoming event preview card prominently displayed in the hero section, showcasing the next scheduled show or event at a glance. This mobile-optimized preview provides immediate visibility to upcoming events without scrolling, while remaining hidden on larger screens to maintain a clean desktop experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->