### PR TITLE
fix: use Berlin calendar day for event filtering, highlight today's events

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server"
 import { Link } from "@/i18n/navigation"
 import { cn } from "@/lib/utils"
+import { isTodayBerlin } from "@/lib/date"
 import {
   getHeroVariant,
   getUpcomingEventsWithin,
@@ -58,13 +59,22 @@ export default async function HomePage({
     getCurrentUser(),
   ])
 
-  // El "próximo show" del mini-card mobile del hero = primera fila de
-  // la agenda (eventos ya ordenados por fecha asc). Una sola query.
-  // (El `limit` de `getUpcomingEventsWithin` se aplica en memoria, no
-  // en Prisma, así que pedir `(365, 1)` aparte traería los mismos
-  // events que `(365, 10)` con otro slice — dos cache entries
-  // equivalentes. Mejor derivar.)
-  const nextEvent = upcomingAgenda[0] ?? null
+  // Separamos los eventos de HOY de los demás futuros. Los de hoy van
+  // arriba en su propia sección destacada con badge "HOY"; el resto baja
+  // a "Próximas 4 semanas" y "Próximas semanas" sin duplicar. Derivamos
+  // del agenda (10/365d) porque ahí seguro caben todos los de hoy aunque
+  // sean varios.
+  const todayEvents = upcomingAgenda.filter((ev) =>
+    ev.dates.some((d) => isTodayBerlin(d))
+  )
+  const todayIds = new Set(todayEvents.map((ev) => ev.id))
+  const futureAgenda = upcomingAgenda.filter((ev) => !todayIds.has(ev.id))
+  const futureNextWeeks = nextWeeksEvents.filter((ev) => !todayIds.has(ev.id))
+
+  // El mini-card del hero (mobile) muestra el próximo show DESPUÉS de hoy
+  // — si hay eventos hoy, esos ya están destacados arriba; el mini-card
+  // entonces actúa como teaser "lo que viene después".
+  const nextEvent = futureAgenda[0] ?? null
 
   return (
     <div>
@@ -75,13 +85,17 @@ export default async function HomePage({
           Re-agregar cuando crezca: `git log` tiene el componente, el copy
           sigue en `messages.home.stats`. */}
 
-      {nextWeeksEvents.length > 0 ? (
-        <NextWeeksSection events={nextWeeksEvents} locale={locale} />
+      {todayEvents.length > 0 ? (
+        <TodaySection events={todayEvents} locale={locale} />
       ) : null}
 
-      {upcomingAgenda.length > 0 ? (
+      {futureNextWeeks.length > 0 ? (
+        <NextWeeksSection events={futureNextWeeks} locale={locale} />
+      ) : null}
+
+      {futureAgenda.length > 0 ? (
         <AgendaSection
-          events={upcomingAgenda}
+          events={futureAgenda}
           genres={activeGenres}
           locale={locale}
         />
@@ -154,6 +168,46 @@ async function HeroSection({ variant, nextEvent, locale }: HeroSectionProps) {
           <EventRow event={nextEvent} locale={locale} />
         </div>
       ) : null}
+    </section>
+  )
+}
+
+// ── Hoy ───────────────────────────────────────────────────────────────
+
+interface TodaySectionProps {
+  events: EventSummary[]
+  locale: string
+}
+
+/**
+ * Sección de eventos de HOY (día calendario Berlín). Aparece arriba del
+ * home cuando hay al menos un evento que sucede hoy. Reusa `EventCard`
+ * con la prop `todayLabel`, que tiñe el `DateTile` de rojo (accent
+ * `brand`) y reemplaza el eyebrow por "HOY · 21:00" (o "HOY" si el
+ * evento no tiene `time`). Si no hay eventos hoy, el caller no la
+ * renderiza — no muestra una sección vacía.
+ */
+async function TodaySection({ events, locale }: TodaySectionProps) {
+  const t = await getTranslations({ locale, namespace: "home.today" })
+  const badge = t("badge")
+
+  return (
+    <section className={cn(SECTION_GAP_CLASS, "border-b border-border")}>
+      <div className="mx-auto flex flex-col gap-xl" style={CONTAINER_STYLE}>
+        <SectionHeader title={t("title")} />
+        <div className="grid grid-cols-1 gap-l sm:grid-cols-2 lg:grid-cols-3">
+          {events.map((event, index) => (
+            <EventCard
+              key={event.id}
+              event={event}
+              variant="featured"
+              priority={index === 0}
+              locale={locale}
+              todayLabel={badge}
+            />
+          ))}
+        </div>
+      </div>
     </section>
   )
 }

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -37,6 +37,13 @@ export interface EventCardProps {
   priority?: boolean
   /** Si el caller ya resolvió el locale, pasarlo evita un await por card. */
   locale?: string
+  /**
+   * Si está presente, la card se renderiza marcada como "hoy": el
+   * `DateTile` pasa a accent `brand` (rojo) y el eyebrow muestra este
+   * label (típicamente "HOY"/"TODAY"/"HEUTE") en lugar del weekday +
+   * fecha. Lo usa el home para destacar los eventos del día.
+   */
+  todayLabel?: string
 }
 
 const MONTHS_BY_LOCALE: Record<string, string> = {
@@ -50,13 +57,22 @@ export async function EventCard({
   variant = "default",
   priority = false,
   locale,
+  todayLabel,
 }: EventCardProps) {
   const resolvedLocale = locale ?? (await getLocale())
   const nextDate = event.dates[0] ?? null
   const accent = genreAccent(event.genre)
   const isFeatured = variant === "featured"
+  const isToday = Boolean(todayLabel)
 
-  const eyebrowText = formatEyebrow(nextDate, event.time, resolvedLocale)
+  // Cuando la card es "hoy", el eyebrow dice "HOY · 21:00" (o solo "HOY"
+  // si no hay time) en vez del weekday-fecha. El día/mes igual quedan
+  // visibles en el `DateTile` rojo del overlay.
+  const eyebrowText = isToday
+    ? event.time
+      ? `${todayLabel} · ${event.time}`
+      : (todayLabel as string)
+    : formatEyebrow(nextDate, event.time, resolvedLocale)
 
   return (
     <Link
@@ -83,7 +99,12 @@ export async function EventCard({
 
         {nextDate ? (
           <div className="absolute top-m left-m">
-            <DateTile date={nextDate} size="m" locale={resolvedLocale} />
+            <DateTile
+              date={nextDate}
+              size="m"
+              locale={resolvedLocale}
+              accent={isToday ? "brand" : undefined}
+            />
           </div>
         ) : null}
 
@@ -99,7 +120,9 @@ export async function EventCard({
       {/* Info debajo del flyer */}
       <div className="flex flex-col gap-xs p-m flex-1">
         {eyebrowText ? (
-          <Eyebrow accent={isFeatured ? "editorial" : "neutral"}>
+          <Eyebrow
+            accent={isToday ? "brand" : isFeatured ? "editorial" : "neutral"}
+          >
             {eyebrowText}
           </Eyebrow>
         ) : null}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -32,3 +32,100 @@ export function rehydrateDates(
   }
   return out
 }
+
+// ── Timezone helpers (Europe/Berlin) ──────────────────────────────────
+//
+// El portal opera en Berlín y todos los eventos viven en ese huso. Las
+// fechas de evento se guardan como `TIMESTAMP` sin zona (Prisma `DateTime`
+// → Postgres `TIMESTAMP`); el form acaba enviando la medianoche UTC del
+// día calendario elegido, lo cual en Berlín verano (CEST UTC+2) equivale a
+// las 02:00 AM de ese día. Si los services comparan contra `new Date()`
+// (instante exacto), cualquier evento del día actual "expira" a las
+// 02:00 AM Berlín y migra incorrectamente a "pasados" — bug observado
+// y diagnosticado.
+//
+// Solución (Opción A del diagnóstico): comparar contra el INICIO DEL DÍA
+// CALENDARIO en Berlín. Un evento es "próximo/vigente" mientras su fecha
+// caiga en hoy o futuro (día calendario), y "pasado" recién a partir de
+// medianoche Berlín del día siguiente.
+//
+// CEST/CET (horario de verano) se resuelve via `Intl.DateTimeFormat` con
+// `timeZone: "Europe/Berlin"` — no hardcodeamos offset.
+
+export const BERLIN_TZ = "Europe/Berlin"
+
+/**
+ * Devuelve la fecha calendario (YYYY-MM-DD) correspondiente al instante
+ * `d` visto en hora de Berlín. Helper interno usado por `startOfTodayBerlin`
+ * y `isTodayBerlin`. `en-CA` produce el formato ISO sin reordenar.
+ */
+function berlinDateString(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: BERLIN_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d)
+}
+
+/**
+ * Convierte una fecha-hora local en Berlín (string ISO sin zona, ej.
+ * "2026-05-24T00:00:00") al `Date` UTC correspondiente. Funciona en CEST
+ * y CET sin hardcodear el offset:
+ *  1. Interpreta el string como si fuera UTC ("naïve parse").
+ *  2. Pregunta a Intl qué hora marca ese instante en Berlín.
+ *  3. La diferencia es el offset de Berlín en ese momento.
+ *  4. Resta el offset al instante original para obtener el UTC real.
+ */
+function berlinLocalToUtc(localISO: string): Date {
+  const asIfUtc = new Date(`${localISO}Z`)
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: BERLIN_TZ,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(asIfUtc)
+  const get = (t: string) =>
+    parseInt(parts.find((p) => p.type === t)!.value, 10)
+  // Algunas implementaciones devuelven "24" para medianoche → normalizar.
+  const hour = get("hour") % 24
+  const tzAsIfUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    hour,
+    get("minute"),
+    get("second")
+  )
+  const offsetMs = tzAsIfUtc - asIfUtc.getTime()
+  return new Date(asIfUtc.getTime() - offsetMs)
+}
+
+/**
+ * Instante UTC correspondiente a las 00:00 de HOY en hora de Berlín.
+ * Para filtrar eventos: usar este valor en lugar de `new Date()` permite
+ * que un evento de hoy se considere "próximo/vigente" durante todo el
+ * día calendario Berlín, no solo hasta las 02:00 AM (caso CEST) /
+ * 01:00 AM (caso CET).
+ *
+ * Ejemplos (CEST, mayo, UTC+2):
+ *   2026-05-24 09:00 Berlin → 2026-05-23T22:00:00.000Z
+ * Ejemplos (CET, enero, UTC+1):
+ *   2026-01-15 09:00 Berlin → 2026-01-14T23:00:00.000Z
+ */
+export function startOfTodayBerlin(): Date {
+  const today = berlinDateString(new Date())
+  return berlinLocalToUtc(`${today}T00:00:00`)
+}
+
+/**
+ * `true` si `d` cae en el mismo día calendario Berlín que ahora. Usado
+ * en el home para marcar eventos de hoy con el badge "HOY".
+ */
+export function isTodayBerlin(d: Date): boolean {
+  return berlinDateString(d) === berlinDateString(new Date())
+}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -29,6 +29,10 @@
       "cities": "Städte",
       "dateRange": "Zeitraum"
     },
+    "today": {
+      "title": "Heute",
+      "badge": "HEUTE"
+    },
     "nextWeeks": {
       "eyebrow": "NÄCHSTE 4 WOCHEN",
       "title": "Was bald läuft",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -29,6 +29,10 @@
       "cities": "cities",
       "dateRange": "range"
     },
+    "today": {
+      "title": "Today",
+      "badge": "TODAY"
+    },
     "nextWeeks": {
       "eyebrow": "NEXT 4 WEEKS",
       "title": "What's coming up",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -29,6 +29,10 @@
       "cities": "ciudades",
       "dateRange": "rango"
     },
+    "today": {
+      "title": "Hoy",
+      "badge": "HOY"
+    },
     "nextWeeks": {
       "eyebrow": "PRÓXIMAS 4 SEMANAS",
       "title": "Lo que se viene",

--- a/src/services/artists.ts
+++ b/src/services/artists.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { cache } from "react"
 import { unstable_cache, revalidateTag } from "next/cache"
 import { prisma } from "@/lib/prisma"
+import { startOfTodayBerlin } from "@/lib/date"
 import { generateUniqueSlug } from "@/lib/slugify"
 import { deleteImages } from "./cloudinary"
 
@@ -100,7 +101,7 @@ export async function getUpcomingArtists(): Promise<ArtistSummary[]> {
             some: {
               isDeleted: false,
               isActive: true,
-              dates: { some: { date: { gte: new Date() } } },
+              dates: { some: { date: { gte: startOfTodayBerlin() } } },
             },
           },
         },
@@ -120,11 +121,11 @@ export async function getPastArtists(): Promise<ArtistSummary[]> {
       events: {
         some: {
           isDeleted: false,
-          dates: { some: { date: { lt: new Date() } } },
+          dates: { some: { date: { lt: startOfTodayBerlin() } } },
         },
         none: {
           isDeleted: false,
-          dates: { some: { date: { gte: new Date() } } },
+          dates: { some: { date: { gte: startOfTodayBerlin() } } },
         },
       },
     },
@@ -180,7 +181,7 @@ export const getActiveArtists = unstable_cache(
           some: {
             isDeleted: false,
             isActive: true,
-            dates: { some: { date: { gte: new Date() } } },
+            dates: { some: { date: { gte: startOfTodayBerlin() } } },
           },
         },
       },

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -3,7 +3,7 @@ import "server-only"
 import { cache } from "react"
 import { unstable_cache, revalidateTag } from "next/cache"
 import { prisma } from "@/lib/prisma"
-import { rehydrateDate, rehydrateDates } from "@/lib/date"
+import { rehydrateDate, rehydrateDates, startOfTodayBerlin } from "@/lib/date"
 import { generateUniqueSlug } from "@/lib/slugify"
 import { deleteImages } from "./cloudinary"
 
@@ -119,11 +119,11 @@ const eventInclude = {
  * en el `mapToSummary` resulta en la próxima fecha real del evento, no
  * en una fecha pasada de un evento que tiene varias funciones.
  */
-function futureEventInclude(now: Date, until?: Date) {
+function futureEventInclude(from: Date, until?: Date) {
   return {
     dates: {
       where: {
-        date: { gte: now, ...(until ? { lte: until } : {}) },
+        date: { gte: from, ...(until ? { lte: until } : {}) },
       },
       orderBy: { date: "asc" as const },
       take: 1,
@@ -155,18 +155,22 @@ function sortByNextDate(events: EventSummary[]): EventSummary[] {
  */
 export const getHeroVariant = unstable_cache(
   async (): Promise<"thisWeek" | "nextMonth" | "whatComes"> => {
-    const now = new Date()
-    const in7 = new Date(now)
-    in7.setDate(in7.getDate() + 7)
-    const in30 = new Date(now)
-    in30.setDate(in30.getDate() + 30)
+    // Filtramos por día calendario en Berlín, no por instante (ver
+    // `startOfTodayBerlin` y el comentario en `@/lib/date`). Los `in7`/
+    // `in30` se calculan en ms desde ese inicio de día — tz-independiente.
+    const today = startOfTodayBerlin()
+    // `+(N+1)*24h - 1ms` = último instante del día calendario Berlín N
+    // días después de hoy, INCLUSIVE. Sin el +1 perdíamos los eventos
+    // del día N (almacenados como 00:00 UTC = anteriores al bound).
+    const in7 = new Date(today.getTime() + 8 * 24 * 60 * 60 * 1000 - 1)
+    const in30 = new Date(today.getTime() + 31 * 24 * 60 * 60 * 1000 - 1)
 
     // Una sola query: trae la próxima fecha de evento activo no borrado
     // y decidimos contra los umbrales en memoria. `select: { date: true }`
     // mantiene el payload mínimo.
     const nextDate = await prisma.eventDate.findFirst({
       where: {
-        date: { gte: now, lte: in30 },
+        date: { gte: today, lte: in30 },
         event: { isDeleted: false, isActive: true },
       },
       orderBy: { date: "asc" },
@@ -189,16 +193,19 @@ export const getHeroVariant = unstable_cache(
  */
 const _getUpcomingEventsWithin = unstable_cache(
   async (days: number, limit?: number): Promise<EventSummary[]> => {
-    const now = new Date()
-    const until = new Date(now)
-    until.setDate(until.getDate() + days)
+    const today = startOfTodayBerlin()
+    // `+(days+1)*24h - 1ms` = último instante del día calendario Berlín
+    // `days` después de hoy, INCLUSIVE (los eventos se guardan como
+    // 00:00 UTC, así que el bound debe extenderse al fin del día para
+    // capturarlos). Ver mismo patrón en getHeroVariant.
+    const until = new Date(today.getTime() + (days + 1) * 24 * 60 * 60 * 1000 - 1)
     const events = await prisma.event.findMany({
       where: {
         isDeleted: false,
         isActive: true,
-        dates: { some: { date: { gte: now, lte: until } } },
+        dates: { some: { date: { gte: today, lte: until } } },
       },
-      include: futureEventInclude(now, until),
+      include: futureEventInclude(today, until),
     })
     const ordered = sortByNextDate(events.map(mapToSummary))
     return limit ? ordered.slice(0, limit) : ordered
@@ -223,14 +230,14 @@ export async function getUpcomingEventsWithin(
  */
 const _getFeaturedEvents = unstable_cache(
   async (limit = 3): Promise<EventSummary[]> => {
-    const now = new Date()
+    const today = startOfTodayBerlin()
     const events = await prisma.event.findMany({
       where: {
         isDeleted: false,
         isActive: true,
-        dates: { some: { date: { gte: now } } },
+        dates: { some: { date: { gte: today } } },
       },
-      include: futureEventInclude(now),
+      include: futureEventInclude(today),
     })
     return sortByNextDate(events.map(mapToSummary)).slice(0, limit)
   },
@@ -256,17 +263,17 @@ export interface UpcomingStats {
  */
 const _getUpcomingStats = unstable_cache(
   async (): Promise<UpcomingStats> => {
-    const now = new Date()
+    const today = startOfTodayBerlin()
     const events = await prisma.event.findMany({
       where: {
         isDeleted: false,
         isActive: true,
-        dates: { some: { date: { gte: now } } },
+        dates: { some: { date: { gte: today } } },
       },
       select: {
         artistId: true,
         location: true,
-        dates: { where: { date: { gte: now } }, select: { date: true } },
+        dates: { where: { date: { gte: today } }, select: { date: true } },
       },
     })
 
@@ -316,11 +323,12 @@ export async function getUpcomingStats(): Promise<UpcomingStats> {
 
 const _getUpcomingEvents = unstable_cache(
   async (filters?: { genre?: string; city?: string }): Promise<EventSummary[]> => {
+    const today = startOfTodayBerlin()
     const events = await prisma.event.findMany({
       where: {
         isDeleted: false,
         isActive: true,
-        dates: { some: { date: { gte: new Date() } } },
+        dates: { some: { date: { gte: today } } },
         ...(filters?.genre ? { genre: filters.genre } : {}),
         ...(filters?.city ? { location: { contains: filters.city, mode: "insensitive" } } : {}),
       },
@@ -344,7 +352,7 @@ const _getPastEvents = unstable_cache(
     const events = await prisma.event.findMany({
       where: {
         isDeleted: false,
-        dates: { every: { date: { lt: new Date() } } },
+        dates: { every: { date: { lt: startOfTodayBerlin() } } },
       },
       include: eventInclude,
       orderBy: { createdAt: "desc" },
@@ -432,7 +440,7 @@ export const getActiveGenres = unstable_cache(
         isDeleted: false,
         isActive: true,
         genre: { not: null },
-        dates: { some: { date: { gte: new Date() } } },
+        dates: { some: { date: { gte: startOfTodayBerlin() } } },
       },
       select: { genre: true },
       distinct: ["genre"],
@@ -450,7 +458,7 @@ export const getActiveCities = unstable_cache(
       where: {
         isDeleted: false,
         isActive: true,
-        dates: { some: { date: { gte: new Date() } } },
+        dates: { some: { date: { gte: startOfTodayBerlin() } } },
       },
       select: { location: true },
       distinct: ["location"],
@@ -488,15 +496,15 @@ export async function getEventsByArtist(artistId: string): Promise<EventSummary[
  */
 const _getUpcomingEventsByArtist = unstable_cache(
   async (artistId: string, limit?: number): Promise<EventSummary[]> => {
-    const now = new Date()
+    const today = startOfTodayBerlin()
     const events = await prisma.event.findMany({
       where: {
         artistId,
         isDeleted: false,
         isActive: true,
-        dates: { some: { date: { gte: now } } },
+        dates: { some: { date: { gte: today } } },
       },
-      include: futureEventInclude(now),
+      include: futureEventInclude(today),
     })
     const ordered = sortByNextDate(events.map(mapToSummary))
     return limit ? ordered.slice(0, limit) : ordered
@@ -524,16 +532,16 @@ const _getOtherEventsByArtist = unstable_cache(
     excludeEventId: string,
     limit?: number
   ): Promise<EventSummary[]> => {
-    const now = new Date()
+    const today = startOfTodayBerlin()
     const events = await prisma.event.findMany({
       where: {
         artistId,
         isDeleted: false,
         isActive: true,
         id: { not: excludeEventId },
-        dates: { some: { date: { gte: now } } },
+        dates: { some: { date: { gte: today } } },
       },
-      include: futureEventInclude(now),
+      include: futureEventInclude(today),
     })
     const ordered = sortByNextDate(events.map(mapToSummary))
     return limit ? ordered.slice(0, limit) : ordered
@@ -602,13 +610,14 @@ export async function getEventsByUserGrouped(
     include: eventInclude,
     orderBy: { createdAt: "desc" },
   })
-  const now = new Date()
+  const today = startOfTodayBerlin()
 
   // Agrupamos sobre el array Prisma para tener acceso a `isActive` (no
   // expuesto en `EventSummary`). `event.dates` viene ordenado asc por
   // `eventInclude`. Para distinguir upcoming/past comparamos la **última**
-  // fecha: si la última ya pasó, el evento entero es pasado; si hay al
-  // menos una futura, es upcoming. Evita duplicación entre buckets.
+  // fecha contra el inicio del día calendario Berlín: si la última ya
+  // pasó (anterior a hoy), el evento entero es pasado; si hay al menos
+  // una hoy/futura, es upcoming. Evita duplicación entre buckets.
   const upcoming: EventSummary[] = []
   const drafts: EventSummary[] = []
   const past: EventSummary[] = []
@@ -622,15 +631,15 @@ export async function getEventsByUserGrouped(
       continue
     }
     const lastDate = summary.dates[summary.dates.length - 1]
-    if (lastDate && lastDate >= now) {
-      // En upcoming filtramos las fechas a solo las futuras, para que el
-      // `EventRow` muestre la próxima cronológica real (`dates[0]`) en su
-      // `DateTile`. Sin este filtro, un evento con varias funciones (una
-      // pasada + una futura) mostraría la pasada porque `dates` viene
-      // ordenado asc desde el include.
+    if (lastDate && lastDate >= today) {
+      // En upcoming filtramos las fechas a solo las hoy/futuras, para
+      // que el `EventRow` muestre la próxima cronológica real
+      // (`dates[0]`) en su `DateTile`. Sin este filtro, un evento con
+      // varias funciones (una pasada + una futura) mostraría la pasada
+      // porque `dates` viene ordenado asc desde el include.
       upcoming.push({
         ...summary,
-        dates: summary.dates.filter((d) => d >= now),
+        dates: summary.dates.filter((d) => d >= today),
       })
     } else {
       past.push(summary)


### PR DESCRIPTION
## Bug y urgencia

Las fechas de eventos se guardan como **medianoche UTC del día calendario** (Prisma `DateTime` → Postgres `TIMESTAMP` sin tz). En CEST (UTC+2, mayo) eso = 02:00 AM Berlín. Los queries comparaban contra `new Date()` (instante), así que **eventos de HOY "expiraban" a las 02:00 AM Berlín** y migraban a "pasados".

Confirmado contra Neon a las 09:00 Berlín del 24-may: **Fogón Criollo** (que se hace hoy 15:00-22:00) NO aparecía en próximos y SÍ en pasados. Hoy se reparten flyers — había que arreglarlo ya.

## Fix — Opción A del diagnóstico

**Solo lógica de servicio**, sin tocar schema ni datos.

### Helpers nuevos (`src/lib/date.ts`)
- `startOfTodayBerlin()`: instante UTC = 00:00 hoy en Europe/Berlin. Maneja CEST/CET via `Intl.DateTimeFormat`, sin hardcodear offset.
- `isTodayBerlin(d)`: `true` si `d` cae en el día calendario Berlín de hoy.

### Queries refactoreadas (12 callsites en `events.ts` + `artists.ts`)
Todas las comparaciones `date >= new Date()` / `date < new Date()` pasan a usar `startOfTodayBerlin()`. Efecto: un evento es "vigente" durante todo su día calendario Berlín, y "pasado" recién desde medianoche Berlín del día siguiente.

### Off-by-1-day en `until` (catch del reviewer)
`getUpcomingEventsWithin` y `getHeroVariant` calculaban `until = today + N*24h`. Como `today = 22:00 UTC` (verano) y los eventos del día N+1 están en 00:00 UTC, quedaban excluidos por 2 horas. Fix: `+(N+1)*24h - 1ms` para llegar al fin del día N inclusive.

### Verificación contra DB
```
=== UPCOMING después del fix (gte: startOfTodayBerlin) ===
- fogon-criollo | Fogón Criollo | 24/5/26  ← HOY
- milena-salamanca | Milena Salamanca | 7/6/26
- wayra-puka | Wayra Puka | 7/6/26

=== PAST después del fix (every lt: startOfTodayBerlin) ===
- pena-carnaval | Peña Carnaval | last: 1/3/26
- el-fogon-argentino | El Fogón Argentino | last: 21/12/25

¿Está Fogón Criollo en upcoming? true
¿Está Fogón Criollo en past?     false
```

## Sección "HOY" en el home

Nueva `TodaySection` inline en `page.tsx`:
- Solo aparece si hay eventos hoy.
- Reusa `EventCard` con nueva prop `todayLabel`: el `DateTile` pasa a accent `brand` (rojo sangre) y el eyebrow muestra "HOY · 15:00-22:00" en vez del weekday + fecha.
- Eventos de hoy se **filtran de "Próximas 4 semanas" y "Agenda"** para no duplicar.
- El **mini-card del hero mobile** ahora apunta al próximo evento DESPUÉS de hoy (los de hoy ya están destacados arriba).
- i18n ES/EN/DE en `home.today` (`title` + `badge`).

## Architecture review

Corrido sobre el diff. **2 ALTOS, ambos aplicados** en el PR:
1. `artists.ts` tenía el mismo bug en 4 queries → fixed (consistencia con `events.ts`).
2. La aritmética `+ N*24h` excluía el día N de la ventana → fixed (`+ (N+1)*24h - 1ms`).

**2 MEDIOS, documentados como follow-up** (no bloqueantes para hoy):
- `events/[slug]/page.tsx isLive` usa `getDate()` naive → mismo class de bug, solo afecta el badge "EN VIVO" del detalle.
- `unstable_cache` keys no incluyen el día → ≤5 min de drift a las 00:00 Berlín cuando un evento cambia de bucket.

## Verificación

- [x] Build OK (type-check + compile).
- [x] DB verificada: Fogón Criollo en upcoming, fuera de past.
- [x] Helper validado por reviewer en boundaries CEST/CET y DST switches (mar/oct).
- [ ] Smoke test live: dev local en estado roto — verificable en prod tras deploy.

## Backlog

- Mismo fix en `events/[slug]/page.tsx isLive`.
- Cache keys con día Berlín para eliminar el drift de 5 min post-medianoche.
- **Long-term (Opción C)**: rediseño de schema `startsAt`/`endsAt` con timezone explícita, hora real del evento. Permitiría lógica "evento en curso / ya terminó" en lugar de día calendario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Today" section on the home page to highlight events occurring today
  * Event cards now display a "today" badge for current-day events
  * Events are now organized into "Today," "Next Week," and "Future Agenda" sections

* **Improvements**
  * Enhanced date filtering consistency for events across the platform

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->