### PR TITLE
fix(home): derive Próximas 4 semanas from agenda — filter today before slice

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server"
 import { Link } from "@/i18n/navigation"
 import { cn } from "@/lib/utils"
-import { isTodayBerlin } from "@/lib/date"
+import { endOfDayBerlinPlus, isTodayBerlin } from "@/lib/date"
 import {
   getHeroVariant,
   getUpcomingEventsWithin,
@@ -39,7 +39,6 @@ export default async function HomePage({
 
   const [
     heroVariant,
-    nextWeeksEvents,
     upcomingAgenda,
     activeArtists,
     activeGenres,
@@ -47,10 +46,12 @@ export default async function HomePage({
     user,
   ] = await Promise.all([
     getHeroVariant(),
-    // Próximos 3 dentro de las 4 semanas — sección "Próximas 4 semanas".
-    getUpcomingEventsWithin(28, 3),
-    // Próximos 10 dentro del próximo año, suficiente para la agenda
-    // compacta de la home sin traer toda la lista futura.
+    // Próximos 10 dentro del próximo año — fuente única para la Agenda y
+    // para "Próximas 4 semanas" (que se deriva de este set abajo). Antes
+    // había una query separada `getUpcomingEventsWithin(28, 3)` que
+    // duplicaba el fetch y disparaba un bug de orden: el slice top-3 se
+    // aplicaba ANTES de filtrar today, dejando los slots tomados por
+    // eventos de hoy cuando había varios.
     getUpcomingEventsWithin(365, 10),
     getActiveArtists(8),
     getActiveGenres(),
@@ -69,7 +70,15 @@ export default async function HomePage({
   )
   const todayIds = new Set(todayEvents.map((ev) => ev.id))
   const futureAgenda = upcomingAgenda.filter((ev) => !todayIds.has(ev.id))
-  const futureNextWeeks = nextWeeksEvents.filter((ev) => !todayIds.has(ev.id))
+
+  // "Próximas 4 semanas" sale del mismo set ya filtrado de today, y el
+  // slice top-3 ocurre DESPUÉS del filtrado (no antes, como en la versión
+  // con query separada). Eso evita que N eventos de hoy se coman N slots
+  // del top-3 y dejen fuera eventos futuros legítimos.
+  const fourWeeksCutoff = endOfDayBerlinPlus(28)
+  const futureNextWeeks = futureAgenda
+    .filter((ev) => ev.dates[0] && ev.dates[0] <= fourWeeksCutoff)
+    .slice(0, 3)
 
   // El mini-card del hero (mobile) muestra el próximo show DESPUÉS de hoy
   // — si hay eventos hoy, esos ya están destacados arriba; el mini-card

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -129,3 +129,20 @@ export function startOfTodayBerlin(): Date {
 export function isTodayBerlin(d: Date): boolean {
   return berlinDateString(d) === berlinDateString(new Date())
 }
+
+/**
+ * Último instante del día calendario Berlín `days` días después de hoy
+ * (INCLUSIVE). Pensado como bound superior para filtros tipo "eventos
+ * dentro de los próximos N días" — sirve tanto en queries Prisma (con
+ * `lte`) como en comparaciones en memoria contra `event.dates[0]`.
+ *
+ * Las fechas de evento se guardan como `00:00 UTC` del día calendario,
+ * así que el bound se extiende al fin del día N para capturar esos
+ * eventos. `+(days+1)*24h - 1ms` es equivalente a `startOfBerlinDay(today+N+1) - 1ms`
+ * para días sin transición DST en la ventana.
+ */
+export function endOfDayBerlinPlus(days: number): Date {
+  return new Date(
+    startOfTodayBerlin().getTime() + (days + 1) * 24 * 60 * 60 * 1000 - 1
+  )
+}


### PR DESCRIPTION
## Bug

Cuando había **2+ eventos en el mismo día calendario Berlín**, la sección "Próximas 4 semanas" del home dejaba afuera eventos legítimos.

Observado el 24-may: Fogón Criollo + Mukunda Cruz (ambos HOY) + Wayra Puka + Milena Salamanca (ambos 7-jun). "Próximas 4 semanas" mostraba solo Wayra; Milena desaparecía. Pero "La Agenda" sí los mostraba a los dos — discrepancia visible.

## Causa

La sección se alimentaba con una query separada `getUpcomingEventsWithin(28, 3)`. El `take: 3` se aplicaba **antes** que el filtrado de today (que ocurre a nivel de page.tsx). Con 2 today, el top-3 se llenaba con `[today1, today2, oneFuture]`, y al filtrar today quedaba `[oneFuture]` → solo 1 evento en la sección.

## Fix

- Quito la query separada `getUpcomingEventsWithin(28, 3)`. Una sola fuente: `getUpcomingEventsWithin(365, 10)`.
- Derivo `futureNextWeeks` del set `futureAgenda` (ya filtrado de today), aplicando un cutoff de 4 semanas y el slice top-3 **después** del filter.
- Nuevo helper `endOfDayBerlinPlus(days)` en `@/lib/date` para el bound superior inclusivo. Replica la misma matemática `+(N+1)*24h - 1ms` que ya está inline en `services/events.ts` (futuro PR puede DRY adoptando el helper ahí).

## Beneficios

- Bug arreglado (verificado por simulación: con 4 eventos / 2 today, ahora "Próximas 4 semanas" muestra correctamente los 2 futuros en lugar de 1).
- Una query menos al DB (eliminada la duplicación que el architecture-reviewer ya había marcado en PR previo).
- `futureNextWeeks` y `futureAgenda` ahora comparten fuente — imposible que se desincronicen.

## No toca

- Schema Prisma. Datos. Servicios (events.ts queda igual). El form de eventos.

## Verificación

- [x] `npm run build` OK.
- [x] Simulación: con el set actual (Wayra + Milena, sin eventos hoy) ambas secciones muestran lo esperado, 2 eventos.
- [x] Simulación del bug original: con [today1, today2, Wayra, Milena] el fix mostraría [Wayra, Milena] en "Próximas 4 semanas" (antes mostraba solo [Wayra]).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized home page event selection logic by consolidating data fetching operations and deriving the "Próximas 4 semanas" (Next 4 Weeks) section from the existing agenda dataset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->