### PR TITLE
chore(cache): pass `{ expire: 0 }` to revalidateTag (Next 16 fix)

### DIFF
--- a/src/services/artists.ts
+++ b/src/services/artists.ts
@@ -225,7 +225,7 @@ export async function createArtist(
     },
   })
 
-  revalidateTag("artists", {})
+  revalidateTag("artists", { expire: 0 })
   return artist
 }
 
@@ -266,7 +266,7 @@ export async function updateArtist(id: string, data: UpdateArtistInput) {
     },
   })
 
-  revalidateTag("artists", {})
+  revalidateTag("artists", { expire: 0 })
   return artist
 }
 
@@ -281,5 +281,5 @@ export async function deleteArtist(id: string): Promise<void> {
   }
 
   await prisma.artist.delete({ where: { id } })
-  revalidateTag("artists", {})
+  revalidateTag("artists", { expire: 0 })
 }

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -694,7 +694,7 @@ export async function createEvent(
     return created
   })
 
-  revalidateTag("events", {})
+  revalidateTag("events", { expire: 0 })
   return event
 }
 
@@ -741,7 +741,7 @@ export async function updateEvent(id: string, data: UpdateEventInput): Promise<v
     },
   })
 
-  revalidateTag("events", {})
+  revalidateTag("events", { expire: 0 })
 }
 
 export async function softDeleteEvent(id: string): Promise<void> {
@@ -758,7 +758,7 @@ export async function softDeleteEvent(id: string): Promise<void> {
     where: { id },
     data: { isDeleted: true, deletedAt: new Date() },
   })
-  revalidateTag("events", {})
+  revalidateTag("events", { expire: 0 })
 }
 
 export async function restoreEvent(id: string): Promise<void> {
@@ -766,7 +766,7 @@ export async function restoreEvent(id: string): Promise<void> {
     where: { id },
     data: { isDeleted: false, deletedAt: null },
   })
-  revalidateTag("events", {})
+  revalidateTag("events", { expire: 0 })
 }
 
 export async function hardDeleteEvent(id: string): Promise<void> {
@@ -780,5 +780,5 @@ export async function hardDeleteEvent(id: string): Promise<void> {
   }
 
   await prisma.event.delete({ where: { id } })
-  revalidateTag("events", {})
+  revalidateTag("events", { expire: 0 })
 }


### PR DESCRIPTION
## Summary
- Next 16 requiere `revalidateTag(tag, profile)` con el 2º arg como `string` (`"max"`) o `{ expire?: number }`.
- Pasar `{}` tipa pero cae al comportamiento single-arg deprecated (per `node_modules/next/dist/docs/01-app/03-api-reference/04-functions/revalidateTag.md` líneas 22 y 55).
- 8 call sites en mutaciones de admin dashboard pasados a `{ expire: 0 }` para preservar la semántica actual de invalidación inmediata.
- Detectado por CodeRabbit en #53 sobre 2 call sites nuevos; este PR cierra el resto del proyecto.

## Files
- `src/services/artists.ts` — 3 sites (create/update/delete)
- `src/services/events.ts` — 5 sites (create/update/softDelete/restore/hardDelete)

## Trade-off
`{ expire: 0 }` = invalidación inmediata (comportamiento actual, preservado). La alternativa moderna `"max"` (SWR) sería válida pero cambia el comportamiento — data stale hasta el próximo visit. Para dashboards admin (admin clickea "Save" y al navegar a la pública espera ver lo nuevo ya), immediate-invalidation matches expectations.

## Test plan
- [ ] Crear/editar/eliminar un artist → verificar que `/artists` refleja el cambio en la próxima visita sin esperar TTL.
- [ ] Crear/editar/eliminar un event → mismo check en `/events` y home.
- [ ] No regresiones en bylines de eventos cacheados.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cache invalidation behavior for artist and event data operations to enhance response times and ensure data consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->