### PR TITLE
chore(prisma): use DIRECT_URL for migrate to bypass Neon pooler P1002

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,9 @@
-DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+# Pooler de Neon (PgBouncer) — lo usa el Prisma client en runtime.
+DATABASE_URL=postgresql://user:password@host-pooler.region.aws.neon.tech/dbname?sslmode=require
+# Endpoint directo de Neon (mismo host pero SIN `-pooler`) — lo usa Prisma
+# CLI para `migrate deploy`/`migrate dev`. El pooler no soporta de forma
+# confiable `pg_advisory_lock`, lo que provoca P1002 en migrate.
+DIRECT_URL=postgresql://user:password@host.region.aws.neon.tech/dbname?sslmode=require
 BETTER_AUTH_SECRET=tu_secreto_aleatorio_minimo_32_caracteres_aqui
 BETTER_AUTH_URL=http://localhost:3000
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/deploy.sh
+++ b/deploy.sh
@@ -53,16 +53,19 @@ echo "→ Applying pending migrations on VPS..."
 # regenera el client TS. Sin esto, código nuevo que referencia columnas
 # de migrations no aplicadas vuelca 500 en runtime.
 #
-# DATABASE_URL / DIRECT_URL: Prisma CLI por sí solo NO auto-loadea
-# `.env.local` (solo `.env`). Este repo cierra ese gap en `prisma.config.ts`
-# con un `loadEnv()` custom que lee `.env.local` y populá `process.env`
-# antes de que Prisma resuelva `env("DATABASE_URL")` y `env("DIRECT_URL")`
-# del `datasource db` en el schema.
+# DATABASE_URL / DIRECT_URL: en Prisma 7 las URLs no viven en el schema
+# (`datasource db` solo declara `provider`); la URL para el CLI vive en
+# `prisma.config.ts`, donde resolvemos `process.env.DIRECT_URL ??
+# process.env.DATABASE_URL`. Prisma CLI por sí solo NO auto-loadea
+# `.env.local` (solo `.env`); ese gap lo cierra el `loadEnv()` custom
+# del propio `prisma.config.ts`, que lee `.env.local` y populá
+# `process.env` antes de que se resuelva el datasource.
 #
-# `migrate deploy` usa `DIRECT_URL` (endpoint Neon sin pooler) porque el
-# pooler de Neon no soporta de forma confiable `pg_advisory_lock`, lo que
-# producía P1002 intermitente en deploys. El runtime client sigue usando
-# `DATABASE_URL` (pooler).
+# Por qué `DIRECT_URL`: el pooler de Neon no soporta de forma confiable
+# `pg_advisory_lock`, lo que producía P1002 intermitente en `migrate
+# deploy`. El endpoint sin pooler lo cierra. El runtime client de la app
+# sigue usando `DATABASE_URL` (pooler) vía el adapter PrismaPg en
+# `src/lib/prisma.ts` — independiente de esto.
 #
 # Verificado empíricamente: `prisma migrate status` desde el VPS conecta
 # a Neon prod.

--- a/deploy.sh
+++ b/deploy.sh
@@ -53,10 +53,19 @@ echo "→ Applying pending migrations on VPS..."
 # regenera el client TS. Sin esto, código nuevo que referencia columnas
 # de migrations no aplicadas vuelca 500 en runtime.
 #
-# DATABASE_URL: Prisma CLI por sí solo NO auto-loadea `.env.local` (solo
-# `.env`). Este repo cierra ese gap en `prisma.config.ts` con un `loadEnv()`
-# custom que lee `.env.local` antes de exponer `datasource.url`. Verificado
-# empíricamente: `prisma migrate status` desde el VPS conecta a Neon prod.
+# DATABASE_URL / DIRECT_URL: Prisma CLI por sí solo NO auto-loadea
+# `.env.local` (solo `.env`). Este repo cierra ese gap en `prisma.config.ts`
+# con un `loadEnv()` custom que lee `.env.local` y populá `process.env`
+# antes de que Prisma resuelva `env("DATABASE_URL")` y `env("DIRECT_URL")`
+# del `datasource db` en el schema.
+#
+# `migrate deploy` usa `DIRECT_URL` (endpoint Neon sin pooler) porque el
+# pooler de Neon no soporta de forma confiable `pg_advisory_lock`, lo que
+# producía P1002 intermitente en deploys. El runtime client sigue usando
+# `DATABASE_URL` (pooler).
+#
+# Verificado empíricamente: `prisma migrate status` desde el VPS conecta
+# a Neon prod.
 ssh $VPS "cd $REMOTE_DIR && npx prisma migrate deploy"
 
 echo "→ Regenerating Prisma client on VPS..."

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -19,9 +19,18 @@ function loadEnv() {
 
 loadEnv()
 
+// Prisma 7: el `url` del datasource vive acá, no en el schema (P1012).
+// Preferimos `DIRECT_URL` (endpoint Neon sin pooler) para que el CLI
+// (`migrate deploy`, `migrate dev`, `introspect`) no se cuelgue en el
+// `pg_advisory_lock` que el pooler no soporta — esto cierra el P1002
+// intermitente que veíamos en deploys. Fallback a `DATABASE_URL` para
+// entornos que aún no migraron las env vars (dev local sin DIRECT_URL).
+//
+// El runtime client de la app sigue usando `DATABASE_URL` (pooler) vía
+// el adapter PrismaPg en `src/lib/prisma.ts` — independiente de esto.
 export default defineConfig({
   schema: path.join("prisma", "schema.prisma"),
   datasource: {
-    url: process.env.DATABASE_URL!,
+    url: process.env.DIRECT_URL ?? process.env.DATABASE_URL!,
   },
 })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,12 @@ generator client {
 }
 
 datasource db {
+  // En Prisma 7 las URLs viven fuera del schema (P1012 si se declaran
+  // acá). El runtime client lee `DATABASE_URL` (pooler de Neon) vía el
+  // adapter en `src/lib/prisma.ts`. El CLI lee la URL desde
+  // `prisma.config.ts`, donde resolvemos `DIRECT_URL` (endpoint sin
+  // pooler) para evitar P1002 en migrate por timeout del
+  // `pg_advisory_lock` del pooler.
   provider = "postgresql"
 }
 


### PR DESCRIPTION
## Summary
- Neon pooler (PgBouncer) no soporta de forma confiable `pg_advisory_lock`, que Prisma usa para serializar `migrate deploy`. Resultado: **P1002 intermitente** en deploys.
- Caso real: deploy de hoy de PRs #48 + #50 → `migrate deploy` falló con P1002, retry funcionó (vimos el bug en vivo).
- Fix canónico Neon + Prisma: usar `DIRECT_URL` (endpoint sin `-pooler`) para CLI commands, mantener `DATABASE_URL` (pooler) para runtime.

## Changes
- `prisma/schema.prisma` — solo `provider` en `datasource db`. **Prisma 7 removió** `url`/`directUrl` del schema (P1012). Comentario explicando dónde viven ahora las URLs.
- `prisma.config.ts` — `datasource.url = process.env.DIRECT_URL ?? process.env.DATABASE_URL`. Fallback preserva back-compat con entornos que aún no setearon `DIRECT_URL`.
- `.env.local.example` — documenta el patrón `DATABASE_URL` (pooler) + `DIRECT_URL` (no-pooler).
- `deploy.sh` — comentario actualizado explicando el flujo.

## Pre-merge requirement
Ambos `.env.local` (local y VPS) deben tener `DIRECT_URL` seteada **antes** del merge. Ya hecho en esta sesión:
- Local: derivada de `DATABASE_URL` sustituyendo `-pooler` por nada
- VPS: mismo patrón

Sin `DIRECT_URL` seteada, el fallback `?? DATABASE_URL` mantiene el comportamiento actual (volverías a ver P1002 ocasional pero nada se rompe).

## Verificación empírica (ya corrida)
\`\`\`
ssh root@VPS \"cd /var/www/lahuelladelcaminante && npx prisma migrate status\"
→ Datasource at \"ep-muddy-surf-al0awhfe.c-3.eu-central-1.aws.neon.tech\"  ← sin -pooler ✓
→ 2 migrations found, Database schema is up to date!
\`\`\`

## Test plan
- [ ] Próximo `bash deploy.sh` no debe arrojar P1002 en el step de `migrate deploy`
- [ ] Runtime de la app sigue funcionando (queries van por el pooler)
- [ ] `npx prisma migrate status` desde local funciona

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated example environment to use a pooled DATABASE_URL for runtime and a separate DIRECT_URL for reliable migrations.
* **Documentation**
  * Clarified deployment and Prisma CLI behavior around which DB URL is used for runtime vs. migrations and why a direct connection is required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->