### PR TITLE
fix(artists): restore photo gallery removed by detail-page redesign

### DIFF
--- a/src/app/[locale]/(public)/artists/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/artists/[slug]/page.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { Metadata } from "next"
+import Image from "next/image"
 import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
 import { Link } from "@/i18n/navigation"
@@ -145,6 +146,38 @@ export default async function ArtistDetailPage({
 
           {/* Redes sociales */}
           <SocialLinks socialMedia={artist.socialMedia} />
+
+          {/*
+            Galería de fotos — restaura la sección que el redesign (commit
+            6e18e53) borró sin querer. Datos y forms de upload nunca se
+            tocaron; solo faltaba el render.
+
+            `images[0]` ya se renderiza como portrait grande arriba, así
+            que la galería empieza desde `images[1]` para no duplicar.
+            El grid responsive (2 cols mobile, 3 cols sm+) cabe bien
+            dentro del col-span-7 del layout.
+          */}
+          {artist.images.length > 1 ? (
+            <section className="flex flex-col gap-m">
+              <Eyebrow as="h2">{t("photosLabel")}</Eyebrow>
+              <ul className="grid grid-cols-2 sm:grid-cols-3 gap-s">
+                {artist.images.slice(1).map((img) => (
+                  <li
+                    key={img.id}
+                    className="relative aspect-square overflow-hidden rounded-lg bg-bg-surface-2"
+                  >
+                    <Image
+                      src={img.url}
+                      alt={img.alt ?? artist.name}
+                      fill
+                      sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 22vw"
+                      className="object-cover transition-transform duration-500 hover:scale-105"
+                    />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
 
           {/* Próximas fechas */}
           <section className="flex flex-col gap-m">

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -278,7 +278,8 @@
     "noUpcomingShows": "Aktuell keine Shows geplant. Folge uns auf Social Media, um nichts zu verpassen.",
     "bioShowMore": "Mehr anzeigen",
     "bioShowLess": "Weniger anzeigen",
-    "backToArtists": "Zu den Künstlern"
+    "backToArtists": "Zu den Künstlern",
+    "photosLabel": "Fotos"
   },
   "dashboard": {
     "title": "Mein Dashboard",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -278,7 +278,8 @@
     "noUpcomingShows": "No upcoming shows for now. Follow us on socials to stay tuned.",
     "bioShowMore": "Show more",
     "bioShowLess": "Show less",
-    "backToArtists": "Artists"
+    "backToArtists": "Artists",
+    "photosLabel": "Photos"
   },
   "dashboard": {
     "title": "My Dashboard",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -278,7 +278,8 @@
     "noUpcomingShows": "Por ahora no hay shows próximos. Seguinos en redes para enterarte.",
     "bioShowMore": "Mostrar más",
     "bioShowLess": "Mostrar menos",
-    "backToArtists": "Artistas"
+    "backToArtists": "Artistas",
+    "photosLabel": "Fotos"
   },
   "dashboard": {
     "title": "Mi Panel",


### PR DESCRIPTION
## Summary
- Regresión real detectada por el dev: el commit `6e18e53` ("redesign event and artist detail pages") removió sin querer la sección de gallery del artist detail page.
- Datos (`ArtistDetail.images[]`) y forms del dashboard (upload múltiple) nunca cambiaron — solo faltaba el render.
- Esta PR restaura el render en el nuevo layout 5+7.

## Restored section
Dentro del col-span-7, entre SocialLinks y "Próximas fechas" (mismo flow conceptual que el diseño pre-redesign):

\`\`\`tsx
{artist.images.length > 1 ? (
  <section className="flex flex-col gap-m">
    <Eyebrow as="h2">{t("photosLabel")}</Eyebrow>
    <ul className="grid grid-cols-2 sm:grid-cols-3 gap-s">
      {artist.images.slice(1).map((img) => (
        <li key={img.id} className="relative aspect-square overflow-hidden rounded-lg bg-bg-surface-2">
          <Image src={img.url} alt={img.alt ?? artist.name} fill ... />
        </li>
      ))}
    </ul>
  </section>
) : null}
\`\`\`

- `images[0]` se renderiza como portrait grande arriba → galería empieza desde `images[1]` para no duplicar el cover.
- Grid responsive (2 cols mobile, 3 cols sm+), aspect-square, `object-cover` + hover scale.
- Renderiza solo si hay >1 imagen.

## i18n
\`photosLabel\` agregada al namespace \`artistDetail\` en es/en/de:
- es: "Fotos"
- en: "Photos"
- de: "Fotos"

(Ya existía suelta en el namespace `artists` pre-redesign, pero ese namespace es para el listado. No la toco para evitar scope creep.)

## Out of scope (decisión explícita con el dev)
- **Events** detail page → nunca tuvo gallery pública en git history. Feature nueva, no regresión.
- **Creators** detail page → nuevo (de PR #53), `UserProfile` no tiene relación `images` en el schema. Necesita migration + form en `/dashboard/profile`. Laburo aparte.

## Test plan
- [ ] `/es/artists/[slug-de-artist-con-multiple-fotos]` muestra el grid debajo de social links
- [ ] `/es/artists/[slug-de-artist-con-1-foto]` no muestra la sección (sin gallery vacía)
- [ ] EN + DE funcionan con i18n correcto
- [ ] Sin gallery layout shift (cover sigue arriba, el grid no empuja contenido raro)
- [ ] Responsive: 2 cols en mobile, 3 cols sm+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a photos gallery section to artist detail pages, displaying multiple images in a responsive grid layout with interactive hover scaling effects
  * Extended multi-language localization support for the gallery with translations in English, German, and Spanish

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->