### PR TITLE
feat(events): dirección clickeable abre Google Maps

### DIFF
--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -187,6 +187,21 @@ export default async function EventDetailPage({
     />
   )
 
+  // Link de Google Maps: combina venue + dirección para mejorar resultados
+  // cuando solo está el nombre del local sin dirección exacta.
+  const addressLink = event.address ? (
+    <a
+      href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+        [event.location, event.address].filter(Boolean).join(", ")
+      )}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-2 hover:text-brand transition-colors"
+    >
+      {event.address}
+    </a>
+  ) : null
+
   return (
     <>
       <div className="max-w-7xl mx-auto px-m sm:px-l py-l lg:py-xl">
@@ -301,23 +316,7 @@ export default async function EventDetailPage({
                 {
                   id: "address",
                   label: t("facts.address"),
-                  value: event.address
-                    ? (() => {
-                        const q = [event.location, event.address]
-                          .filter(Boolean)
-                          .join(", ")
-                        return (
-                          <a
-                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline underline-offset-2 hover:text-brand transition-colors"
-                          >
-                            {event.address}
-                          </a>
-                        )
-                      })()
-                    : null,
+                  value: addressLink,
                 },
               ]}
             />

--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -301,7 +301,23 @@ export default async function EventDetailPage({
                 {
                   id: "address",
                   label: t("facts.address"),
-                  value: event.address,
+                  value: event.address
+                    ? (() => {
+                        const q = [event.location, event.address]
+                          .filter(Boolean)
+                          .join(", ")
+                        return (
+                          <a
+                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline underline-offset-2 hover:text-brand transition-colors"
+                          >
+                            {event.address}
+                          </a>
+                        )
+                      })()
+                    : null,
                 },
               ]}
             />


### PR DESCRIPTION
## Summary
- La dirección en el fact grid del detalle de evento ahora es un link a Google Maps
- La query combina `location` (nombre del venue) + `address` para mejorar resultados cuando la dirección no es precisa
- Si no hay `address`, el campo sigue oculto (sin cambio de comportamiento)

## Test plan
- [ ] Evento con `address` cargada: el texto es clickeable y abre Maps con venue + dirección
- [ ] Evento con solo nombre de venue (sin dirección exacta): Maps igual lo encuentra por nombre
- [ ] Evento sin `address`: la celda no aparece (igual que antes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Event addresses now appear as clickable links that open a Google Maps search in a new tab for quick access to locations.
  * If an event address is missing, no address is shown, avoiding broken or empty links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thusspokedata/lahuelladelcaminante/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->