### PR TITLE
feat(calendar): vista mensual pública + entradas de escena admin

### DIFF
--- a/docs/superpowers/plans/2026-06-02-calendar.md
+++ b/docs/superpowers/plans/2026-06-02-calendar.md
@@ -1,0 +1,1482 @@
+# Calendar de Eventos — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Página pública `/events/calendar` con vista mensual que muestra eventos oficiales (rojo) y entradas de escena cargadas por el admin (ámbar), más un panel admin para gestionar las entradas de escena.
+
+**Architecture:** Server Component renderiza el mes actual; Client Component `EventsCalendar` maneja navegación mes a mes via `GET /api/calendar?month=YYYY-MM`. Nuevo modelo Prisma `SceneEvent` para entradas de escena. Admin panel en el grupo `(admin)` existente.
+
+**Tech Stack:** Prisma 7, Next.js 16 App Router, next-intl, Tailwind v4, React useState/useEffect.
+
+---
+
+## Task 1: Prisma — modelo SceneEvent + migración
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+
+- [ ] **Step 1: Agregar el modelo al schema**
+
+En `prisma/schema.prisma`, agregar al final del archivo (después del último modelo):
+
+```prisma
+model SceneEvent {
+  id          String   @id @default(cuid())
+  date        DateTime @db.Date
+  title       String
+  venue       String?
+  externalUrl String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+```
+
+- [ ] **Step 2: Crear la migración**
+
+```bash
+npx prisma migrate dev --name add_scene_events
+```
+
+Resultado esperado:
+```
+✔ Generated Prisma Client
+```
+
+- [ ] **Step 3: Verificar que el client genera el tipo**
+
+```bash
+grep -r "sceneEvent\|SceneEvent" node_modules/@prisma/client/index.d.ts | head -3
+```
+
+Debe mostrar el tipo generado.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/
+git commit -S -m "feat(calendar): modelo SceneEvent en Prisma"
+```
+
+---
+
+## Task 2: Servicio de calendario
+
+**Files:**
+- Create: `src/services/calendar.ts`
+
+- [ ] **Step 1: Crear el archivo**
+
+```ts
+/**
+ * Servicio de calendario — agrega entradas de Event y SceneEvent
+ * en el rango de fechas visible en la grilla mensual.
+ */
+import "server-only"
+
+import { prisma } from "@/lib/prisma"
+
+export interface CalendarEntry {
+  id: string
+  type: "event" | "scene"
+  /** ISO date string "YYYY-MM-DD" */
+  date: string
+  title: string
+  venue: string | null
+  time: string | null
+  slug: string | null
+  externalUrl: string | null
+}
+
+/**
+ * Retorna todas las entradas (Event + SceneEvent) en el rango [from, to].
+ * `from` y `to` son los límites de la grilla (primer lunes visible al
+ * último domingo visible), pueden extenderse fuera del mes pedido.
+ */
+export async function getCalendarEntries(
+  from: Date,
+  to: Date
+): Promise<CalendarEntry[]> {
+  const [events, sceneEvents] = await Promise.all([
+    prisma.event.findMany({
+      where: {
+        isDeleted: false,
+        isActive: true,
+        dates: { some: { date: { gte: from, lte: to } } },
+      },
+      include: {
+        dates: {
+          where: { date: { gte: from, lte: to } },
+          orderBy: { date: "asc" },
+        },
+      },
+    }),
+    prisma.sceneEvent.findMany({
+      where: { date: { gte: from, lte: to } },
+      orderBy: { date: "asc" },
+    }),
+  ])
+
+  const entries: CalendarEntry[] = []
+
+  for (const event of events) {
+    for (const d of event.dates) {
+      entries.push({
+        id: `${event.id}__${d.id}`,
+        type: "event",
+        date: d.date.toISOString().split("T")[0]!,
+        title: event.title,
+        venue: event.location,
+        time: event.time ?? null,
+        slug: event.slug,
+        externalUrl: null,
+      })
+    }
+  }
+
+  for (const se of sceneEvents) {
+    entries.push({
+      id: se.id,
+      type: "scene",
+      date: se.date.toISOString().split("T")[0]!,
+      title: se.title,
+      venue: se.venue ?? null,
+      time: null,
+      slug: null,
+      externalUrl: se.externalUrl ?? null,
+    })
+  }
+
+  return entries.sort((a, b) => a.date.localeCompare(b.date))
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/services/calendar.ts
+git commit -S -m "feat(calendar): servicio getCalendarEntries"
+```
+
+---
+
+## Task 3: API route GET /api/calendar
+
+**Files:**
+- Create: `src/app/api/calendar/route.ts`
+
+- [ ] **Step 1: Crear el archivo**
+
+```ts
+/**
+ * GET /api/calendar?month=YYYY-MM
+ *
+ * Retorna CalendarEntry[] para la grilla mensual completa (incluye días
+ * de meses adyacentes para completar la primera y última semana).
+ * No requiere auth — es público.
+ */
+import { NextResponse } from "next/server"
+import { getCalendarEntries } from "@/services/calendar"
+
+/** Calcula los límites de la grilla de un mes: primer lunes visible y
+ *  último domingo visible. La grilla arranca siempre en lunes. */
+function calendarGridBounds(year: number, month: number): { from: Date; to: Date } {
+  // Primer día del mes (month es 1-indexed)
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const dayOfWeek = firstDay.getUTCDay() // 0=Dom, 1=Lun ... 6=Sáb
+  const daysBack = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  const from = new Date(firstDay)
+  from.setUTCDate(from.getUTCDate() - daysBack)
+
+  // Último día del mes
+  const lastDay = new Date(Date.UTC(year, month, 0))
+  const lastDayOfWeek = lastDay.getUTCDay()
+  const daysForward = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+  const to = new Date(lastDay)
+  to.setUTCDate(to.getUTCDate() + daysForward)
+  // Incluir hasta el final del día
+  to.setUTCHours(23, 59, 59, 999)
+
+  return { from, to }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const month = searchParams.get("month")
+
+  if (!month || !/^\d{4}-(?:0[1-9]|1[0-2])$/.test(month)) {
+    return NextResponse.json({ error: "invalid_month" }, { status: 400 })
+  }
+
+  const [yearStr, monthStr] = month.split("-")
+  const year = parseInt(yearStr!, 10)
+  const m = parseInt(monthStr!, 10)
+
+  const { from, to } = calendarGridBounds(year, m)
+  const entries = await getCalendarEntries(from, to)
+
+  return NextResponse.json({ data: { entries } })
+}
+```
+
+- [ ] **Step 2: Verificar manualmente**
+
+```bash
+curl "http://localhost:3000/api/calendar?month=2026-07" | python3 -m json.tool | head -20
+```
+
+Esperar: `{"data":{"entries":[...]}}` o entries vacío si no hay eventos.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/calendar/route.ts
+git commit -S -m "feat(calendar): GET /api/calendar?month=YYYY-MM"
+```
+
+---
+
+## Task 4: i18n — namespace calendar
+
+**Files:**
+- Modify: `src/messages/es.json`
+- Modify: `src/messages/en.json`
+- Modify: `src/messages/de.json`
+
+- [ ] **Step 1: Agregar claves a `es.json`**
+
+Agregar en el objeto raíz (antes del `}`):
+
+```json
+"calendar": {
+  "pageTitle": "Calendario",
+  "pageDescription": "Todos los eventos de la escena latina en Berlín",
+  "navPrev": "Mes anterior",
+  "navNext": "Mes siguiente",
+  "noEvents": "Sin eventos este mes",
+  "sceneEventBadge": "Otra escena",
+  "viewEvent": "Ver evento →",
+  "viewSource": "Ver fuente →",
+  "moreEvents": "+{count} más",
+  "loading": "Cargando...",
+  "weekdays": {
+    "mon": "Lun",
+    "tue": "Mar",
+    "wed": "Mié",
+    "thu": "Jue",
+    "fri": "Vie",
+    "sat": "Sáb",
+    "sun": "Dom"
+  },
+  "months": {
+    "1": "Enero", "2": "Febrero", "3": "Marzo", "4": "Abril",
+    "5": "Mayo", "6": "Junio", "7": "Julio", "8": "Agosto",
+    "9": "Septiembre", "10": "Octubre", "11": "Noviembre", "12": "Diciembre"
+  },
+  "dashboard": {
+    "title": "Entradas de escena",
+    "addEntry": "Agregar entrada",
+    "dateLabel": "Fecha",
+    "titleLabel": "Título",
+    "venueLabel": "Venue (opcional)",
+    "urlLabel": "Link externo (opcional)",
+    "delete": "Eliminar",
+    "empty": "No hay entradas de escena cargadas",
+    "saving": "Guardando...",
+    "saved": "Guardado"
+  }
+}
+```
+
+- [ ] **Step 2: Agregar claves a `en.json`**
+
+```json
+"calendar": {
+  "pageTitle": "Calendar",
+  "pageDescription": "All events from the Latin scene in Berlin",
+  "navPrev": "Previous month",
+  "navNext": "Next month",
+  "noEvents": "No events this month",
+  "sceneEventBadge": "Other scene",
+  "viewEvent": "View event →",
+  "viewSource": "View source →",
+  "moreEvents": "+{count} more",
+  "loading": "Loading...",
+  "weekdays": {
+    "mon": "Mon", "tue": "Tue", "wed": "Wed", "thu": "Thu",
+    "fri": "Fri", "sat": "Sat", "sun": "Sun"
+  },
+  "months": {
+    "1": "January", "2": "February", "3": "March", "4": "April",
+    "5": "May", "6": "June", "7": "July", "8": "August",
+    "9": "September", "10": "October", "11": "November", "12": "December"
+  },
+  "dashboard": {
+    "title": "Scene entries",
+    "addEntry": "Add entry",
+    "dateLabel": "Date",
+    "titleLabel": "Title",
+    "venueLabel": "Venue (optional)",
+    "urlLabel": "External link (optional)",
+    "delete": "Delete",
+    "empty": "No scene entries loaded",
+    "saving": "Saving...",
+    "saved": "Saved"
+  }
+}
+```
+
+- [ ] **Step 3: Agregar claves a `de.json`**
+
+```json
+"calendar": {
+  "pageTitle": "Kalender",
+  "pageDescription": "Alle Events der lateinamerikanischen Szene in Berlin",
+  "navPrev": "Vorheriger Monat",
+  "navNext": "Nächster Monat",
+  "noEvents": "Keine Events in diesem Monat",
+  "sceneEventBadge": "Andere Szene",
+  "viewEvent": "Event ansehen →",
+  "viewSource": "Quelle ansehen →",
+  "moreEvents": "+{count} mehr",
+  "loading": "Laden...",
+  "weekdays": {
+    "mon": "Mo", "tue": "Di", "wed": "Mi", "thu": "Do",
+    "fri": "Fr", "sat": "Sa", "sun": "So"
+  },
+  "months": {
+    "1": "Januar", "2": "Februar", "3": "März", "4": "April",
+    "5": "Mai", "6": "Juni", "7": "Juli", "8": "August",
+    "9": "September", "10": "Oktober", "11": "November", "12": "Dezember"
+  },
+  "dashboard": {
+    "title": "Szene-Einträge",
+    "addEntry": "Eintrag hinzufügen",
+    "dateLabel": "Datum",
+    "titleLabel": "Titel",
+    "venueLabel": "Venue (optional)",
+    "urlLabel": "Externer Link (optional)",
+    "delete": "Löschen",
+    "empty": "Keine Szene-Einträge vorhanden",
+    "saving": "Speichern...",
+    "saved": "Gespeichert"
+  }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/messages/es.json src/messages/en.json src/messages/de.json
+git commit -S -m "feat(calendar): i18n keys ES/EN/DE"
+```
+
+---
+
+## Task 5: CalendarEventPopup component
+
+**Files:**
+- Create: `src/components/events/CalendarEventPopup.tsx`
+
+- [ ] **Step 1: Crear el componente**
+
+```tsx
+"use client"
+
+/**
+ * CalendarEventPopup — popup que aparece al hacer click en un evento
+ * del calendario.
+ *
+ * Desktop: posicionado cerca del elemento clicado (anchorRect).
+ * Mobile (anchorRect === null): centrado en pantalla con overlay oscuro.
+ *
+ * Cierra con Escape o click fuera.
+ */
+
+import { useEffect, useRef } from "react"
+import { useRouter } from "@/i18n/navigation"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import type { CalendarEntry } from "@/services/calendar"
+
+interface CalendarEventPopupProps {
+  entry: CalendarEntry
+  anchorRect: DOMRect | null
+  locale: string
+  onClose: () => void
+}
+
+export default function CalendarEventPopup({
+  entry,
+  anchorRect,
+  locale,
+  onClose,
+}: CalendarEventPopupProps) {
+  const t = useTranslations("calendar")
+  const router = useRouter()
+  const popupRef = useRef<HTMLDivElement>(null)
+  const isMobile = anchorRect === null
+
+  // Cerrar con Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", handleKey)
+    return () => document.removeEventListener("keydown", handleKey)
+  }, [onClose])
+
+  // Cerrar con click fuera
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    // Timeout para no capturar el click que abrió el popup
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", handleClick)
+    }, 0)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener("mousedown", handleClick)
+    }
+  }, [onClose])
+
+  // Calcular posición desktop
+  const style: React.CSSProperties = isMobile
+    ? {}
+    : (() => {
+        const POPUP_WIDTH = 220
+        const POPUP_HEIGHT = 160
+        const MARGIN = 8
+        const vw = window.innerWidth
+        const vh = window.innerHeight
+        let left = anchorRect.left
+        let top = anchorRect.bottom + MARGIN
+
+        if (left + POPUP_WIDTH > vw - MARGIN) {
+          left = vw - POPUP_WIDTH - MARGIN
+        }
+        if (top + POPUP_HEIGHT > vh - MARGIN) {
+          top = anchorRect.top - POPUP_HEIGHT - MARGIN
+        }
+
+        return { position: "fixed", left, top, width: POPUP_WIDTH, zIndex: 50 }
+      })()
+
+  const isOfficial = entry.type === "event"
+  const accentColor = isOfficial ? "#c0392b" : "#e5a93b"
+  const borderColor = isOfficial ? "rgba(192,57,43,0.35)" : "rgba(229,169,59,0.35)"
+
+  const popup = (
+    <div
+      ref={popupRef}
+      style={style}
+      className={cn(
+        "bg-bg-subtle rounded-xl border p-4 shadow-xl",
+        isMobile && "w-[280px] max-w-[90vw]"
+      )}
+      role="dialog"
+      aria-modal="true"
+      aria-label={entry.title}
+    >
+      {/* Badge de tipo */}
+      <div className="flex items-center gap-2 mb-3">
+        <div
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ background: accentColor }}
+        />
+        <span
+          className="text-[10px] font-bold tracking-widest uppercase"
+          style={{ color: accentColor }}
+        >
+          {isOfficial ? "La Huella" : t("sceneEventBadge")}
+        </span>
+      </div>
+
+      {/* Fecha + título */}
+      <p className="text-caption text-fg-tertiary mb-1">
+        {new Date(entry.date + "T12:00:00").toLocaleDateString(
+          locale === "de" ? "de-DE" : locale === "en" ? "en-GB" : "es-AR",
+          { weekday: "short", day: "numeric", month: "short" }
+        )}
+        {entry.time ? ` · ${entry.time}` : ""}
+      </p>
+      <p className="text-body font-bold text-fg-primary mb-1 leading-tight">
+        {entry.title}
+      </p>
+      {entry.venue && (
+        <p className="text-body-s text-fg-secondary mb-3">{entry.venue}</p>
+      )}
+
+      {/* CTA */}
+      {isOfficial && entry.slug ? (
+        <button
+          onClick={() => {
+            router.push(`/events/${entry.slug}`)
+            onClose()
+          }}
+          className="w-full text-center text-body-s font-bold py-2 rounded-m text-on-brand"
+          style={{ background: accentColor }}
+        >
+          {t("viewEvent")}
+        </button>
+      ) : entry.externalUrl ? (
+        <a
+          href={entry.externalUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onClose}
+          className="block w-full text-center text-body-s font-bold py-2 rounded-m border"
+          style={{ color: accentColor, borderColor }}
+        >
+          {t("viewSource")}
+        </a>
+      ) : null}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        {/* Overlay */}
+        <div
+          className="fixed inset-0 bg-black/60 z-40"
+          onClick={onClose}
+          aria-hidden
+        />
+        <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+          <div className="pointer-events-auto">{popup}</div>
+        </div>
+      </>
+    )
+  }
+
+  return popup
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/events/CalendarEventPopup.tsx
+git commit -S -m "feat(calendar): CalendarEventPopup component"
+```
+
+---
+
+## Task 6: CalendarDayCell component
+
+**Files:**
+- Create: `src/components/events/CalendarDayCell.tsx`
+
+- [ ] **Step 1: Crear el componente**
+
+```tsx
+/**
+ * CalendarDayCell — celda individual de la grilla del calendario.
+ *
+ * Muestra el número del día, los pills de eventos (max 2 visibles,
+ * el resto colapsa en "+N más"), y llama a onEntryClick al hacer click.
+ * Si `day` es null, renderiza una celda vacía (días de meses adyacentes
+ * que no pertenecen al mes visible — se muestran atenuados).
+ */
+
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+import type { CalendarEntry } from "@/services/calendar"
+
+const MAX_VISIBLE = 2
+
+interface CalendarDayCellProps {
+  day: number | null
+  isCurrentMonth: boolean
+  isToday: boolean
+  entries: CalendarEntry[]
+  onEntryClick: (entry: CalendarEntry, rect: DOMRect | null) => void
+}
+
+export default function CalendarDayCell({
+  day,
+  isCurrentMonth,
+  isToday,
+  entries,
+  onEntryClick,
+}: CalendarDayCellProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const hasEvents = entries.length > 0
+  const hasOfficial = entries.some((e) => e.type === "event")
+  const hasScene = entries.some((e) => e.type === "scene")
+
+  const visible = expanded ? entries : entries.slice(0, MAX_VISIBLE)
+  const hiddenCount = entries.length - MAX_VISIBLE
+
+  function handlePillClick(
+    e: React.MouseEvent<HTMLButtonElement>,
+    entry: CalendarEntry
+  ) {
+    e.stopPropagation()
+    const isMobile = window.innerWidth < 768
+    const rect = isMobile ? null : e.currentTarget.getBoundingClientRect()
+    onEntryClick(entry, rect)
+  }
+
+  return (
+    <div
+      className={cn(
+        "min-h-[80px] p-1.5 rounded-lg border transition-colors",
+        !isCurrentMonth && "opacity-30",
+        hasEvents && hasOfficial && !hasScene && "border-[rgba(192,57,43,0.3)] bg-[rgba(192,57,43,0.05)]",
+        hasEvents && hasScene && !hasOfficial && "border-[rgba(229,169,59,0.25)] bg-[rgba(229,169,59,0.04)]",
+        hasEvents && hasOfficial && hasScene && "border-[rgba(192,57,43,0.3)] bg-[rgba(192,57,43,0.05)]",
+        !hasEvents && "border-transparent",
+        isToday && "border-white/20 bg-white/[0.03]"
+      )}
+    >
+      {/* Número del día */}
+      <div className="mb-1.5">
+        {isToday ? (
+          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-fg-primary text-bg-page text-[11px] font-bold">
+            {day}
+          </span>
+        ) : (
+          <span
+            className={cn(
+              "text-[11px]",
+              isCurrentMonth ? "text-fg-tertiary" : "text-fg-tertiary/50"
+            )}
+          >
+            {day}
+          </span>
+        )}
+      </div>
+
+      {/* Pills */}
+      <div className="flex flex-col gap-0.5">
+        {visible.map((entry) => (
+          <button
+            key={entry.id}
+            onClick={(e) => handlePillClick(e, entry)}
+            className={cn(
+              "w-full text-left rounded px-1.5 py-0.5 text-[10px] font-semibold truncate cursor-pointer transition-opacity hover:opacity-80",
+              entry.type === "event"
+                ? "bg-brand text-on-brand"
+                : "bg-[rgba(229,169,59,0.18)] border border-[rgba(229,169,59,0.4)] text-[#e5a93b]"
+            )}
+          >
+            {entry.title}
+          </button>
+        ))}
+
+        {/* +N más */}
+        {!expanded && hiddenCount > 0 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              setExpanded(true)
+            }}
+            className="w-full text-left rounded px-1.5 py-0.5 text-[9px] font-semibold text-fg-tertiary border border-dashed border-fg-tertiary/30 hover:border-fg-tertiary/60 transition-colors"
+          >
+            +{hiddenCount} más
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/events/CalendarDayCell.tsx
+git commit -S -m "feat(calendar): CalendarDayCell component"
+```
+
+---
+
+## Task 7: EventsCalendar client component
+
+**Files:**
+- Create: `src/components/events/EventsCalendar.tsx`
+
+- [ ] **Step 1: Crear el componente**
+
+```tsx
+"use client"
+
+/**
+ * EventsCalendar — grilla mensual interactiva.
+ *
+ * Recibe los datos del mes actual del Server Component padre y maneja
+ * navegación mes a mes via fetch a /api/calendar?month=YYYY-MM.
+ *
+ * La grilla siempre empieza en Lunes (semana europea).
+ */
+
+import { useState, useCallback } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import CalendarDayCell from "./CalendarDayCell"
+import CalendarEventPopup from "./CalendarEventPopup"
+import type { CalendarEntry } from "@/services/calendar"
+
+interface EventsCalendarProps {
+  initialEntries: CalendarEntry[]
+  initialMonth: string // "YYYY-MM"
+  locale: string
+}
+
+interface PopupState {
+  entry: CalendarEntry
+  anchorRect: DOMRect | null
+}
+
+/** Retorna "YYYY-MM" del mes anterior */
+function prevMonth(ym: string): string {
+  const [y, m] = ym.split("-").map(Number)
+  if (m === 1) return `${y - 1}-12`
+  return `${y}-${String(m - 1).padStart(2, "0")}`
+}
+
+/** Retorna "YYYY-MM" del mes siguiente */
+function nextMonth(ym: string): string {
+  const [y, m] = ym.split("-").map(Number)
+  if (m === 12) return `${y + 1}-01`
+  return `${y}-${String(m + 1).padStart(2, "0")}`
+}
+
+/**
+ * Genera los días de la grilla para el mes dado.
+ * Cada elemento es { date: "YYYY-MM-DD", day: number, isCurrentMonth: boolean }.
+ * La grilla siempre empieza en lunes y termina en domingo, cubriendo
+ * entre 5 y 6 semanas (35 o 42 celdas).
+ */
+function buildGrid(ym: string): { date: string; day: number; isCurrentMonth: boolean }[] {
+  const [year, month] = ym.split("-").map(Number)
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const dayOfWeek = firstDay.getUTCDay() // 0=Dom...6=Sáb
+  const daysBack = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+
+  const start = new Date(firstDay)
+  start.setUTCDate(start.getUTCDate() - daysBack)
+
+  const lastDay = new Date(Date.UTC(year, month, 0))
+  const lastDayOfWeek = lastDay.getUTCDay()
+  const daysForward = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+
+  const end = new Date(lastDay)
+  end.setUTCDate(end.getUTCDate() + daysForward)
+
+  const cells: { date: string; day: number; isCurrentMonth: boolean }[] = []
+  const cursor = new Date(start)
+  while (cursor <= end) {
+    const dateStr = cursor.toISOString().split("T")[0]!
+    cells.push({
+      date: dateStr,
+      day: cursor.getUTCDate(),
+      isCurrentMonth: cursor.getUTCMonth() === month - 1,
+    })
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+
+  return cells
+}
+
+/** "YYYY-MM-DD" de hoy en UTC (conservador — sin timezone magic) */
+function todayString(): string {
+  return new Date().toISOString().split("T")[0]!
+}
+
+const WEEKDAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const
+
+export default function EventsCalendar({
+  initialEntries,
+  initialMonth,
+  locale,
+}: EventsCalendarProps) {
+  const t = useTranslations("calendar")
+  const [currentMonth, setCurrentMonth] = useState(initialMonth)
+  const [entries, setEntries] = useState<CalendarEntry[]>(initialEntries)
+  const [loading, setLoading] = useState(false)
+  const [popup, setPopup] = useState<PopupState | null>(null)
+
+  const today = todayString()
+  const [year, month] = currentMonth.split("-").map(Number)
+  const grid = buildGrid(currentMonth)
+
+  // Agrupar entries por fecha
+  const entriesByDate = new Map<string, CalendarEntry[]>()
+  for (const entry of entries) {
+    const list = entriesByDate.get(entry.date) ?? []
+    list.push(entry)
+    entriesByDate.set(entry.date, list)
+  }
+
+  async function navigateTo(ym: string) {
+    setLoading(true)
+    setPopup(null)
+    try {
+      const res = await fetch(`/api/calendar?month=${ym}`)
+      if (res.ok) {
+        const json = await res.json()
+        setEntries(json.data.entries)
+      }
+    } finally {
+      setLoading(false)
+      setCurrentMonth(ym)
+    }
+  }
+
+  const handleEntryClick = useCallback(
+    (entry: CalendarEntry, rect: DOMRect | null) => {
+      setPopup({ entry, anchorRect: rect })
+    },
+    []
+  )
+
+  const monthName = t(`months.${month}` as Parameters<typeof t>[0])
+
+  return (
+    <div className="relative">
+      {/* Nav del mes */}
+      <div className="flex items-center justify-between px-0 pb-6">
+        <button
+          onClick={() => navigateTo(prevMonth(currentMonth))}
+          disabled={loading}
+          aria-label={t("navPrev")}
+          className="border border-border rounded-m px-4 py-2 text-body-s text-fg-secondary hover:text-fg-primary transition-colors disabled:opacity-40"
+        >
+          ← {t(`months.${prevMonth(currentMonth).split("-")[1]?.replace(/^0/, "")}` as Parameters<typeof t>[0])}
+        </button>
+
+        <div className="text-center">
+          <p className="text-caption text-fg-tertiary tracking-widest uppercase mb-1">
+            {year}
+          </p>
+          <h1 className="text-heading-m font-display font-bold text-fg-primary">
+            {monthName}
+          </h1>
+        </div>
+
+        <button
+          onClick={() => navigateTo(nextMonth(currentMonth))}
+          disabled={loading}
+          aria-label={t("navNext")}
+          className="border border-border rounded-m px-4 py-2 text-body-s text-fg-secondary hover:text-fg-primary transition-colors disabled:opacity-40"
+        >
+          {t(`months.${nextMonth(currentMonth).split("-")[1]?.replace(/^0/, "")}` as Parameters<typeof t>[0])} →
+        </button>
+      </div>
+
+      {/* Cabeceras de días */}
+      <div className="grid grid-cols-7 mb-1">
+        {WEEKDAY_KEYS.map((key) => (
+          <div
+            key={key}
+            className="text-center text-[10px] font-bold tracking-widest uppercase text-fg-tertiary/50 py-2"
+          >
+            {t(`weekdays.${key}`)}
+          </div>
+        ))}
+      </div>
+
+      {/* Grilla de días */}
+      <div
+        className={cn(
+          "grid grid-cols-7 gap-0.5 transition-opacity",
+          loading && "opacity-50 pointer-events-none"
+        )}
+      >
+        {grid.map((cell) => (
+          <CalendarDayCell
+            key={cell.date}
+            day={cell.day}
+            isCurrentMonth={cell.isCurrentMonth}
+            isToday={cell.date === today}
+            entries={entriesByDate.get(cell.date) ?? []}
+            onEntryClick={handleEntryClick}
+          />
+        ))}
+      </div>
+
+      {/* Estado vacío */}
+      {!loading && entries.length === 0 && (
+        <p className="text-center text-fg-tertiary text-body py-12">
+          {t("noEvents")}
+        </p>
+      )}
+
+      {/* Popup */}
+      {popup && (
+        <CalendarEventPopup
+          entry={popup.entry}
+          anchorRect={popup.anchorRect}
+          locale={locale}
+          onClose={() => setPopup(null)}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/events/EventsCalendar.tsx
+git commit -S -m "feat(calendar): EventsCalendar client component"
+```
+
+---
+
+## Task 8: Página pública /events/calendar
+
+**Files:**
+- Create: `src/app/[locale]/(public)/events/calendar/page.tsx`
+
+- [ ] **Step 1: Crear el archivo**
+
+```tsx
+/**
+ * `/events/calendar` — vista mensual pública de todos los eventos.
+ *
+ * Server Component: renderiza el mes actual con datos frescos.
+ * El Client Component `EventsCalendar` maneja navegación mes a mes.
+ */
+
+import type { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
+import { getCalendarEntries } from "@/services/calendar"
+import EventsCalendar from "@/components/events/EventsCalendar"
+
+interface PageProps {
+  params: Promise<{ locale: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "calendar" })
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  }
+}
+
+/** Calcula los límites de la grilla para el mes actual (UTC). */
+function currentMonthGridBounds(): { from: Date; to: Date; ym: string } {
+  const now = new Date()
+  const year = now.getUTCFullYear()
+  const month = now.getUTCMonth() + 1
+
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const dayOfWeek = firstDay.getUTCDay()
+  const daysBack = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  const from = new Date(firstDay)
+  from.setUTCDate(from.getUTCDate() - daysBack)
+
+  const lastDay = new Date(Date.UTC(year, month, 0))
+  const lastDayOfWeek = lastDay.getUTCDay()
+  const daysForward = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+  const to = new Date(lastDay)
+  to.setUTCDate(to.getUTCDate() + daysForward)
+  to.setUTCHours(23, 59, 59, 999)
+
+  const ym = `${year}-${String(month).padStart(2, "0")}`
+  return { from, to, ym }
+}
+
+export default async function EventsCalendarPage({ params }: PageProps) {
+  const { locale } = await params
+  const { from, to, ym } = currentMonthGridBounds()
+  const initialEntries = await getCalendarEntries(from, to)
+
+  return (
+    <div className="max-w-7xl mx-auto px-m sm:px-l py-l lg:py-xl">
+      <EventsCalendar
+        initialEntries={initialEntries}
+        initialMonth={ym}
+        locale={locale}
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verificar que compila**
+
+```bash
+npm run build 2>&1 | grep -E "error|Error|calendar" | head -10
+```
+
+Esperado: sin errores, `/[locale]/events/calendar` en el output de rutas.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "src/app/[locale]/(public)/events/calendar/page.tsx"
+git commit -S -m "feat(calendar): página pública /events/calendar"
+```
+
+---
+
+## Task 9: Link "Calendario" en la navegación del Header
+
+**Files:**
+- Modify: `src/components/layout/Header.tsx`
+- Modify: `src/messages/es.json`
+- Modify: `src/messages/en.json`
+- Modify: `src/messages/de.json`
+
+- [ ] **Step 1: Agregar clave i18n en los 3 archivos**
+
+En cada archivo de mensajes, dentro del objeto `"nav"`:
+
+```json
+// es.json → "calendar": "Calendario"
+// en.json → "calendar": "Calendar"
+// de.json → "calendar": "Kalender"
+```
+
+- [ ] **Step 2: Modificar Header.tsx**
+
+Buscar el array `navItems` en `src/components/layout/Header.tsx`:
+
+```tsx
+const navItems: NavItem[] = [
+  { href: "/events", label: t("events") },
+  // ...
+]
+```
+
+Agregar el item de calendario después del de artistas:
+
+```tsx
+const navItems: NavItem[] = [
+  { href: "/events", label: t("events") },
+  { href: "/artists", label: t("artists") },
+  { href: "/events/calendar", label: t("calendar") },
+  { href: "/events#esta-semana", hashOnly: true, label: t("thisWeek") },
+]
+```
+
+- [ ] **Step 3: Verificar que compila**
+
+```bash
+npm run build 2>&1 | grep -E "error|Error" | head -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/layout/Header.tsx src/messages/es.json src/messages/en.json src/messages/de.json
+git commit -S -m "feat(calendar): link Calendario en la navegación principal"
+```
+
+---
+
+## Task 10: API admin — CRUD SceneEvents
+
+**Files:**
+- Create: `src/app/api/dashboard/scene-events/route.ts`
+
+- [ ] **Step 1: Crear el archivo**
+
+```ts
+/**
+ * /api/dashboard/scene-events
+ *
+ * GET  — lista todas las SceneEvents (admin only)
+ * POST — crea una SceneEvent (admin only)
+ *
+ * /api/dashboard/scene-events/[id]
+ *  → ver Task separado para DELETE
+ */
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser, isAdmin } from "@/services/auth"
+
+const createSceneEventSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
+  title: z.string().min(1).max(200),
+  venue: z.string().max(200).optional(),
+  externalUrl: z.string().url().optional().or(z.literal("")),
+})
+
+export async function GET() {
+  const user = await getCurrentUser()
+  if (!user || !isAdmin(user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const events = await prisma.sceneEvent.findMany({
+    orderBy: { date: "asc" },
+  })
+
+  return NextResponse.json({ data: events })
+}
+
+export async function POST(request: Request) {
+  const user = await getCurrentUser()
+  if (!user || !isAdmin(user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 })
+  }
+
+  const result = createSceneEventSchema.safeParse(body)
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "validation_error", issues: result.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const { date, title, venue, externalUrl } = result.data
+
+  const created = await prisma.sceneEvent.create({
+    data: {
+      date: new Date(date + "T12:00:00.000Z"),
+      title,
+      venue: venue || null,
+      externalUrl: externalUrl || null,
+    },
+  })
+
+  return NextResponse.json({ data: created }, { status: 201 })
+}
+```
+
+- [ ] **Step 2: Crear el handler DELETE**
+
+Crear `src/app/api/dashboard/scene-events/[id]/route.ts`:
+
+```ts
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser, isAdmin } from "@/services/auth"
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getCurrentUser()
+  if (!user || !isAdmin(user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  try {
+    await prisma.sceneEvent.delete({ where: { id } })
+    return NextResponse.json({ data: { deleted: true } })
+  } catch {
+    return NextResponse.json({ error: "not_found" }, { status: 404 })
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/dashboard/scene-events/route.ts "src/app/api/dashboard/scene-events/[id]/route.ts"
+git commit -S -m "feat(calendar): API admin CRUD SceneEvents"
+```
+
+---
+
+## Task 11: Panel admin — gestión de SceneEvents
+
+**Files:**
+- Create: `src/app/[locale]/(admin)/admin/calendar/page.tsx`
+
+El grupo `(admin)` ya tiene el layout con `requireRole("admin", locale)` — la página hereda la protección automáticamente.
+
+- [ ] **Step 1: Crear la página**
+
+```tsx
+/**
+ * `/admin/calendar` — gestión de entradas de escena para el calendario.
+ *
+ * Admin puede ver, agregar y borrar entradas de escena (SceneEvent).
+ * La protección de rol viene del layout `(admin)/layout.tsx`.
+ */
+"use client"
+
+import { useState, useEffect, useTransition } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface SceneEvent {
+  id: string
+  date: string
+  title: string
+  venue: string | null
+  externalUrl: string | null
+}
+
+export default function AdminCalendarPage() {
+  const t = useTranslations("calendar.dashboard")
+  const [events, setEvents] = useState<SceneEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [isPending, startTransition] = useTransition()
+
+  // Form state
+  const [date, setDate] = useState("")
+  const [title, setTitle] = useState("")
+  const [venue, setVenue] = useState("")
+  const [url, setUrl] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  async function loadEvents() {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/dashboard/scene-events")
+      if (res.ok) {
+        const json = await res.json()
+        setEvents(
+          json.data.map((e: SceneEvent & { date: string }) => ({
+            ...e,
+            date: e.date.split("T")[0],
+          }))
+        )
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadEvents()
+  }, [])
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    startTransition(async () => {
+      const res = await fetch("/api/dashboard/scene-events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date, title, venue: venue || undefined, externalUrl: url || undefined }),
+      })
+      if (res.ok) {
+        setDate("")
+        setTitle("")
+        setVenue("")
+        setUrl("")
+        await loadEvents()
+      } else {
+        const json = await res.json()
+        setError(json.error ?? "Error al guardar")
+      }
+    })
+  }
+
+  async function handleDelete(id: string) {
+    await fetch(`/api/dashboard/scene-events/${id}`, { method: "DELETE" })
+    await loadEvents()
+  }
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold text-fg-primary">{t("title")}</h1>
+
+      {/* Form de creación */}
+      <form onSubmit={handleAdd} className="bg-bg-subtle border border-border rounded-xl p-6 space-y-4">
+        <h2 className="text-body-l font-semibold text-fg-primary">{t("addEntry")}</h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-date">{t("dateLabel")}</Label>
+            <Input
+              id="cal-date"
+              type="date"
+              required
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-title">{t("titleLabel")}</Label>
+            <Input
+              id="cal-title"
+              type="text"
+              required
+              maxLength={200}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-venue">{t("venueLabel")}</Label>
+            <Input
+              id="cal-venue"
+              type="text"
+              maxLength={200}
+              value={venue}
+              onChange={(e) => setVenue(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-url">{t("urlLabel")}</Label>
+            <Input
+              id="cal-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://instagram.com/..."
+            />
+          </div>
+        </div>
+
+        {error && <p className="text-body-s text-destructive">{error}</p>}
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? t("saving") : t("addEntry")}
+        </Button>
+      </form>
+
+      {/* Lista de entradas */}
+      {loading ? (
+        <p className="text-fg-tertiary text-body">Cargando...</p>
+      ) : events.length === 0 ? (
+        <p className="text-fg-tertiary text-body">{t("empty")}</p>
+      ) : (
+        <div className="border border-border rounded-xl overflow-hidden">
+          <table className="w-full text-body-s">
+            <thead className="bg-bg-subtle border-b border-border">
+              <tr>
+                <th className="text-left px-4 py-3 text-fg-secondary font-semibold">{t("dateLabel")}</th>
+                <th className="text-left px-4 py-3 text-fg-secondary font-semibold">{t("titleLabel")}</th>
+                <th className="text-left px-4 py-3 text-fg-secondary font-semibold hidden sm:table-cell">{t("venueLabel")}</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((ev, i) => (
+                <tr
+                  key={ev.id}
+                  className={cn(
+                    "border-b border-border last:border-0",
+                    i % 2 === 0 ? "bg-bg-page" : "bg-bg-subtle/30"
+                  )}
+                >
+                  <td className="px-4 py-3 text-fg-secondary font-mono">{ev.date}</td>
+                  <td className="px-4 py-3 text-fg-primary font-medium">
+                    {ev.title}
+                    {ev.externalUrl && (
+                      <a
+                        href={ev.externalUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-2 text-brand text-[11px]"
+                      >
+                        ↗
+                      </a>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-fg-secondary hidden sm:table-cell">
+                    {ev.venue ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => handleDelete(ev.id)}
+                      className="text-[11px] text-fg-tertiary hover:text-destructive transition-colors"
+                    >
+                      {t("delete")}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verificar que compila**
+
+```bash
+npm run build 2>&1 | grep -E "error|Error" | head -5
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "src/app/[locale]/(admin)/admin/calendar/page.tsx"
+git commit -S -m "feat(calendar): panel admin para gestión de SceneEvents"
+```
+
+---
+
+## Task 12: Build final + PR
+
+- [ ] **Step 1: Build limpio**
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+Verificar que aparecen en el output:
+- `ƒ /[locale]/events/calendar`
+- `ƒ /[locale]/admin/calendar` (o similar)
+- `ƒ /api/calendar`
+- `ƒ /api/dashboard/scene-events`
+
+- [ ] **Step 2: Push y PR**
+
+```bash
+git push -u origin feat/calendar
+gh pr create \
+  --title "feat(calendar): vista mensual pública + entradas de escena admin" \
+  --body "$(cat <<'EOF'
+## Summary
+- Página pública /events/calendar con grilla mensual (eventos La Huella en rojo, entradas de escena en ámbar)
+- Navegación mes a mes via fetch — sin recarga de página
+- Popup en desktop al hacer click en un evento, navegación directa en mobile
+- Nuevo modelo SceneEvent para eventos que el admin carga desde Instagram/otras fuentes
+- Panel admin /admin/calendar para crear y borrar entradas de escena
+- Link "Calendario" en la navegación principal
+
+## Test plan
+- [ ] Abrir /es/events/calendar — ver grilla mensual
+- [ ] Navegar al mes anterior y siguiente
+- [ ] Click en evento oficial → popup con "Ver evento →" en desktop
+- [ ] Click en entrada de escena → popup con datos en desktop
+- [ ] En mobile: click en evento oficial navega al detalle
+- [ ] Admin carga una entrada en /admin/calendar → aparece en el calendario
+- [ ] Admin borra una entrada → desaparece del calendario
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+- [x] Task 1: SceneEvent model + migración ✓
+- [x] Task 2: `getCalendarEntries(from, to)` → `CalendarEntry[]` ✓
+- [x] Task 3: `GET /api/calendar?month=YYYY-MM` usa `getCalendarEntries` ✓
+- [x] Task 4: i18n calendar namespace en 3 idiomas ✓
+- [x] Task 5: `CalendarEventPopup` — maneja entry.type, anchorRect, Escape, click-outside ✓
+- [x] Task 6: `CalendarDayCell` — pills, expand "+N más", `onEntryClick` con DOMRect ✓
+- [x] Task 7: `EventsCalendar` — buildGrid, navegación, fetch por mes, popup state ✓
+- [x] Task 8: página server que llama `getCalendarEntries` y pasa a EventsCalendar ✓
+- [x] Task 9: Header nav + i18n key "calendar" ✓
+- [x] Task 10: POST/GET/DELETE SceneEvents con auth `isAdmin` ✓
+- [x] Task 11: Admin page bajo `(admin)` layout (protección heredada) ✓
+- [x] `CalendarEntry` interface consistente entre service, API, componentes ✓
+- [x] `buildGrid` y `calendarGridBounds` usan la misma lógica (UTC, lunes como primer día) ✓

--- a/docs/superpowers/specs/2026-06-02-calendar-design.md
+++ b/docs/superpowers/specs/2026-06-02-calendar-design.md
@@ -1,0 +1,217 @@
+# Calendario de Eventos — Diseño e spec
+
+**Fecha:** 2026-06-02
+**Estado:** aprobado para implementación
+
+---
+
+## 1. Resumen
+
+Página pública `/events/calendar` con vista mensual de todos los eventos. Muestra dos tipos de entradas: eventos oficiales de La Huella (del modelo `Event` existente) y entradas de escena cargadas por el admin desde Instagram u otras fuentes. El admin carga las entradas de escena desde el dashboard. Cualquier visitante puede ver el calendario.
+
+---
+
+## 2. Casos de uso
+
+1. **Visitante público** — ve qué pasa en la escena latina de Berlín este mes, puede navegar a meses anteriores/futuros.
+2. **Creator planificando un evento** — antes de crear, abre el calendario para ver si la fecha que eligió ya tiene otro evento parecido.
+3. **Admin curando la escena** — carga eventos de Instagram/otras fuentes sin crear una página de evento completa.
+
+---
+
+## 3. Decisiones de diseño
+
+| Decisión | Elección | Razón |
+|---|---|---|
+| Arquitectura | Opción A: Server Component inicial + Client Component para navegación | Carga rápida del mes actual, navegación sin recarga |
+| Fetch por mes | `GET /api/calendar?month=YYYY-MM` | Evita traer 12 meses de datos innecesarios |
+| Tipos de entrada | `Event` (oficial) + `SceneEvent` (admin) | Reutiliza modelo existente, agrega modelo liviano |
+| Visual oficial | Pill rojo `#c0392b` sólido | Consistente con brand del sitio |
+| Visual escena | Pill ámbar `#e5a93b` translúcido | Usa color ochre del logo, claramente diferenciado |
+| Click oficial desktop | Popup con nombre, fecha, venue → "Ver evento →" | UX más fluida que navegar directo |
+| Click escena desktop | Popup con nombre, venue, link externo opcional | Sin página propia — el popup es todo |
+| Click mobile | Navega directo (oficial) / abre popup nativo (escena) | Mobile no tiene hover, popup sería torpe |
+| Colapso | 3+ eventos en un día → "+N más" | Evita desborde visual en celdas |
+| Admin ingreso | Form en `/dashboard/calendar` | Lo más simple — sin cambiar el flujo del calendario |
+| Hoy | Número en círculo blanco | Referencia visual rápida |
+
+---
+
+## 4. Modelo de datos nuevo
+
+```prisma
+model SceneEvent {
+  id          String   @id @default(cuid())
+  date        DateTime @db.Date
+  title       String
+  venue       String?
+  externalUrl String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+```
+
+Sin relación a `User` — cualquier admin puede crear/borrar. Sin soft delete — si se borró, se borró.
+
+---
+
+## 5. API
+
+### `GET /api/calendar?month=YYYY-MM`
+
+Devuelve todos los eventos y entradas de escena del mes dado, incluyendo los días necesarios para completar la grilla (desde el primer lunes visible hasta el último domingo visible — puede incluir hasta 6 días del mes anterior y 6 del siguiente).
+
+**Response shape:**
+```ts
+{
+  data: {
+    entries: CalendarEntry[]
+  }
+}
+
+interface CalendarEntry {
+  id: string
+  type: "event" | "scene"
+  date: string        // "2026-07-11"
+  title: string
+  venue: string | null
+  time: string | null // "21:00" — solo eventos oficiales
+  slug: string | null // solo eventos oficiales
+  externalUrl: string | null // solo entradas de escena
+}
+```
+
+El endpoint no requiere auth — es público.
+
+---
+
+## 6. Archivos nuevos / modificados
+
+### Nuevos
+
+| Archivo | Descripción |
+|---|---|
+| `prisma/migrations/YYYYMMDD_scene_events/` | Migración para el modelo `SceneEvent` |
+| `src/services/calendar.ts` | `getCalendarEntries(month: string)` — fetches Event + SceneEvent |
+| `src/app/api/calendar/route.ts` | GET handler — valida `month` param, llama al service |
+| `src/app/[locale]/(public)/events/calendar/page.tsx` | Server Component — renderiza mes actual |
+| `src/components/events/EventsCalendar.tsx` | Client Component — navegación + grilla + popups |
+| `src/components/events/CalendarDayCell.tsx` | Celda individual — pills + colapso |
+| `src/components/events/CalendarEventPopup.tsx` | Popup desktop para ambos tipos |
+| `src/app/[locale]/(protected)/dashboard/calendar/page.tsx` | Form admin para SceneEvents |
+| `src/app/api/dashboard/scene-events/route.ts` | POST / DELETE para SceneEvents (solo admin) |
+
+### Modificados
+
+| Archivo | Cambio |
+|---|---|
+| `prisma/schema.prisma` | Agrega modelo `SceneEvent` |
+| `src/messages/es.json` | Claves `calendar.*` |
+| `src/messages/en.json` | Claves `calendar.*` |
+| `src/messages/de.json` | Claves `calendar.*` |
+| `src/components/layout/Header.tsx` / nav | Agrega link "Calendario" en la navegación principal |
+
+---
+
+## 7. Componentes clave
+
+### `EventsCalendar` (Client Component)
+
+Props:
+```ts
+interface EventsCalendarProps {
+  initialEntries: CalendarEntry[]
+  initialMonth: string // "2026-07"
+  locale: string
+}
+```
+
+Estado interno:
+- `currentMonth: string` — mes visible
+- `entries: CalendarEntry[]` — entradas del mes actual
+- `loading: boolean` — mientras fetches
+- `popup: { entry: CalendarEntry; anchorRect: DOMRect } | null` — popup activo en desktop
+
+Lógica:
+- `prevMonth()` / `nextMonth()` — cambia `currentMonth`, fetches `/api/calendar?month=YYYY-MM`, actualiza `entries`
+- Click en pill en desktop → abre popup con posición relativa al elemento
+- Click en pill en mobile (`window.innerWidth < 768`) → si es evento oficial, navega a `/events/[slug]`; si es escena, abre el mismo `CalendarEventPopup` pero centrado en pantalla con overlay oscuro (no posicionado relativo al elemento)
+- Click fuera del popup → cierra
+
+### `CalendarDayCell`
+
+Props: `{ day: number | null; entries: CalendarEntry[]; onEntryClick: (entry, rect) => void }`
+
+Muestra:
+- Número del día (blanco en círculo si es hoy)
+- Pills ordenados: oficiales primero, escena después
+- Si hay más de 2 pills → muestra los 2 primeros + "+N más" colapsado
+- Click en "+N más" → expande todos los pills de ese día
+
+### `CalendarEventPopup`
+
+Posicionado con `position: fixed` relativo al `anchorRect`. Dos variantes visuales según `entry.type`:
+- `"event"` → header rojo, botón "Ver evento →" que navega a `/events/[slug]`
+- `"scene"` → header ámbar, badge "Otra escena", link "Ver en Instagram →" si hay `externalUrl`
+
+Cierra con click fuera o Escape.
+
+---
+
+## 8. Dashboard admin — carga de SceneEvents
+
+Página simple en `/dashboard/calendar`:
+- Lista de entradas de escena existentes (tabla con fecha, título, venue, acciones)
+- Form de creación: fecha (date picker), título, venue (opcional), URL externa (opcional)
+- Botón de borrar por entrada
+- Solo accesible para rol `admin`
+
+---
+
+## 9. i18n — claves nuevas
+
+```json
+{
+  "calendar": {
+    "pageTitle": "Calendario",
+    "pageDescription": "Todos los eventos de la escena latina en Berlín",
+    "navPrev": "Mes anterior",
+    "navNext": "Mes siguiente",
+    "today": "Hoy",
+    "noEvents": "Sin eventos este mes",
+    "sceneEventBadge": "Otra escena",
+    "viewEvent": "Ver evento →",
+    "viewSource": "Ver fuente →",
+    "moreEvents": "+{count} más",
+    "weekdays": {
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mié",
+      "thu": "Jue",
+      "fri": "Vie",
+      "sat": "Sáb",
+      "sun": "Dom"
+    },
+    "dashboard": {
+      "title": "Entradas de escena",
+      "addEntry": "Agregar entrada",
+      "date": "Fecha",
+      "titleLabel": "Título",
+      "venue": "Venue (opcional)",
+      "externalUrl": "Link externo (opcional)",
+      "delete": "Eliminar",
+      "empty": "No hay entradas de escena cargadas"
+    }
+  }
+}
+```
+
+---
+
+## 10. Fuera de scope (esta iteración)
+
+- Filtro por género o tipo de evento en el calendario
+- Vista semanal o de agenda
+- Exportar a Google Calendar / iCal
+- Notificaciones de conflicto automáticas al crear un evento desde el dashboard
+- Paginación de "+N más" con modal expandido (se expande inline)

--- a/prisma/migrations/20260603082505_add_scene_events/migration.sql
+++ b/prisma/migrations/20260603082505_add_scene_events/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "SceneEvent" (
+    "id" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "title" TEXT NOT NULL,
+    "venue" TEXT,
+    "externalUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SceneEvent_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20260603090000_scene_event_date_index/migration.sql
+++ b/prisma/migrations/20260603090000_scene_event_date_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "SceneEvent_date_idx" ON "SceneEvent"("date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,3 +179,13 @@ enum ApplicationStatus {
   APPROVED
   REJECTED
 }
+
+model SceneEvent {
+  id          String   @id @default(cuid())
+  date        DateTime @db.Date
+  title       String
+  venue       String?
+  externalUrl String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,4 +188,6 @@ model SceneEvent {
   externalUrl String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+
+  @@index([date])
 }

--- a/src/app/[locale]/(admin)/admin/calendar/page.tsx
+++ b/src/app/[locale]/(admin)/admin/calendar/page.tsx
@@ -1,0 +1,217 @@
+/**
+ * `/admin/calendar` — gestión de entradas de escena para el calendario.
+ *
+ * Admin puede ver, agregar y borrar entradas de escena (SceneEvent).
+ * La protección de rol viene del layout `(admin)/layout.tsx` via requireRole("admin").
+ */
+"use client"
+
+import { useState, useEffect, useTransition } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface SceneEvent {
+  id: string
+  date: string
+  title: string
+  venue: string | null
+  externalUrl: string | null
+}
+
+export default function AdminCalendarPage() {
+  const t = useTranslations("calendar.dashboard")
+  const [events, setEvents] = useState<SceneEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [isPending, startTransition] = useTransition()
+
+  // Form state
+  const [date, setDate] = useState("")
+  const [title, setTitle] = useState("")
+  const [venue, setVenue] = useState("")
+  const [url, setUrl] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  async function loadEvents() {
+    setLoading(true)
+    try {
+      const res = await fetch("/api/dashboard/scene-events")
+      if (res.ok) {
+        const json = await res.json()
+        setEvents(
+          json.data.map((e: SceneEvent & { date: string }) => ({
+            ...e,
+            date: e.date.split("T")[0],
+          }))
+        )
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadEvents()
+  }, [])
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    startTransition(async () => {
+      const res = await fetch("/api/dashboard/scene-events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          date,
+          title,
+          venue: venue || undefined,
+          externalUrl: url || undefined,
+        }),
+      })
+      if (res.ok) {
+        setDate("")
+        setTitle("")
+        setVenue("")
+        setUrl("")
+        await loadEvents()
+      } else {
+        const json = await res.json()
+        setError(json.error ?? "Error al guardar")
+      }
+    })
+  }
+
+  async function handleDelete(id: string) {
+    await fetch(`/api/dashboard/scene-events/${id}`, { method: "DELETE" })
+    await loadEvents()
+  }
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold text-fg-primary">{t("title")}</h1>
+
+      {/* Form de creación */}
+      <form
+        onSubmit={handleAdd}
+        className="bg-bg-subtle border border-border rounded-xl p-6 space-y-4"
+      >
+        <h2 className="text-body-l font-semibold text-fg-primary">{t("addEntry")}</h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-date">{t("dateLabel")}</Label>
+            <Input
+              id="cal-date"
+              type="date"
+              required
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-title">{t("titleLabel")}</Label>
+            <Input
+              id="cal-title"
+              type="text"
+              required
+              maxLength={200}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-venue">{t("venueLabel")}</Label>
+            <Input
+              id="cal-venue"
+              type="text"
+              maxLength={200}
+              value={venue}
+              onChange={(e) => setVenue(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="cal-url">{t("urlLabel")}</Label>
+            <Input
+              id="cal-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://instagram.com/..."
+            />
+          </div>
+        </div>
+
+        {error && <p className="text-body-s text-destructive">{error}</p>}
+
+        <Button type="submit" disabled={isPending}>
+          {isPending ? t("saving") : t("addEntry")}
+        </Button>
+      </form>
+
+      {/* Lista de entradas */}
+      {loading ? (
+        <p className="text-fg-tertiary text-body">Cargando...</p>
+      ) : events.length === 0 ? (
+        <p className="text-fg-tertiary text-body">{t("empty")}</p>
+      ) : (
+        <div className="border border-border rounded-xl overflow-hidden">
+          <table className="w-full text-body-s">
+            <thead className="bg-bg-subtle border-b border-border">
+              <tr>
+                <th className="text-left px-4 py-3 text-fg-secondary font-semibold">
+                  {t("dateLabel")}
+                </th>
+                <th className="text-left px-4 py-3 text-fg-secondary font-semibold">
+                  {t("titleLabel")}
+                </th>
+                <th className="text-left px-4 py-3 text-fg-secondary font-semibold hidden sm:table-cell">
+                  {t("venueLabel")}
+                </th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((ev, i) => (
+                <tr
+                  key={ev.id}
+                  className={cn(
+                    "border-b border-border last:border-0",
+                    i % 2 === 0 ? "bg-bg-page" : "bg-bg-subtle/30"
+                  )}
+                >
+                  <td className="px-4 py-3 text-fg-secondary font-mono">{ev.date}</td>
+                  <td className="px-4 py-3 text-fg-primary font-medium">
+                    {ev.title}
+                    {ev.externalUrl && (
+                      <a
+                        href={ev.externalUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-2 text-brand text-[11px]"
+                      >
+                        ↗
+                      </a>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-fg-secondary hidden sm:table-cell">
+                    {ev.venue ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => handleDelete(ev.id)}
+                      className="text-[11px] text-fg-tertiary hover:text-destructive transition-colors"
+                    >
+                      {t("delete")}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/[locale]/(admin)/admin/calendar/page.tsx
+++ b/src/app/[locale]/(admin)/admin/calendar/page.tsx
@@ -77,14 +77,17 @@ export default function AdminCalendarPage() {
         setUrl("")
         await loadEvents()
       } else {
-        const json = await res.json()
-        setError(json.error ?? "Error al guardar")
+        setError(t("errorMessage"))
       }
     })
   }
 
   async function handleDelete(id: string) {
-    await fetch(`/api/dashboard/scene-events/${id}`, { method: "DELETE" })
+    const res = await fetch(`/api/dashboard/scene-events/${id}`, { method: "DELETE" })
+    if (!res.ok) {
+      setError(t("errorMessage"))
+      return
+    }
     await loadEvents()
   }
 
@@ -152,7 +155,7 @@ export default function AdminCalendarPage() {
 
       {/* Lista de entradas */}
       {loading ? (
-        <p className="text-fg-tertiary text-body">Cargando...</p>
+        <p className="text-fg-tertiary text-body">{t("loading")}</p>
       ) : events.length === 0 ? (
         <p className="text-fg-tertiary text-body">{t("empty")}</p>
       ) : (

--- a/src/app/[locale]/(public)/events/calendar/page.tsx
+++ b/src/app/[locale]/(public)/events/calendar/page.tsx
@@ -1,0 +1,63 @@
+/**
+ * `/events/calendar` — vista mensual pública de todos los eventos.
+ *
+ * Server Component: renderiza el mes actual con datos frescos.
+ * El Client Component `EventsCalendar` maneja navegación mes a mes.
+ */
+
+import type { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
+import { getCalendarEntries } from "@/services/calendar"
+import EventsCalendar from "@/components/events/EventsCalendar"
+
+interface PageProps {
+  params: Promise<{ locale: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { locale } = await params
+  const t = await getTranslations({ locale, namespace: "calendar" })
+  return {
+    title: t("pageTitle"),
+    description: t("pageDescription"),
+  }
+}
+
+/** Calcula los límites de la grilla para el mes actual (UTC). */
+function currentMonthGridBounds(): { from: Date; to: Date; ym: string } {
+  const now = new Date()
+  const year = now.getUTCFullYear()
+  const month = now.getUTCMonth() + 1
+
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const dayOfWeek = firstDay.getUTCDay()
+  const daysBack = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  const from = new Date(firstDay)
+  from.setUTCDate(from.getUTCDate() - daysBack)
+
+  const lastDay = new Date(Date.UTC(year, month, 0))
+  const lastDayOfWeek = lastDay.getUTCDay()
+  const daysForward = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+  const to = new Date(lastDay)
+  to.setUTCDate(to.getUTCDate() + daysForward)
+  to.setUTCHours(23, 59, 59, 999)
+
+  const ym = `${year}-${String(month).padStart(2, "0")}`
+  return { from, to, ym }
+}
+
+export default async function EventsCalendarPage({ params }: PageProps) {
+  const { locale } = await params
+  const { from, to, ym } = currentMonthGridBounds()
+  const initialEntries = await getCalendarEntries(from, to)
+
+  return (
+    <div className="max-w-7xl mx-auto px-m sm:px-l py-l lg:py-xl">
+      <EventsCalendar
+        initialEntries={initialEntries}
+        initialMonth={ym}
+        locale={locale}
+      />
+    </div>
+  )
+}

--- a/src/app/[locale]/(public)/events/calendar/page.tsx
+++ b/src/app/[locale]/(public)/events/calendar/page.tsx
@@ -23,6 +23,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 }
 
+/**
+ * TODO: esta lógica duplica `calendarGridBounds` en /api/calendar/route.ts.
+ * Extraer a src/lib/calendar-utils.ts cuando se necesite reutilizar en más lugares.
+ */
 /** Calcula los límites de la grilla para el mes actual (UTC). */
 function currentMonthGridBounds(): { from: Date; to: Date; ym: string } {
   const now = new Date()

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,0 +1,49 @@
+/**
+ * GET /api/calendar?month=YYYY-MM
+ *
+ * Retorna CalendarEntry[] para la grilla mensual completa (incluye días
+ * de meses adyacentes para completar la primera y última semana).
+ * No requiere auth — es público.
+ */
+import { NextResponse } from "next/server"
+import { getCalendarEntries } from "@/services/calendar"
+
+/** Calcula los límites de la grilla de un mes: primer lunes visible y
+ *  último domingo visible. La grilla arranca siempre en lunes. */
+function calendarGridBounds(year: number, month: number): { from: Date; to: Date } {
+  // Primer día del mes (month es 1-indexed)
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const dayOfWeek = firstDay.getUTCDay() // 0=Dom, 1=Lun ... 6=Sáb
+  const daysBack = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+  const from = new Date(firstDay)
+  from.setUTCDate(from.getUTCDate() - daysBack)
+
+  // Último día del mes
+  const lastDay = new Date(Date.UTC(year, month, 0))
+  const lastDayOfWeek = lastDay.getUTCDay()
+  const daysForward = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+  const to = new Date(lastDay)
+  to.setUTCDate(to.getUTCDate() + daysForward)
+  // Incluir hasta el final del día
+  to.setUTCHours(23, 59, 59, 999)
+
+  return { from, to }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const month = searchParams.get("month")
+
+  if (!month || !/^\d{4}-(?:0[1-9]|1[0-2])$/.test(month)) {
+    return NextResponse.json({ error: "invalid_month" }, { status: 400 })
+  }
+
+  const [yearStr, monthStr] = month.split("-")
+  const year = parseInt(yearStr!, 10)
+  const m = parseInt(monthStr!, 10)
+
+  const { from, to } = calendarGridBounds(year, m)
+  const entries = await getCalendarEntries(from, to)
+
+  return NextResponse.json({ data: { entries } })
+}

--- a/src/app/api/dashboard/scene-events/[id]/route.ts
+++ b/src/app/api/dashboard/scene-events/[id]/route.ts
@@ -16,7 +16,14 @@ export async function DELETE(
   try {
     await prisma.sceneEvent.delete({ where: { id } })
     return NextResponse.json({ data: { deleted: true } })
-  } catch {
-    return NextResponse.json({ error: "not_found" }, { status: 404 })
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as { code: string }).code === "P2025"
+    ) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 })
+    }
+    throw err
   }
 }

--- a/src/app/api/dashboard/scene-events/[id]/route.ts
+++ b/src/app/api/dashboard/scene-events/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser, isAdmin } from "@/services/auth"
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getCurrentUser()
+  if (!user || !isAdmin(user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  try {
+    await prisma.sceneEvent.delete({ where: { id } })
+    return NextResponse.json({ data: { deleted: true } })
+  } catch {
+    return NextResponse.json({ error: "not_found" }, { status: 404 })
+  }
+}

--- a/src/app/api/dashboard/scene-events/route.ts
+++ b/src/app/api/dashboard/scene-events/route.ts
@@ -1,0 +1,65 @@
+/**
+ * /api/dashboard/scene-events
+ *
+ * GET  — lista todas las SceneEvents (admin only)
+ * POST — crea una SceneEvent (admin only)
+ */
+import { NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUser, isAdmin } from "@/services/auth"
+
+const createSceneEventSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
+  title: z.string().min(1).max(200),
+  venue: z.string().max(200).optional(),
+  externalUrl: z.string().url().optional().or(z.literal("")),
+})
+
+export async function GET() {
+  const user = await getCurrentUser()
+  if (!user || !isAdmin(user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const events = await prisma.sceneEvent.findMany({
+    orderBy: { date: "asc" },
+  })
+
+  return NextResponse.json({ data: events })
+}
+
+export async function POST(request: Request) {
+  const user = await getCurrentUser()
+  if (!user || !isAdmin(user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 })
+  }
+
+  const result = createSceneEventSchema.safeParse(body)
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "validation_error", issues: result.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const { date, title, venue, externalUrl } = result.data
+
+  const created = await prisma.sceneEvent.create({
+    data: {
+      date: new Date(date + "T12:00:00.000Z"),
+      title,
+      venue: venue || null,
+      externalUrl: externalUrl || null,
+    },
+  })
+
+  return NextResponse.json({ data: created }, { status: 201 })
+}

--- a/src/app/api/dashboard/scene-events/route.ts
+++ b/src/app/api/dashboard/scene-events/route.ts
@@ -13,7 +13,7 @@ const createSceneEventSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date must be YYYY-MM-DD"),
   title: z.string().min(1).max(200),
   venue: z.string().max(200).optional(),
-  externalUrl: z.string().url().optional().or(z.literal("")),
+  externalUrl: z.url().optional().or(z.literal("")),
 })
 
 export async function GET() {

--- a/src/components/events/CalendarDayCell.tsx
+++ b/src/components/events/CalendarDayCell.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useState } from "react"
+import { useTranslations } from "next-intl"
 import { cn } from "@/lib/utils"
 import type { CalendarEntry } from "@/services/calendar"
 
@@ -30,6 +31,7 @@ export default function CalendarDayCell({
   entries,
   onEntryClick,
 }: CalendarDayCellProps) {
+  const t = useTranslations("calendar")
   const [expanded, setExpanded] = useState(false)
 
   const hasEvents = entries.length > 0
@@ -105,7 +107,7 @@ export default function CalendarDayCell({
             }}
             className="w-full text-left rounded px-1.5 py-0.5 text-[9px] font-semibold text-fg-tertiary border border-dashed border-fg-tertiary/30 hover:border-fg-tertiary/60 transition-colors"
           >
-            +{hiddenCount} más
+            {t("moreEvents", { count: hiddenCount })}
           </button>
         )}
       </div>

--- a/src/components/events/CalendarDayCell.tsx
+++ b/src/components/events/CalendarDayCell.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+/**
+ * CalendarDayCell — celda individual de la grilla del calendario.
+ *
+ * Muestra el número del día, los pills de eventos (max 2 visibles,
+ * el resto colapsa en "+N más"), y llama a onEntryClick al hacer click.
+ * Si `day` es null, renderiza una celda vacía (días de meses adyacentes
+ * que no pertenecen al mes visible — se muestran atenuados).
+ */
+
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+import type { CalendarEntry } from "@/services/calendar"
+
+const MAX_VISIBLE = 2
+
+interface CalendarDayCellProps {
+  day: number | null
+  isCurrentMonth: boolean
+  isToday: boolean
+  entries: CalendarEntry[]
+  onEntryClick: (entry: CalendarEntry, rect: DOMRect | null) => void
+}
+
+export default function CalendarDayCell({
+  day,
+  isCurrentMonth,
+  isToday,
+  entries,
+  onEntryClick,
+}: CalendarDayCellProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const hasEvents = entries.length > 0
+  const hasOfficial = entries.some((e) => e.type === "event")
+  const hasScene = entries.some((e) => e.type === "scene")
+
+  const visible = expanded ? entries : entries.slice(0, MAX_VISIBLE)
+  const hiddenCount = entries.length - MAX_VISIBLE
+
+  function handlePillClick(
+    e: React.MouseEvent<HTMLButtonElement>,
+    entry: CalendarEntry
+  ) {
+    e.stopPropagation()
+    const isMobile = window.innerWidth < 768
+    const rect = isMobile ? null : e.currentTarget.getBoundingClientRect()
+    onEntryClick(entry, rect)
+  }
+
+  return (
+    <div
+      className={cn(
+        "min-h-[80px] p-1.5 rounded-lg border transition-colors",
+        !isCurrentMonth && "opacity-30",
+        hasEvents && hasOfficial && !hasScene && "border-[rgba(192,57,43,0.3)] bg-[rgba(192,57,43,0.05)]",
+        hasEvents && hasScene && !hasOfficial && "border-[rgba(229,169,59,0.25)] bg-[rgba(229,169,59,0.04)]",
+        hasEvents && hasOfficial && hasScene && "border-[rgba(192,57,43,0.3)] bg-[rgba(192,57,43,0.05)]",
+        !hasEvents && "border-transparent",
+        isToday && "border-white/20 bg-white/[0.03]"
+      )}
+    >
+      {/* Número del día */}
+      <div className="mb-1.5">
+        {isToday ? (
+          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-fg-primary text-bg-page text-[11px] font-bold">
+            {day}
+          </span>
+        ) : (
+          <span
+            className={cn(
+              "text-[11px]",
+              isCurrentMonth ? "text-fg-tertiary" : "text-fg-tertiary/50"
+            )}
+          >
+            {day}
+          </span>
+        )}
+      </div>
+
+      {/* Pills */}
+      <div className="flex flex-col gap-0.5">
+        {visible.map((entry) => (
+          <button
+            key={entry.id}
+            onClick={(e) => handlePillClick(e, entry)}
+            className={cn(
+              "w-full text-left rounded px-1.5 py-0.5 text-[10px] font-semibold truncate cursor-pointer transition-opacity hover:opacity-80",
+              entry.type === "event"
+                ? "bg-brand text-on-brand"
+                : "bg-[rgba(229,169,59,0.18)] border border-[rgba(229,169,59,0.4)] text-[#e5a93b]"
+            )}
+          >
+            {entry.title}
+          </button>
+        ))}
+
+        {/* +N más */}
+        {!expanded && hiddenCount > 0 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              setExpanded(true)
+            }}
+            className="w-full text-left rounded px-1.5 py-0.5 text-[9px] font-semibold text-fg-tertiary border border-dashed border-fg-tertiary/30 hover:border-fg-tertiary/60 transition-colors"
+          >
+            +{hiddenCount} más
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/events/CalendarEventPopup.tsx
+++ b/src/components/events/CalendarEventPopup.tsx
@@ -59,6 +59,11 @@ export default function CalendarEventPopup({
     }
   }, [onClose])
 
+  // Mover foco al dialog al abrir
+  useEffect(() => {
+    popupRef.current?.focus()
+  }, [])
+
   // Calcular posición desktop
   const style: React.CSSProperties = isMobile
     ? {}
@@ -88,6 +93,7 @@ export default function CalendarEventPopup({
   const popup = (
     <div
       ref={popupRef}
+      tabIndex={-1}
       style={style}
       className={cn(
         "bg-bg-subtle rounded-xl border border-border p-4 shadow-xl",

--- a/src/components/events/CalendarEventPopup.tsx
+++ b/src/components/events/CalendarEventPopup.tsx
@@ -59,9 +59,11 @@ export default function CalendarEventPopup({
     }
   }, [onClose])
 
-  // Mover foco al dialog al abrir
+  // Mover foco al dialog al abrir y restaurarlo al cerrar
   useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null
     popupRef.current?.focus()
+    return () => previouslyFocused?.focus()
   }, [])
 
   // Calcular posición desktop

--- a/src/components/events/CalendarEventPopup.tsx
+++ b/src/components/events/CalendarEventPopup.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+/**
+ * CalendarEventPopup — popup que aparece al hacer click en un evento
+ * del calendario.
+ *
+ * Desktop: posicionado cerca del elemento clicado (anchorRect).
+ * Mobile (anchorRect === null): centrado en pantalla con overlay oscuro.
+ *
+ * Cierra con Escape o click fuera.
+ */
+
+import { useEffect, useRef } from "react"
+import { useRouter } from "@/i18n/navigation"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import type { CalendarEntry } from "@/services/calendar"
+
+interface CalendarEventPopupProps {
+  entry: CalendarEntry
+  anchorRect: DOMRect | null
+  locale: string
+  onClose: () => void
+}
+
+export default function CalendarEventPopup({
+  entry,
+  anchorRect,
+  locale,
+  onClose,
+}: CalendarEventPopupProps) {
+  const t = useTranslations("calendar")
+  const router = useRouter()
+  const popupRef = useRef<HTMLDivElement>(null)
+  const isMobile = anchorRect === null
+
+  // Cerrar con Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", handleKey)
+    return () => document.removeEventListener("keydown", handleKey)
+  }, [onClose])
+
+  // Cerrar con click fuera
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    const timer = setTimeout(() => {
+      document.addEventListener("mousedown", handleClick)
+    }, 0)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener("mousedown", handleClick)
+    }
+  }, [onClose])
+
+  // Calcular posición desktop
+  const style: React.CSSProperties = isMobile
+    ? {}
+    : (() => {
+        const POPUP_WIDTH = 220
+        const POPUP_HEIGHT = 160
+        const MARGIN = 8
+        const vw = window.innerWidth
+        const vh = window.innerHeight
+        let left = anchorRect.left
+        let top = anchorRect.bottom + MARGIN
+
+        if (left + POPUP_WIDTH > vw - MARGIN) {
+          left = vw - POPUP_WIDTH - MARGIN
+        }
+        if (top + POPUP_HEIGHT > vh - MARGIN) {
+          top = anchorRect.top - POPUP_HEIGHT - MARGIN
+        }
+
+        return { position: "fixed", left, top, width: POPUP_WIDTH, zIndex: 50 }
+      })()
+
+  const isOfficial = entry.type === "event"
+  const accentColor = isOfficial ? "#c0392b" : "#e5a93b"
+  const borderColor = isOfficial ? "rgba(192,57,43,0.35)" : "rgba(229,169,59,0.35)"
+
+  const popup = (
+    <div
+      ref={popupRef}
+      style={style}
+      className={cn(
+        "bg-bg-subtle rounded-xl border border-border p-4 shadow-xl",
+        isMobile && "w-[280px] max-w-[90vw]"
+      )}
+      role="dialog"
+      aria-modal="true"
+      aria-label={entry.title}
+    >
+      {/* Badge de tipo */}
+      <div className="flex items-center gap-2 mb-3">
+        <div
+          className="w-2 h-2 rounded-full shrink-0"
+          style={{ background: accentColor }}
+        />
+        <span
+          className="text-[10px] font-bold tracking-widest uppercase"
+          style={{ color: accentColor }}
+        >
+          {isOfficial ? "La Huella" : t("sceneEventBadge")}
+        </span>
+      </div>
+
+      {/* Fecha + título */}
+      <p className="text-caption text-fg-tertiary mb-1">
+        {new Date(entry.date + "T12:00:00").toLocaleDateString(
+          locale === "de" ? "de-DE" : locale === "en" ? "en-GB" : "es-AR",
+          { weekday: "short", day: "numeric", month: "short" }
+        )}
+        {entry.time ? ` · ${entry.time}` : ""}
+      </p>
+      <p className="text-body font-bold text-fg-primary mb-1 leading-tight">
+        {entry.title}
+      </p>
+      {entry.venue && (
+        <p className="text-body-s text-fg-secondary mb-3">{entry.venue}</p>
+      )}
+
+      {/* CTA */}
+      {isOfficial && entry.slug ? (
+        <button
+          onClick={() => {
+            router.push(`/events/${entry.slug}`)
+            onClose()
+          }}
+          className="w-full text-center text-body-s font-bold py-2 rounded-m text-on-brand"
+          style={{ background: accentColor }}
+        >
+          {t("viewEvent")}
+        </button>
+      ) : entry.externalUrl ? (
+        <a
+          href={entry.externalUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onClose}
+          className="block w-full text-center text-body-s font-bold py-2 rounded-m border"
+          style={{ color: accentColor, borderColor }}
+        >
+          {t("viewSource")}
+        </a>
+      ) : null}
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        {/* Overlay */}
+        <div
+          className="fixed inset-0 bg-black/60 z-40"
+          onClick={onClose}
+          aria-hidden
+        />
+        <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+          <div className="pointer-events-auto">{popup}</div>
+        </div>
+      </>
+    )
+  }
+
+  return popup
+}

--- a/src/components/events/EventsCalendar.tsx
+++ b/src/components/events/EventsCalendar.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+/**
+ * EventsCalendar — grilla mensual interactiva.
+ *
+ * Recibe los datos del mes actual del Server Component padre y maneja
+ * navegación mes a mes via fetch a /api/calendar?month=YYYY-MM.
+ *
+ * La grilla siempre empieza en Lunes (semana europea).
+ */
+
+import { useState, useCallback } from "react"
+import { useTranslations } from "next-intl"
+import { cn } from "@/lib/utils"
+import CalendarDayCell from "./CalendarDayCell"
+import CalendarEventPopup from "./CalendarEventPopup"
+import type { CalendarEntry } from "@/services/calendar"
+
+interface EventsCalendarProps {
+  initialEntries: CalendarEntry[]
+  initialMonth: string // "YYYY-MM"
+  locale: string
+}
+
+interface PopupState {
+  entry: CalendarEntry
+  anchorRect: DOMRect | null
+}
+
+/** Retorna "YYYY-MM" del mes anterior */
+function prevMonth(ym: string): string {
+  const [y, m] = ym.split("-").map(Number)
+  if (m === 1) return `${y - 1}-12`
+  return `${y}-${String(m - 1).padStart(2, "0")}`
+}
+
+/** Retorna "YYYY-MM" del mes siguiente */
+function nextMonth(ym: string): string {
+  const [y, m] = ym.split("-").map(Number)
+  if (m === 12) return `${y + 1}-01`
+  return `${y}-${String(m + 1).padStart(2, "0")}`
+}
+
+/**
+ * Genera los días de la grilla para el mes dado.
+ * La grilla siempre empieza en lunes y termina en domingo.
+ */
+function buildGrid(ym: string): { date: string; day: number; isCurrentMonth: boolean }[] {
+  const [year, month] = ym.split("-").map(Number)
+  const firstDay = new Date(Date.UTC(year, month - 1, 1))
+  const dayOfWeek = firstDay.getUTCDay()
+  const daysBack = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+
+  const start = new Date(firstDay)
+  start.setUTCDate(start.getUTCDate() - daysBack)
+
+  const lastDay = new Date(Date.UTC(year, month, 0))
+  const lastDayOfWeek = lastDay.getUTCDay()
+  const daysForward = lastDayOfWeek === 0 ? 0 : 7 - lastDayOfWeek
+
+  const end = new Date(lastDay)
+  end.setUTCDate(end.getUTCDate() + daysForward)
+
+  const cells: { date: string; day: number; isCurrentMonth: boolean }[] = []
+  const cursor = new Date(start)
+  while (cursor <= end) {
+    const dateStr = cursor.toISOString().split("T")[0]!
+    cells.push({
+      date: dateStr,
+      day: cursor.getUTCDate(),
+      isCurrentMonth: cursor.getUTCMonth() === month - 1,
+    })
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+
+  return cells
+}
+
+/** "YYYY-MM-DD" de hoy en UTC */
+function todayString(): string {
+  return new Date().toISOString().split("T")[0]!
+}
+
+const WEEKDAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const
+
+export default function EventsCalendar({
+  initialEntries,
+  initialMonth,
+  locale,
+}: EventsCalendarProps) {
+  const t = useTranslations("calendar")
+  const [currentMonth, setCurrentMonth] = useState(initialMonth)
+  const [entries, setEntries] = useState<CalendarEntry[]>(initialEntries)
+  const [loading, setLoading] = useState(false)
+  const [popup, setPopup] = useState<PopupState | null>(null)
+
+  const today = todayString()
+  const [, month] = currentMonth.split("-").map(Number)
+  const [year] = currentMonth.split("-").map(Number)
+  const grid = buildGrid(currentMonth)
+
+  // Agrupar entries por fecha
+  const entriesByDate = new Map<string, CalendarEntry[]>()
+  for (const entry of entries) {
+    const list = entriesByDate.get(entry.date) ?? []
+    list.push(entry)
+    entriesByDate.set(entry.date, list)
+  }
+
+  async function navigateTo(ym: string) {
+    setLoading(true)
+    setPopup(null)
+    try {
+      const res = await fetch(`/api/calendar?month=${ym}`)
+      if (res.ok) {
+        const json = await res.json()
+        setEntries(json.data.entries)
+      }
+    } finally {
+      setLoading(false)
+      setCurrentMonth(ym)
+    }
+  }
+
+  const handleEntryClick = useCallback(
+    (entry: CalendarEntry, rect: DOMRect | null) => {
+      setPopup({ entry, anchorRect: rect })
+    },
+    []
+  )
+
+  const monthName = t(`months.${month}` as Parameters<typeof t>[0])
+
+  return (
+    <div className="relative">
+      {/* Nav del mes */}
+      <div className="flex items-center justify-between pb-6">
+        <button
+          onClick={() => navigateTo(prevMonth(currentMonth))}
+          disabled={loading}
+          aria-label={t("navPrev")}
+          className="border border-border rounded-m px-4 py-2 text-body-s text-fg-secondary hover:text-fg-primary transition-colors disabled:opacity-40"
+        >
+          ←{" "}
+          {t(
+            `months.${parseInt(prevMonth(currentMonth).split("-")[1]!, 10)}` as Parameters<typeof t>[0]
+          )}
+        </button>
+
+        <div className="text-center">
+          <p className="text-caption text-fg-tertiary tracking-widest uppercase mb-1">
+            {year}
+          </p>
+          <h1 className="text-heading-m font-display font-bold text-fg-primary">
+            {monthName}
+          </h1>
+        </div>
+
+        <button
+          onClick={() => navigateTo(nextMonth(currentMonth))}
+          disabled={loading}
+          aria-label={t("navNext")}
+          className="border border-border rounded-m px-4 py-2 text-body-s text-fg-secondary hover:text-fg-primary transition-colors disabled:opacity-40"
+        >
+          {t(
+            `months.${parseInt(nextMonth(currentMonth).split("-")[1]!, 10)}` as Parameters<typeof t>[0]
+          )}{" "}
+          →
+        </button>
+      </div>
+
+      {/* Cabeceras de días */}
+      <div className="grid grid-cols-7 mb-1">
+        {WEEKDAY_KEYS.map((key) => (
+          <div
+            key={key}
+            className="text-center text-[10px] font-bold tracking-widest uppercase text-fg-tertiary/50 py-2"
+          >
+            {t(`weekdays.${key}`)}
+          </div>
+        ))}
+      </div>
+
+      {/* Grilla de días */}
+      <div
+        className={cn(
+          "grid grid-cols-7 gap-0.5 transition-opacity",
+          loading && "opacity-50 pointer-events-none"
+        )}
+      >
+        {grid.map((cell) => (
+          <CalendarDayCell
+            key={cell.date}
+            day={cell.day}
+            isCurrentMonth={cell.isCurrentMonth}
+            isToday={cell.date === today}
+            entries={entriesByDate.get(cell.date) ?? []}
+            onEntryClick={handleEntryClick}
+          />
+        ))}
+      </div>
+
+      {/* Estado vacío */}
+      {!loading && entries.length === 0 && (
+        <p className="text-center text-fg-tertiary text-body py-12">
+          {t("noEvents")}
+        </p>
+      )}
+
+      {/* Popup */}
+      {popup && (
+        <CalendarEventPopup
+          entry={popup.entry}
+          anchorRect={popup.anchorRect}
+          locale={locale}
+          onClose={() => setPopup(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/events/EventsCalendar.tsx
+++ b/src/components/events/EventsCalendar.tsx
@@ -115,10 +115,15 @@ export default function EventsCalendar({
       if (res.ok) {
         const json = await res.json()
         setEntries(json.data.entries)
+        // Solo avanzamos de mes si el fetch trajo datos: así el header/grid
+        // nunca muestran el mes nuevo con las entries del anterior.
+        setCurrentMonth(ym)
       }
+    } catch {
+      // Fallo de red: nos quedamos en el mes actual con sus datos (consistente).
+      // El `onClick` no awaitea, así que sin este catch sería un unhandled rejection.
     } finally {
       setLoading(false)
-      setCurrentMonth(ym)
     }
   }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -88,7 +88,7 @@ export function Header() {
         {/* Nav central — desktop only */}
         <nav className="hidden md:flex items-center gap-l mx-auto">
           {navItems.map((item) => {
-            const isActive = isNavItemActive(pathname, item)
+            const isActive = isNavItemActive(pathname, item, navItems)
             return (
               <Link
                 key={item.href}
@@ -146,11 +146,29 @@ export function Header() {
  * `@/i18n/navigation`). Para items con hash (`hashOnly: true`) no
  * intentamos matchear basándonos en el path — el hash es ambiguo entre
  * varias rutas y leerlo desde el server-rendered no es posible. */
-function isNavItemActive(pathname: string, item: NavItem): boolean {
+function isNavItemActive(
+  pathname: string,
+  item: NavItem,
+  allItems: NavItem[]
+): boolean {
   if (item.hashOnly) return false
   const path = item.href
   if (path === "/") return pathname === "/"
-  return pathname === path || pathname.startsWith(`${path}/`)
+  const matches = pathname === path || pathname.startsWith(`${path}/`)
+  if (!matches) return false
+  // "El más específico gana": si otro item del nav es un prefijo más largo
+  // que también matchea el pathname, ese item es el activo y este no. Así
+  // `/events/calendar` no enciende también `/events`, pero `/events` sigue
+  // activo en `/events/past` y `/events/[slug]` (no hay item más específico).
+  const hasMoreSpecific = allItems.some((other) => {
+    if (other === item || other.hashOnly) return false
+    const otherPath = other.href
+    if (otherPath.length <= path.length || !otherPath.startsWith(`${path}/`)) {
+      return false
+    }
+    return pathname === otherPath || pathname.startsWith(`${otherPath}/`)
+  })
+  return !hasMoreSpecific
 }
 
 interface SessionLike {
@@ -426,7 +444,7 @@ function MobileDrawer({
       >
         <nav className="flex flex-col gap-xs px-l py-l">
           {navItems.map((item, index) => {
-            const isActive = isNavItemActive(pathname, item)
+            const isActive = isNavItemActive(pathname, item, navItems)
             return (
               <Link
                 key={item.href}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -60,6 +60,7 @@ export function Header() {
   const navItems: NavItem[] = [
     { href: "/events", label: t("events") },
     { href: "/artists", label: t("artists") },
+    { href: "/events/calendar", label: t("calendar") },
     { href: "/events#esta-semana", hashOnly: true, label: t("thisWeek") },
   ]
 

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -2,6 +2,7 @@
   "nav": {
     "events": "Veranstaltungen",
     "artists": "Künstler",
+    "calendar": "Kalender",
     "dashboard": "Mein Bereich",
     "admin": "Admin",
     "signIn": "Anmelden",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -817,5 +817,38 @@
     "confirmedBanner": "Abonnement bestätigt! Ab dem nächsten Montag erhältst du die Events der Woche.",
     "tokenExpiredMessage": "Der Bestätigungslink ist abgelaufen. Melde dich erneut an, um eine neue E-Mail zu erhalten.",
     "footerLabel": "Wöchentlicher Newsletter"
+  },
+  "calendar": {
+    "pageTitle": "Kalender",
+    "pageDescription": "Alle Events der lateinamerikanischen Szene in Berlin",
+    "navPrev": "Vorheriger Monat",
+    "navNext": "Nächster Monat",
+    "noEvents": "Keine Events in diesem Monat",
+    "sceneEventBadge": "Andere Szene",
+    "viewEvent": "Event ansehen →",
+    "viewSource": "Quelle ansehen →",
+    "moreEvents": "+{count} mehr",
+    "loading": "Laden...",
+    "weekdays": {
+      "mon": "Mo", "tue": "Di", "wed": "Mi", "thu": "Do",
+      "fri": "Fr", "sat": "Sa", "sun": "So"
+    },
+    "months": {
+      "1": "Januar", "2": "Februar", "3": "März", "4": "April",
+      "5": "Mai", "6": "Juni", "7": "Juli", "8": "August",
+      "9": "September", "10": "Oktober", "11": "November", "12": "Dezember"
+    },
+    "dashboard": {
+      "title": "Szene-Einträge",
+      "addEntry": "Eintrag hinzufügen",
+      "dateLabel": "Datum",
+      "titleLabel": "Titel",
+      "venueLabel": "Venue (optional)",
+      "urlLabel": "Externer Link (optional)",
+      "delete": "Löschen",
+      "empty": "Keine Szene-Einträge vorhanden",
+      "saving": "Speichern...",
+      "saved": "Gespeichert"
+    }
   }
 }

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -849,7 +849,9 @@
       "delete": "Löschen",
       "empty": "Keine Szene-Einträge vorhanden",
       "saving": "Speichern...",
-      "saved": "Gespeichert"
+      "saved": "Gespeichert",
+      "errorMessage": "Etwas ist schiefgelaufen. Bitte versuche es erneut.",
+      "loading": "Laden..."
     }
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -817,5 +817,38 @@
     "confirmedBanner": "Subscription confirmed! Starting next Monday you'll receive the week's events.",
     "tokenExpiredMessage": "The confirmation link has expired. Subscribe again to receive a new email.",
     "footerLabel": "Weekly newsletter"
+  },
+  "calendar": {
+    "pageTitle": "Calendar",
+    "pageDescription": "All events from the Latin scene in Berlin",
+    "navPrev": "Previous month",
+    "navNext": "Next month",
+    "noEvents": "No events this month",
+    "sceneEventBadge": "Other scene",
+    "viewEvent": "View event →",
+    "viewSource": "View source →",
+    "moreEvents": "+{count} more",
+    "loading": "Loading...",
+    "weekdays": {
+      "mon": "Mon", "tue": "Tue", "wed": "Wed", "thu": "Thu",
+      "fri": "Fri", "sat": "Sat", "sun": "Sun"
+    },
+    "months": {
+      "1": "January", "2": "February", "3": "March", "4": "April",
+      "5": "May", "6": "June", "7": "July", "8": "August",
+      "9": "September", "10": "October", "11": "November", "12": "December"
+    },
+    "dashboard": {
+      "title": "Scene entries",
+      "addEntry": "Add entry",
+      "dateLabel": "Date",
+      "titleLabel": "Title",
+      "venueLabel": "Venue (optional)",
+      "urlLabel": "External link (optional)",
+      "delete": "Delete",
+      "empty": "No scene entries loaded",
+      "saving": "Saving...",
+      "saved": "Saved"
+    }
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2,6 +2,7 @@
   "nav": {
     "events": "Events",
     "artists": "Artists",
+    "calendar": "Calendar",
     "dashboard": "My panel",
     "admin": "Admin",
     "signIn": "Sign In",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -849,7 +849,9 @@
       "delete": "Delete",
       "empty": "No scene entries loaded",
       "saving": "Saving...",
-      "saved": "Saved"
+      "saved": "Saved",
+      "errorMessage": "Something went wrong. Please try again.",
+      "loading": "Loading..."
     }
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -817,5 +817,43 @@
     "confirmedBanner": "¡Suscripción confirmada! A partir del próximo lunes vas a recibir los eventos de la semana.",
     "tokenExpiredMessage": "El link de confirmación expiró. Volvé a suscribirte para recibir un nuevo email.",
     "footerLabel": "Newsletter semanal"
+  },
+  "calendar": {
+    "pageTitle": "Calendario",
+    "pageDescription": "Todos los eventos de la escena latina en Berlín",
+    "navPrev": "Mes anterior",
+    "navNext": "Mes siguiente",
+    "noEvents": "Sin eventos este mes",
+    "sceneEventBadge": "Otra escena",
+    "viewEvent": "Ver evento →",
+    "viewSource": "Ver fuente →",
+    "moreEvents": "+{count} más",
+    "loading": "Cargando...",
+    "weekdays": {
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mié",
+      "thu": "Jue",
+      "fri": "Vie",
+      "sat": "Sáb",
+      "sun": "Dom"
+    },
+    "months": {
+      "1": "Enero", "2": "Febrero", "3": "Marzo", "4": "Abril",
+      "5": "Mayo", "6": "Junio", "7": "Julio", "8": "Agosto",
+      "9": "Septiembre", "10": "Octubre", "11": "Noviembre", "12": "Diciembre"
+    },
+    "dashboard": {
+      "title": "Entradas de escena",
+      "addEntry": "Agregar entrada",
+      "dateLabel": "Fecha",
+      "titleLabel": "Título",
+      "venueLabel": "Venue (opcional)",
+      "urlLabel": "Link externo (opcional)",
+      "delete": "Eliminar",
+      "empty": "No hay entradas de escena cargadas",
+      "saving": "Guardando...",
+      "saved": "Guardado"
+    }
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -2,6 +2,7 @@
   "nav": {
     "events": "Eventos",
     "artists": "Artistas",
+    "calendar": "Calendario",
     "dashboard": "Mi panel",
     "admin": "Admin",
     "signIn": "Iniciar sesión",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -854,7 +854,9 @@
       "delete": "Eliminar",
       "empty": "No hay entradas de escena cargadas",
       "saving": "Guardando...",
-      "saved": "Guardado"
+      "saved": "Guardado",
+      "errorMessage": "Algo salió mal. Intentá de nuevo.",
+      "loading": "Cargando..."
     }
   }
 }

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -1,0 +1,81 @@
+/**
+ * Servicio de calendario — agrega entradas de Event y SceneEvent
+ * en el rango de fechas visible en la grilla mensual.
+ */
+import "server-only"
+
+import { prisma } from "@/lib/prisma"
+
+export interface CalendarEntry {
+  id: string
+  type: "event" | "scene"
+  /** ISO date string "YYYY-MM-DD" */
+  date: string
+  title: string
+  venue: string | null
+  time: string | null
+  slug: string | null
+  externalUrl: string | null
+}
+
+/**
+ * Retorna todas las entradas (Event + SceneEvent) en el rango [from, to].
+ * `from` y `to` son los límites de la grilla (primer lunes visible al
+ * último domingo visible), pueden extenderse fuera del mes pedido.
+ */
+export async function getCalendarEntries(
+  from: Date,
+  to: Date
+): Promise<CalendarEntry[]> {
+  const [events, sceneEvents] = await Promise.all([
+    prisma.event.findMany({
+      where: {
+        isDeleted: false,
+        isActive: true,
+        dates: { some: { date: { gte: from, lte: to } } },
+      },
+      include: {
+        dates: {
+          where: { date: { gte: from, lte: to } },
+          orderBy: { date: "asc" },
+        },
+      },
+    }),
+    prisma.sceneEvent.findMany({
+      where: { date: { gte: from, lte: to } },
+      orderBy: { date: "asc" },
+    }),
+  ])
+
+  const entries: CalendarEntry[] = []
+
+  for (const event of events) {
+    for (const d of event.dates) {
+      entries.push({
+        id: `${event.id}__${d.id}`,
+        type: "event",
+        date: d.date.toISOString().split("T")[0]!,
+        title: event.title,
+        venue: event.location,
+        time: event.time ?? null,
+        slug: event.slug,
+        externalUrl: null,
+      })
+    }
+  }
+
+  for (const se of sceneEvents) {
+    entries.push({
+      id: se.id,
+      type: "scene",
+      date: se.date.toISOString().split("T")[0]!,
+      title: se.title,
+      venue: se.venue ?? null,
+      time: null,
+      slug: null,
+      externalUrl: se.externalUrl ?? null,
+    })
+  }
+
+  return entries.sort((a, b) => a.date.localeCompare(b.date))
+}


### PR DESCRIPTION
## Summary

- **Página pública `/events/calendar`** — grilla mensual con navegación mes a mes sin recarga de página
- **Dos tipos de entradas** — eventos La Huella (rojo) y entradas de escena cargadas por el admin (ámbar)
- **Popup en desktop** al hacer click en un evento, navegación directa en mobile
- **Nuevo modelo `SceneEvent`** para eventos que el admin carga desde Instagram/otras fuentes
- **Panel admin `/admin/calendar`** — crear y borrar entradas de escena
- **Link "Calendario"** en la navegación principal

## Migrations
- Nueva tabla `SceneEvent` (date, title, venue?, externalUrl?)

## Test plan
- [ ] Abrir /es/events/calendar — ver grilla mensual del mes actual
- [ ] Navegar al mes anterior y siguiente sin recarga de página
- [ ] Click en evento oficial (rojo) → popup con "Ver evento →" en desktop
- [ ] Click en entrada de escena (ámbar) → popup con datos en desktop
- [ ] En mobile: click en evento oficial navega al detalle
- [ ] Admin crea una entrada en /admin/calendar → aparece en el calendario
- [ ] Admin borra una entrada → desaparece del calendario
- [ ] Acceder a /admin/calendar sin ser admin → redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public monthly calendar at /events/calendar with month navigation, day grid, entry popups, responsive mobile view, and click-through CTAs to event details or external sources
  * Admin dashboard to create and delete curated “scene” entries; admin-only API endpoints for managing them
  * Public calendar API powering month views and combined official + scene entries

* **Localization**
  * Spanish, English and German translations for calendar UI and admin texts

* **Documentation**
  * Design spec and implementation plan for calendar rollout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->