### PR TITLE
feat(events): múltiples géneros por evento + creación al vuelo

### DIFF
--- a/docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md
+++ b/docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md
@@ -1,0 +1,140 @@
+# Eventos con múltiples géneros + géneros nuevos
+
+**Fecha:** 2026-06-12
+**Branch sugerida:** `feat/event-multiple-genres` (desde `main` actualizado)
+
+## Problema
+
+Hoy un evento tiene un único género (`Event.genre String?`) elegido de una lista
+hardcodeada con un `<select>` de opción única. Necesitamos:
+
+1. Que un evento pueda tener **varios géneros**.
+2. Que si un género **no existe** en la lista, se pueda **agregar** en el momento.
+
+Caso disparador: un organizador pidió cargar un evento cuyo género es
+"Fusión Multicultural: Latin Pop, Blues, Reggae" — tres géneros, dos de ellos
+(Blues, Reggae) no están en la lista curada actual.
+
+## Decisión de diseño
+
+**Array de strings + combobox multi-select creatable.** No se introduce una tabla
+catálogo (`Genre`) ni relación many-to-many: sería overkill. El catálogo "crece
+solo" porque las sugerencias se derivan de los géneros ya usados en eventos.
+
+Esto es consistente con `Artist.genres` (que ya es `String[]`), pero mejora la UX
+respecto al input de texto-por-comas de Artists usando el Combobox nativo de
+Base UI (chips + sugerencias + crear).
+
+## Modelo de datos
+
+`Event.genre String?` → **`Event.genres String[] @default([])`**
+
+`prisma/schema.prisma`: reemplazar la línea `genre String?` por `genres String[]`.
+
+### Migración (Neon, manual según runbook de deploy)
+
+```sql
+ALTER TABLE "Event" ADD COLUMN "genres" TEXT[] NOT NULL DEFAULT '{}';
+UPDATE "Event" SET "genres" = ARRAY["genre"] WHERE "genre" IS NOT NULL;
+ALTER TABLE "Event" DROP COLUMN "genre";
+```
+
+- Backfill antes de dropear: ningún evento existente pierde su género.
+- La columna `genre` vieja **se elimina** (decisión confirmada: no se conserva).
+- Orden seguro contra downtime: el ADD con default y el UPDATE son no-bloqueantes
+  en la práctica para el tamaño actual de la tabla; el DROP corre al final.
+- `SceneEvent` (calendario) no tiene género: no se toca.
+- `Artist.genres` ya es `String[]`: no se toca.
+
+Recordatorio del proyecto: Prisma 7 declara las URLs en `prisma.config.ts`, no en
+`schema.prisma`. Tras `npm ci` correr `prisma generate` a mano (no hay postinstall).
+
+## Form — `src/components/events/EventForm.tsx`
+
+- Eliminar la const `GENRES` y el `<FormSelect>` de género único (incluida la
+  opción `""`/`noGenre` y `Otros`/`genreOther`).
+- Insertar un **Combobox multi-select creatable** (`@base-ui/react/combobox`,
+  partes `Chips` / `Chip` / `ChipRemove` / `Input` / `Item` / `Empty`):
+  - Chips para los géneros seleccionados, cada uno con su botón de quitar.
+  - Lista de sugerencias filtrada por lo que se escribe.
+  - Opción "+ crear «X»" cuando el texto tipeado no coincide con ninguna sugerencia.
+- **Fuente de sugerencias:** unión de
+  1. lista curada base (la actual: Tango, Salsa, Cumbia, Reggaeton, Merengue,
+     Son Cubano, Bossa Nova, Vallenato, Flamenco Latino, Latin Jazz, Folklore), y
+  2. géneros ya usados en eventos existentes.
+
+  Se pasa al form como prop `genreSuggestions: string[]` desde el server (páginas
+  new/edit), calculada con un helper de servicios. La lista curada base vive como
+  constante compartida (p. ej. `BASE_GENRES` en services o en un módulo de constantes).
+- **Validación / normalización al guardar** (antes de mandar al backend):
+  - `trim` de cada valor, descartar vacíos.
+  - **Dedup case-insensitive**: Reggae y reggae cuentan como uno; se conserva la
+    primera grafía ingresada.
+  - Zod del form: `genre: z.string().optional()` → `genres: z.array(z.string())`.
+- `defaultValues`: `genre ?? ""` → `genres ?? []`.
+
+## Servicios — `src/services/events.ts`
+
+- Tipos: `genre: string | null` → `genres: string[]` en `EventSummary` y en el tipo
+  de detalle. Los mapeos (`genre: event.genre`) pasan a `genres: event.genres`.
+- **Create / update**: escribir `genres` (array normalizado) en lugar de `genre`.
+- **Filtrado por género**: `where: { genre: X }` → `where: { genres: { has: X } }`.
+- **`getActiveGenres()`**: hoy hace `distinct` + `orderBy` sobre la columna escalar.
+  Pasa a: traer `select: { genres: true }` de los eventos activos no borrados,
+  aplanar, dedup (case-insensitive) y ordenar alfabéticamente en JS. El dataset es
+  chico; no se necesita `unnest` en SQL.
+- **Nuevo helper** `getGenreSuggestions(): Promise<string[]>` (o reusar
+  `getActiveGenres` unido a `BASE_GENRES`) para alimentar el form.
+
+## API — Zod schemas
+
+- `src/app/api/events/route.ts`: `genre: z.string().optional()` →
+  `genres: z.array(z.string()).optional()`. El filtro GET por `genre` (query param)
+  se mantiene como string único y se traduce a `{ genres: { has } }` en el servicio.
+- `src/app/api/events/[id]/route.ts`: mismo cambio en el schema de update.
+
+## Superficies de display (1 badge → N badges)
+
+Renderizar varios chips/badges en vez de uno:
+
+- Detalle público: `src/app/[locale]/(public)/events/[slug]/page.tsx` (badge de género).
+- Card de evento (lista pública) — donde se muestre el género.
+- Lista dashboard: `src/app/[locale]/(protected)/dashboard/events/page.tsx`.
+- Lista admin: `src/app/[locale]/(admin)/admin/events/page.tsx`.
+
+Sin cambios funcionales (siguen operando sobre lista de strings), sólo se adaptan
+a array:
+
+- Strip de géneros del home (`(public)/page.tsx`) — ya consume `getActiveGenres()`.
+- `EventFilter` — ya opera sobre `string[]`; el filtrado pasa a `has` vía servicio.
+
+## i18n — `messages/{es,en,de}.json`
+
+- Quitar las keys obsoletas `eventForm.fields.noGenre` y `eventForm.fields.genreOther`.
+- Agregar las del combobox en los tres locales:
+  - placeholder del input (p. ej. "Agregá o elegí géneros…").
+  - label de crear (p. ej. "Crear «{value}»").
+  - empty state (sin coincidencias).
+
+## Testing / verificación
+
+- `prisma generate` + typecheck pasan tras el cambio de tipos.
+- Build local con Node 22.13.1.
+- Manual: crear un evento con varios géneros incluyendo uno nuevo (Blues/Reggae),
+  editar uno existente (se ve su género migrado como chip), verificar que el género
+  nuevo aparece como sugerencia en el siguiente alta, y que el filtro público por
+  ese género lista el evento.
+
+## Fuera de alcance (YAGNI)
+
+- Tabla catálogo `Genre` y UI de gestión de catálogo.
+- Renombrado/merge masivo de géneros existentes.
+- Traducción de los nombres de género (se guardan como strings tal cual).
+
+## Flujo de entrega
+
+1. Branch desde `main` actualizado, commits atómicos.
+2. PR contra `main`, esperar CodeRabbit antes de proponer merge.
+3. Correr architecture-reviewer / api-contract-reviewer sobre el diff antes del PR.
+4. Como el PR toca `prisma/schema.prisma`: además de `deploy.sh`, aplicar la
+   migración SQL manual + `prisma db push` contra Neon.

--- a/docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md
+++ b/docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md
@@ -39,10 +39,34 @@ En `prisma/schema.prisma`: reemplazar la línea `genre String?` por `genres Stri
 
 ### Migración (Neon, manual según runbook de deploy)
 
+El script real vive en `prisma/migrations-manual/2026-06-12_event_genre_to_genres_array.sql`
+(transaccional e idempotente, con guards `IF NOT EXISTS` y backfill condicional).
+Resumen:
+
 ```sql
-ALTER TABLE "Event" ADD COLUMN "genres" TEXT[] NOT NULL DEFAULT '{}';
-UPDATE "Event" SET "genres" = ARRAY["genre"] WHERE "genre" IS NOT NULL;
-ALTER TABLE "Event" DROP COLUMN "genre";
+BEGIN;
+
+ALTER TABLE "Event" ADD COLUMN IF NOT EXISTS "genres" TEXT[] NOT NULL DEFAULT '{}';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'Event' AND column_name = 'genre'
+  ) THEN
+    UPDATE "Event"
+    SET "genres" = ARRAY["genre"]
+    WHERE "genre" IS NOT NULL
+      AND ("genres" IS NULL OR cardinality("genres") = 0);
+
+    ALTER TABLE "Event" DROP COLUMN "genre";
+  END IF;
+END $$;
+
+-- GIN para el filtro público `genres: { has }` (home / `/events`).
+CREATE INDEX IF NOT EXISTS "Event_genres_idx" ON "Event" USING GIN ("genres");
+
+COMMIT;
 ```
 
 - Backfill ANTES de dropear: ningún evento existente pierde su género.

--- a/docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md
+++ b/docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md
@@ -1,35 +1,41 @@
-# Eventos con múltiples géneros + géneros nuevos
+# Eventos con múltiples géneros + creación de géneros nuevos
 
-**Fecha:** 2026-06-12
-**Branch sugerida:** `feat/event-multiple-genres` (desde `main` actualizado)
+## Contexto
 
-## Problema
+Portal de eventos de música latinoamericana (Next.js 16, React 19, TS, Tailwind 4,
+Prisma 7 + PostgreSQL en **Neon**, Better Auth, next-intl). Roles: admin, creator, user.
 
 Hoy un evento tiene un único género (`Event.genre String?`) elegido de una lista
-hardcodeada con un `<select>` de opción única. Necesitamos:
+hardcodeada con un `<select>` de opción única. Caso disparador real: un organizador
+necesita cargar un evento cuyo género es "Fusión Multicultural: Latin Pop, Blues,
+Reggae" — tres géneros, dos de ellos (Blues, Reggae) no están en la lista curada.
 
-1. Que un evento pueda tener **varios géneros**.
-2. Que si un género **no existe** en la lista, se pueda **agregar** en el momento.
+Decisión de producto ya tomada (no la re-evalúes): cualquier usuario con permiso de
+cargar/editar eventos (creator o admin) puede crear géneros nuevos al vuelo. El
+control de duplicados va por UX (filtrado normalizado de sugerencias), NO por
+permisos ni por flujo de aprobación.
 
-Caso disparador: un organizador pidió cargar un evento cuyo género es
-"Fusión Multicultural: Latin Pop, Blues, Reggae" — tres géneros, dos de ellos
-(Blues, Reggae) no están en la lista curada actual.
+## Objetivo
+
+1. Que un evento pueda tener **varios géneros** (`String[]`).
+2. Que si un género no existe en la lista, se pueda **crear en el momento** desde el
+   form, con un combobox multi-select creatable.
+3. Que el filtrado de sugerencias sea **normalizado** (case + acentos) para empujar
+   reutilización y minimizar duplicados semánticos.
 
 ## Decisión de diseño
 
-**Array de strings + combobox multi-select creatable.** No se introduce una tabla
-catálogo (`Genre`) ni relación many-to-many: sería overkill. El catálogo "crece
-solo" porque las sugerencias se derivan de los géneros ya usados en eventos.
-
-Esto es consistente con `Artist.genres` (que ya es `String[]`), pero mejora la UX
-respecto al input de texto-por-comas de Artists usando el Combobox nativo de
-Base UI (chips + sugerencias + crear).
+Array de strings + combobox multi-select creatable. **No** se introduce tabla
+catálogo (`Genre`) ni relación many-to-many: es overkill. El catálogo "crece solo"
+porque las sugerencias se derivan de los géneros ya usados en eventos, unidos a una
+lista curada base. Consistente con `Artist.genres` (ya es `String[]`), pero con mejor
+UX vía el Combobox de Base UI (chips + sugerencias + crear).
 
 ## Modelo de datos
 
 `Event.genre String?` → **`Event.genres String[] @default([])`**
 
-`prisma/schema.prisma`: reemplazar la línea `genre String?` por `genres String[]`.
+En `prisma/schema.prisma`: reemplazar la línea `genre String?` por `genres String[]`.
 
 ### Migración (Neon, manual según runbook de deploy)
 
@@ -39,37 +45,44 @@ UPDATE "Event" SET "genres" = ARRAY["genre"] WHERE "genre" IS NOT NULL;
 ALTER TABLE "Event" DROP COLUMN "genre";
 ```
 
-- Backfill antes de dropear: ningún evento existente pierde su género.
-- La columna `genre` vieja **se elimina** (decisión confirmada: no se conserva).
+- Backfill ANTES de dropear: ningún evento existente pierde su género.
+- La columna `genre` vieja se elimina (decisión confirmada: no se conserva).
 - Orden seguro contra downtime: el ADD con default y el UPDATE son no-bloqueantes
-  en la práctica para el tamaño actual de la tabla; el DROP corre al final.
+  para el tamaño actual de la tabla; el DROP corre al final.
 - `SceneEvent` (calendario) no tiene género: no se toca.
 - `Artist.genres` ya es `String[]`: no se toca.
 
-Recordatorio del proyecto: Prisma 7 declara las URLs en `prisma.config.ts`, no en
-`schema.prisma`. Tras `npm ci` correr `prisma generate` a mano (no hay postinstall).
+Recordatorio Prisma 7: las URLs se declaran en `prisma.config.ts`, no en
+`schema.prisma`. Tras `npm ci`, correr `prisma generate` a mano (no hay postinstall).
 
 ## Form — `src/components/events/EventForm.tsx`
 
-- Eliminar la const `GENRES` y el `<FormSelect>` de género único (incluida la
-  opción `""`/`noGenre` y `Otros`/`genreOther`).
-- Insertar un **Combobox multi-select creatable** (`@base-ui/react/combobox`,
-  partes `Chips` / `Chip` / `ChipRemove` / `Input` / `Item` / `Empty`):
-  - Chips para los géneros seleccionados, cada uno con su botón de quitar.
+- Eliminar la const `GENRES` y el `<FormSelect>` de género único (incluida la opción
+  `""`/`noGenre` y `Otros`/`genreOther`).
+- Insertar un **Combobox multi-select creatable** (`@base-ui/react/combobox`, partes
+  `Chips` / `Chip` / `ChipRemove` / `Input` / `Item` / `Empty`):
+  - Chips para los géneros seleccionados, cada uno con botón de quitar.
   - Lista de sugerencias filtrada por lo que se escribe.
-  - Opción "+ crear «X»" cuando el texto tipeado no coincide con ninguna sugerencia.
-- **Fuente de sugerencias:** unión de
-  1. lista curada base (la actual: Tango, Salsa, Cumbia, Reggaeton, Merengue,
-     Son Cubano, Bossa Nova, Vallenato, Flamenco Latino, Latin Jazz, Folklore), y
+  - Opción "+ crear «X»" SOLO cuando el texto tipeado no matchea ninguna sugerencia
+    tras normalizar (ver abajo).
+- **Fuente de sugerencias** (prop `genreSuggestions: string[]` desde el server):
+  unión de
+  1. lista curada base (`BASE_GENRES`): Tango, Salsa, Cumbia, Reggaeton, Merengue,
+     Son Cubano, Bossa Nova, Vallenato, Flamenco Latino, Latin Jazz, Folklore; y
   2. géneros ya usados en eventos existentes.
 
-  Se pasa al form como prop `genreSuggestions: string[]` desde el server (páginas
-  new/edit), calculada con un helper de servicios. La lista curada base vive como
-  constante compartida (p. ej. `BASE_GENRES` en services o en un módulo de constantes).
+  `BASE_GENRES` vive como constante compartida (en services o un módulo de constantes).
+- **Filtrado normalizado (el delta clave):** al comparar lo tipeado contra las
+  sugerencias, normalizar AMBOS lados con lowercase + strip de acentos antes de
+  matchear (substring sobre el valor normalizado). Esto hace que "regae" sugiera
+  "Reggae" y "folclore" sugiera "Folklore", suprimiendo la opción "+ crear" cuando
+  ya existe algo equivalente. Typo-tolerance completa (Levenshtein/fuzzy con
+  distancia) es OPCIONAL y solo si NO requiere sumar dependencia nueva; si la
+  requiere, no la implementes.
 - **Validación / normalización al guardar** (antes de mandar al backend):
   - `trim` de cada valor, descartar vacíos.
-  - **Dedup case-insensitive**: Reggae y reggae cuentan como uno; se conserva la
-    primera grafía ingresada.
+  - Dedup case-insensitive (y acento-insensitive): "Reggae" y "reggae" cuentan como
+    uno; se conserva la primera grafía ingresada.
   - Zod del form: `genre: z.string().optional()` → `genres: z.array(z.string())`.
 - `defaultValues`: `genre ?? ""` → `genres ?? []`.
 
@@ -77,14 +90,14 @@ Recordatorio del proyecto: Prisma 7 declara las URLs en `prisma.config.ts`, no e
 
 - Tipos: `genre: string | null` → `genres: string[]` en `EventSummary` y en el tipo
   de detalle. Los mapeos (`genre: event.genre`) pasan a `genres: event.genres`.
-- **Create / update**: escribir `genres` (array normalizado) en lugar de `genre`.
-- **Filtrado por género**: `where: { genre: X }` → `where: { genres: { has: X } }`.
-- **`getActiveGenres()`**: hoy hace `distinct` + `orderBy` sobre la columna escalar.
+- Create / update: escribir `genres` (array normalizado) en lugar de `genre`.
+- Filtrado por género: `where: { genre: X }` → `where: { genres: { has: X } }`.
+- `getActiveGenres()`: hoy hace `distinct` + `orderBy` sobre la columna escalar.
   Pasa a: traer `select: { genres: true }` de los eventos activos no borrados,
-  aplanar, dedup (case-insensitive) y ordenar alfabéticamente en JS. El dataset es
+  aplanar, dedup (case/acento-insensitive) y ordenar alfabéticamente en JS. Dataset
   chico; no se necesita `unnest` en SQL.
-- **Nuevo helper** `getGenreSuggestions(): Promise<string[]>` (o reusar
-  `getActiveGenres` unido a `BASE_GENRES`) para alimentar el form.
+- Nuevo helper `getGenreSuggestions(): Promise<string[]>` (o reusar `getActiveGenres`
+  unido a `BASE_GENRES`) para alimentar el form en las páginas new/edit.
 
 ## API — Zod schemas
 
@@ -97,13 +110,12 @@ Recordatorio del proyecto: Prisma 7 declara las URLs en `prisma.config.ts`, no e
 
 Renderizar varios chips/badges en vez de uno:
 
-- Detalle público: `src/app/[locale]/(public)/events/[slug]/page.tsx` (badge de género).
+- Detalle público: `src/app/[locale]/(public)/events/[slug]/page.tsx`.
 - Card de evento (lista pública) — donde se muestre el género.
 - Lista dashboard: `src/app/[locale]/(protected)/dashboard/events/page.tsx`.
 - Lista admin: `src/app/[locale]/(admin)/admin/events/page.tsx`.
 
-Sin cambios funcionales (siguen operando sobre lista de strings), sólo se adaptan
-a array:
+Sin cambios funcionales (siguen operando sobre lista de strings), solo adaptar a array:
 
 - Strip de géneros del home (`(public)/page.tsx`) — ya consume `getActiveGenres()`.
 - `EventFilter` — ya opera sobre `string[]`; el filtrado pasa a `has` vía servicio.
@@ -112,29 +124,56 @@ a array:
 
 - Quitar las keys obsoletas `eventForm.fields.noGenre` y `eventForm.fields.genreOther`.
 - Agregar las del combobox en los tres locales:
-  - placeholder del input (p. ej. "Agregá o elegí géneros…").
-  - label de crear (p. ej. "Crear «{value}»").
+  - placeholder del input (ej. "Agregá o elegí géneros…").
+  - label de crear (ej. "Crear «{value}»").
   - empty state (sin coincidencias).
 
-## Testing / verificación
+## Criterios de aceptación
 
-- `prisma generate` + typecheck pasan tras el cambio de tipos.
-- Build local con Node 22.13.1.
-- Manual: crear un evento con varios géneros incluyendo uno nuevo (Blues/Reggae),
-  editar uno existente (se ve su género migrado como chip), verificar que el género
-  nuevo aparece como sugerencia en el siguiente alta, y que el filtro público por
-  ese género lista el evento.
+- [ ] `Event.genres String[] @default([])` en schema; columna `genre` eliminada.
+- [ ] Migración SQL hace backfill ANTES del DROP; ningún evento pierde su género.
+- [ ] El form usa el Combobox multi-select creatable con chips removibles.
+- [ ] Se pueden cargar varios géneros en un evento, incluyendo géneros nuevos.
+- [ ] Al tipear "regae" se sugiere "Reggae" y NO aparece "+ crear «regae»"
+      (filtrado normalizado case + acentos funcionando).
+- [ ] La opción "+ crear «X»" solo aparece cuando no hay match normalizado.
+- [ ] Al guardar: trim, descarte de vacíos, y dedup case/acento-insensitive.
+- [ ] Géneros nuevos creados aparecen como sugerencia en el siguiente alta.
+- [ ] Filtro público por un género lista los eventos que lo tienen (vía `has`).
+- [ ] Todas las superficies de display muestran N badges en vez de uno.
+- [ ] i18n: keys obsoletas removidas, nuevas keys en es/en/de.
+- [ ] `prisma generate` + typecheck pasan. Build local con Node 22.13.1.
 
-## Fuera de alcance (YAGNI)
+## Fuera de alcance (YAGNI — no implementar)
 
 - Tabla catálogo `Genre` y UI de gestión de catálogo.
 - Renombrado/merge masivo de géneros existentes.
 - Traducción de los nombres de género (se guardan como strings tal cual).
+- Restricción de creación por rol o flujo de aprobación de géneros.
+- Cualquier analytics/instrumentación de uso de géneros.
+
+## Verificación manual
+
+- Crear un evento con varios géneros incluyendo uno nuevo (Blues/Reggae).
+- Editar uno existente: su género migrado se ve como chip.
+- Verificar que el género nuevo aparece como sugerencia en el siguiente alta.
+- Verificar que tipear una variante (acentos/case) del género existente NO ofrece crear.
+- Verificar que el filtro público por ese género lista el evento.
 
 ## Flujo de entrega
 
-1. Branch desde `main` actualizado, commits atómicos.
-2. PR contra `main`, esperar CodeRabbit antes de proponer merge.
-3. Correr architecture-reviewer / api-contract-reviewer sobre el diff antes del PR.
-4. Como el PR toca `prisma/schema.prisma`: además de `deploy.sh`, aplicar la
-   migración SQL manual + `prisma db push` contra Neon.
+1. Implementá la tarea cumpliendo los criterios de aceptación. Branch
+   `feat/event-multiple-genres` desde `main` actualizado.
+2. Hacé todos los commits necesarios (atómicos, mensajes descriptivos). No abras PR
+   con trabajo a medio terminar.
+3. Antes de abrir el PR, corré el code review interno con los agentes
+   `architecture-reviewer` y `api-contract-reviewer` sobre el diff, y resolvé lo que
+   marquen.
+4. Recién después abrí el PR contra `main` — lo va a revisar CodeRabbit, así que el
+   mensaje del PR debe ser claro y el diff limpio.
+5. NO hagas merge a `main` sin autorización explícita del dev.
+
+## Nota de deploy (para el dev, ejecutar manualmente — CC no lo hace)
+
+Este PR toca `prisma/schema.prisma`. Además de `deploy.sh`, aplicar la migración SQL
+manual contra Neon + `prisma db push`. Correr `prisma generate` tras `npm ci`.

--- a/prisma/migrations-manual/2026-06-12_event_genre_to_genres_array.sql
+++ b/prisma/migrations-manual/2026-06-12_event_genre_to_genres_array.sql
@@ -41,4 +41,9 @@ BEGIN
   END IF;
 END $$;
 
+-- Índice GIN para el filtro público `genres: { has }` (home / `/events`).
+-- Sin esto la contención sobre text[] es seq scan. `db push` debería
+-- reportar "Already in sync" porque el schema declara @@index([genres], Gin).
+CREATE INDEX IF NOT EXISTS "Event_genres_idx" ON "Event" USING GIN ("genres");
+
 COMMIT;

--- a/prisma/migrations-manual/2026-06-12_event_genre_to_genres_array.sql
+++ b/prisma/migrations-manual/2026-06-12_event_genre_to_genres_array.sql
@@ -1,0 +1,44 @@
+-- Aplicar a la DB ANTES del `prisma db push` del deploy de
+-- `feat/event-multiple-genres`.
+--
+-- Local: psql "$DATABASE_URL" -f prisma/migrations-manual/2026-06-12_event_genre_to_genres_array.sql
+-- Prod:  backup primero, después misma cosa apuntando a la URL de producción.
+--
+-- CONTEXTO
+-- Hasta este PR un evento tenía UN solo género (`Event.genre TEXT NULL`).
+-- Ahora puede tener varios: la columna pasa a `Event.genres TEXT[]`. Este
+-- cambio TRANSFORMA datos (backfill del valor único al array) y DROPEA la
+-- columna vieja, así que no se puede delegar a `db push` — va por acá.
+--
+-- ORDEN (seguro contra pérdida de datos):
+--   1. ADD `genres` con default `'{}'` (no-bloqueante para esta tabla).
+--   2. Backfill: cada evento con `genre` no nulo arranca con `[genre]`.
+--   3. DROP de la columna `genre` vieja (al final, ya backfilleada).
+--
+-- Tras correr esto, `prisma db push` debería reportar "Already in sync"
+-- (el schema ya declara `genres String[]` y ya no tiene `genre`).
+--
+-- Idempotente: ADD IF NOT EXISTS es no-op si ya existe; el bloque de
+-- backfill+drop solo corre mientras la columna `genre` siga presente, así
+-- que re-ejecutar el script no rompe nada.
+
+BEGIN;
+
+ALTER TABLE "Event" ADD COLUMN IF NOT EXISTS "genres" TEXT[] NOT NULL DEFAULT '{}';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'Event' AND column_name = 'genre'
+  ) THEN
+    UPDATE "Event"
+    SET "genres" = ARRAY["genre"]
+    WHERE "genre" IS NOT NULL
+      AND ("genres" IS NULL OR cardinality("genres") = 0);
+
+    ALTER TABLE "Event" DROP COLUMN "genre";
+  END IF;
+END $$;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,11 @@ model Event {
   artist      Artist?     @relation(fields: [artistId], references: [id])
   dates       EventDate[]
   images      Image[]
+
+  // GIN para el filtro público por género (`genres: { has }`), camino
+  // caliente en home / `/events`. Sin esto la contención sobre text[] es
+  // seq scan. Ver migración manual 2026-06-12.
+  @@index([genres], type: Gin)
 }
 
 model EventDate {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,7 @@ model Event {
   location    String
   address     String?
   organizer   String?
-  genre       String?
+  genres      String[]
   time        String?
   price       String?
   isActive    Boolean     @default(true)

--- a/src/app/[locale]/(admin)/admin/events/page.tsx
+++ b/src/app/[locale]/(admin)/admin/events/page.tsx
@@ -72,7 +72,15 @@ export default function AdminEventsPage() {
           {events.map((event) => (
             <TableRow key={event.id}>
               <TableCell className="font-medium">{event.title}</TableCell>
-              <TableCell>{event.genre && <Badge variant="outline">{event.genre}</Badge>}</TableCell>
+              <TableCell>
+                <div className="flex flex-wrap gap-1">
+                  {event.genres.map((genre) => (
+                    <Badge key={genre} variant="outline">
+                      {genre}
+                    </Badge>
+                  ))}
+                </div>
+              </TableCell>
               <TableCell className="text-sm text-muted-foreground">{event.artistName}</TableCell>
               <TableCell>
                 <div className="flex gap-2">

--- a/src/app/[locale]/(protected)/dashboard/events/[id]/edit/page.tsx
+++ b/src/app/[locale]/(protected)/dashboard/events/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server"
 import { notFound, redirect } from "next/navigation"
 import { requireActive, canEditEvent } from "@/services/auth"
 import { getArtistsByUser } from "@/services/artists"
+import { getGenreSuggestions } from "@/services/events"
 import { prisma } from "@/lib/prisma"
 import { EventForm } from "@/components/events/EventForm"
 import Eyebrow from "@/components/ui/Eyebrow"
@@ -18,7 +19,7 @@ export default async function EditEventPage({
   const canEdit = await canEditEvent(id)
   if (!canEdit) redirect(`/${locale}/dashboard`)
 
-  const [event, userArtists] = await Promise.all([
+  const [event, userArtists, genreSuggestions] = await Promise.all([
     prisma.event.findUnique({
       where: { id, isDeleted: false },
       include: {
@@ -27,6 +28,7 @@ export default async function EditEventPage({
       },
     }),
     getArtistsByUser(user.id),
+    getGenreSuggestions(),
   ])
 
   if (!event) notFound()
@@ -43,7 +45,7 @@ export default async function EditEventPage({
     city,
     address: event.address ?? "",
     organizer: event.organizer ?? "",
-    genre: event.genre ?? "",
+    genres: event.genres,
     time: event.time ?? "",
     price: event.price ?? "",
     artistId: event.artistId ?? "",
@@ -63,6 +65,7 @@ export default async function EditEventPage({
         eventId={id}
         defaultValues={defaultValues}
         artists={userArtists.map((a) => ({ id: a.id, name: a.name }))}
+        genreSuggestions={genreSuggestions}
       />
     </div>
   )

--- a/src/app/[locale]/(protected)/dashboard/events/create/page.tsx
+++ b/src/app/[locale]/(protected)/dashboard/events/create/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server"
 import { requireRole } from "@/services/auth"
 import { getArtistsByUser } from "@/services/artists"
+import { getGenreSuggestions } from "@/services/events"
 import { EventForm } from "@/components/events/EventForm"
 import Eyebrow from "@/components/ui/Eyebrow"
 
@@ -12,7 +13,10 @@ export default async function CreateEventPage({
   const { locale } = await params
   const user = await requireRole("creator", locale)
   const t = await getTranslations({ locale, namespace: "eventForm.create" })
-  const artists = await getArtistsByUser(user.id)
+  const [artists, genreSuggestions] = await Promise.all([
+    getArtistsByUser(user.id),
+    getGenreSuggestions(),
+  ])
 
   return (
     <div className="flex flex-col gap-xl">
@@ -22,7 +26,10 @@ export default async function CreateEventPage({
           {t("title")}
         </h1>
       </header>
-      <EventForm artists={artists.map((a) => ({ id: a.id, name: a.name }))} />
+      <EventForm
+        artists={artists.map((a) => ({ id: a.id, name: a.name }))}
+        genreSuggestions={genreSuggestions}
+      />
     </div>
   )
 }

--- a/src/app/[locale]/(public)/events/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/events/[slug]/page.tsx
@@ -130,8 +130,8 @@ export default async function EventDetailPage({
     ? await getOtherEventsByArtist(event.artist.id, event.id, 3)
     : []
 
-  const accent = genreAccent(event.genre)
-  const chipAccent = accent === "neutral" ? "brand" : accent
+  // El accent visual (flyer fallback) se deriva del primer género del evento.
+  const accent = genreAccent(event.genres[0])
   const fallbackAccent = accent === "neutral" ? "brand" : accent
   const resolvedLocale = locale
 
@@ -241,11 +241,14 @@ export default async function EventDetailPage({
                   {t("eyebrow.live")}
                 </Chip>
               ) : null}
-              {event.genre ? (
-                <Chip accent={chipAccent} active size="s">
-                  {event.genre}
-                </Chip>
-              ) : null}
+              {event.genres.map((genre) => {
+                const a = genreAccent(genre)
+                return (
+                  <Chip key={genre} accent={a === "neutral" ? "brand" : a} active size="s">
+                    {genre}
+                  </Chip>
+                )
+              })}
             </div>
 
             {/* Título + artista vinculado */}

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -9,7 +9,7 @@ const updateSchema = z.object({
   location: z.string().min(1).optional(),
   address: z.string().optional(),
   organizer: z.string().optional(),
-  genre: z.string().optional(),
+  genres: z.array(z.string()).optional(),
   time: z.string().optional(),
   price: z.string().optional(),
   artistId: z.string().optional(),

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -9,7 +9,7 @@ const updateSchema = z.object({
   location: z.string().min(1).optional(),
   address: z.string().optional(),
   organizer: z.string().optional(),
-  genres: z.array(z.string()).optional(),
+  genres: z.array(z.string().trim().min(1)).optional(),
   time: z.string().optional(),
   price: z.string().optional(),
   artistId: z.string().optional(),

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -9,7 +9,7 @@ const createEventSchema = z.object({
   location: z.string().min(1),
   address: z.string().optional(),
   organizer: z.string().optional(),
-  genre: z.string().optional(),
+  genres: z.array(z.string()).optional(),
   time: z.string().optional(),
   price: z.string().optional(),
   artistId: z.string().optional(),

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -9,7 +9,7 @@ const createEventSchema = z.object({
   location: z.string().min(1),
   address: z.string().optional(),
   organizer: z.string().optional(),
-  genres: z.array(z.string()).optional(),
+  genres: z.array(z.string().trim().min(1)).optional(),
   time: z.string().optional(),
   price: z.string().optional(),
   artistId: z.string().optional(),

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -61,7 +61,8 @@ export async function EventCard({
 }: EventCardProps) {
   const resolvedLocale = locale ?? (await getLocale())
   const nextDate = event.dates[0] ?? null
-  const accent = genreAccent(event.genre)
+  // El accent visual de la card se deriva del primer género del evento.
+  const accent = genreAccent(event.genres[0])
   const isFeatured = variant === "featured"
   const isToday = Boolean(todayLabel)
 
@@ -108,11 +109,13 @@ export async function EventCard({
           </div>
         ) : null}
 
-        {event.genre ? (
-          <div className="absolute top-m right-m">
-            <Chip accent={accent} active size="s">
-              {event.genre}
-            </Chip>
+        {event.genres.length > 0 ? (
+          <div className="absolute top-m right-m flex max-w-[70%] flex-wrap justify-end gap-xs">
+            {event.genres.map((genre) => (
+              <Chip key={genre} accent={genreAccent(genre)} active size="s">
+                {genre}
+              </Chip>
+            ))}
           </div>
         ) : null}
       </div>

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -24,7 +24,7 @@
 
 import { useTranslations } from "next-intl"
 import { useParams, useRouter } from "next/navigation"
-import { useForm, useFieldArray } from "react-hook-form"
+import { useForm, useFieldArray, Controller } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
 import { useState } from "react"
@@ -36,6 +36,8 @@ import FormTextarea from "@/components/forms/FormTextarea"
 import FormSelect from "@/components/forms/FormSelect"
 import FormSection from "@/components/forms/FormSection"
 import FormError from "@/components/forms/FormError"
+import { GenreCombobox } from "@/components/events/GenreCombobox"
+import { dedupeGenres } from "@/lib/genres"
 import ImageUploader, {
   type ExistingImage,
   type PendingImage,
@@ -49,7 +51,7 @@ const schema = z.object({
   city: z.string().min(1),
   address: z.string().optional(),
   organizer: z.string().optional(),
-  genre: z.string().optional(),
+  genres: z.array(z.string()),
   time: z.string().optional(),
   price: z.string().optional(),
   artistId: z.string().optional(),
@@ -73,35 +75,23 @@ interface EventFormProps {
     city?: string
     address?: string
     organizer?: string
-    genre?: string
+    genres?: string[]
     time?: string
     price?: string
     artistId?: string
     dates?: string[]
     images?: ExistingImage[]
   }
+  /** Sugerencias para el combobox de género: base curada ∪ géneros usados. */
+  genreSuggestions?: string[]
 }
 
-/** Lista cerrada de géneros — `""` representa "sin género" (default
- * para nuevos eventos sin clasificar). Si se expande, mantener
- * consistente con el filtro de género en `/events`. */
-const GENRES = [
-  "",
-  "Tango",
-  "Salsa",
-  "Cumbia",
-  "Reggaeton",
-  "Merengue",
-  "Son Cubano",
-  "Bossa Nova",
-  "Vallenato",
-  "Flamenco Latino",
-  "Latin Jazz",
-  "Folklore",
-  "Otros",
-]
-
-export function EventForm({ eventId, artists = [], defaultValues }: EventFormProps) {
+export function EventForm({
+  eventId,
+  artists = [],
+  defaultValues,
+  genreSuggestions = [],
+}: EventFormProps) {
   const tCommon = useTranslations("common")
   const tForms = useTranslations("forms")
   const tEvent = useTranslations("eventForm")
@@ -127,7 +117,7 @@ export function EventForm({ eventId, artists = [], defaultValues }: EventFormPro
       city: defaultValues?.city ?? "",
       address: defaultValues?.address ?? "",
       organizer: defaultValues?.organizer ?? "",
-      genre: defaultValues?.genre ?? "",
+      genres: defaultValues?.genres ?? [],
       time: defaultValues?.time ?? "",
       price: defaultValues?.price ?? "",
       artistId: defaultValues?.artistId ?? "",
@@ -153,7 +143,7 @@ export function EventForm({ eventId, artists = [], defaultValues }: EventFormPro
       location,
       address: data.address || undefined,
       organizer: data.organizer,
-      genre: data.genre || undefined,
+      genres: dedupeGenres(data.genres ?? []),
       time: data.time,
       price: data.price,
       artistId: data.artistId || undefined,
@@ -369,28 +359,27 @@ export function EventForm({ eventId, artists = [], defaultValues }: EventFormPro
           />
         </FormField>
 
-        <FormField label={tEvent("fields.genre")} name="event-genre">
-          <FormSelect id="event-genre" {...register("genre")}>
-            {GENRES.map((g) => {
-              // Display label: la mayoría de los géneros son nombres
-              // propios del estilo musical y no se traducen (Tango,
-              // Cumbia, Salsa, etc. se mantienen igual en ES/EN/DE).
-              // La excepción es "Otros" que SÍ varía por locale —
-              // mapeamos el value crudo (que va al DB) al label
-              // traducido solo para ese caso.
-              const label =
-                g === ""
-                  ? tEvent("fields.noGenre")
-                  : g === "Otros"
-                    ? tEvent("fields.genreOther")
-                    : g
-              return (
-                <option key={g} value={g}>
-                  {label}
-                </option>
-              )
-            })}
-          </FormSelect>
+        <FormField
+          label={tEvent("fields.genre")}
+          name="event-genre"
+          helper={tEvent("fields.genreHelper")}
+        >
+          <Controller
+            control={control}
+            name="genres"
+            render={({ field }) => (
+              <GenreCombobox
+                id="event-genre"
+                value={field.value ?? []}
+                onValueChange={field.onChange}
+                suggestions={genreSuggestions}
+                placeholder={tEvent("fields.genrePlaceholder")}
+                createLabel={(v) => tEvent("fields.genreCreate", { value: v })}
+                emptyLabel={tEvent("fields.genreEmpty")}
+                removeLabel={tEvent("fields.removeGenre")}
+              />
+            )}
+          />
         </FormField>
       </FormSection>
 

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -370,13 +370,14 @@ export function EventForm({
             render={({ field }) => (
               <GenreCombobox
                 id="event-genre"
+                aria-describedby="event-genre-helper"
                 value={field.value ?? []}
                 onValueChange={field.onChange}
                 suggestions={genreSuggestions}
                 placeholder={tEvent("fields.genrePlaceholder")}
                 createLabel={(v) => tEvent("fields.genreCreate", { value: v })}
                 emptyLabel={tEvent("fields.genreEmpty")}
-                removeLabel={tEvent("fields.removeGenre")}
+                removeLabel={(g) => tEvent("fields.removeGenre", { genre: g })}
               />
             )}
           />

--- a/src/components/events/EventRow.tsx
+++ b/src/components/events/EventRow.tsx
@@ -64,7 +64,8 @@ export async function EventRow({
 }: EventRowProps) {
   const resolvedLocale = locale ?? (await getLocale())
   const nextDate = event.dates[0] ?? null
-  const accent = genreAccent(event.genre)
+  // El accent visual de la row se deriva del primer género del evento.
+  const accent = genreAccent(event.genres[0])
 
   const subtitle = [event.location, event.time].filter(Boolean).join(" · ")
 
@@ -107,11 +108,13 @@ export async function EventRow({
     <p className="text-body-s text-fg-secondary line-clamp-1">{subtitle}</p>
   ) : null
 
-  const genreChip = event.genre ? (
-    <div className="shrink-0 hidden md:block">
-      <Chip accent={accent} active size="s">
-        {event.genre}
-      </Chip>
+  const genreChip = event.genres.length > 0 ? (
+    <div className="shrink-0 hidden md:flex flex-wrap justify-end gap-xs">
+      {event.genres.map((genre) => (
+        <Chip key={genre} accent={genreAccent(genre)} active size="s">
+          {genre}
+        </Chip>
+      ))}
     </div>
   ) : null
 

--- a/src/components/events/GenreCombobox.tsx
+++ b/src/components/events/GenreCombobox.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+/**
+ * GenreCombobox — multi-select de géneros con creación al vuelo.
+ *
+ * Por qué un componente nuevo y no `FormSelect`: el propio `FormSelect`
+ * documenta que multiselect/búsqueda van en un componente aparte. Este lo
+ * cubre sobre el Combobox de Base UI (chips removibles + lista filtrable +
+ * crear).
+ *
+ * Comportamiento clave (ver spec `2026-06-12-event-multiple-genres`):
+ *  - Las sugerencias salen de `suggestions` (base curada ∪ géneros usados),
+ *    pasadas desde el server.
+ *  - El filtrado es NORMALIZADO (case + acentos vía `normalizeGenre`): tipear
+ *    "regae" matchea "Reggae" y NO ofrece "+ crear", suprimiendo duplicados
+ *    semánticos.
+ *  - La opción "crear «X»" solo aparece cuando lo tipeado no matchea ninguna
+ *    sugerencia ni un género ya seleccionado (comparando normalizado).
+ *  - El valor del form es `string[]`; este componente es controlado.
+ *
+ * Sin dependencias nuevas: Base UI ya está en el proyecto.
+ */
+
+import * as React from "react"
+import { Combobox } from "@base-ui/react/combobox"
+import { Check, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { normalizeGenre } from "@/lib/genres"
+
+export interface GenreComboboxProps {
+  /** Debe coincidir con el `name` del `FormField` para asociar el label. */
+  id?: string
+  value: string[]
+  onValueChange: (value: string[]) => void
+  suggestions: string[]
+  placeholder?: string
+  /** Label del item "crear" — recibe el texto tipeado, ej. `Crear «{value}»`. */
+  createLabel: (value: string) => string
+  /** Texto cuando no hay coincidencias ni opción de crear. */
+  emptyLabel: string
+  /** aria-label para el botón de quitar cada chip. */
+  removeLabel: string
+  "aria-invalid"?: boolean
+}
+
+export function GenreCombobox({
+  id,
+  value,
+  onValueChange,
+  suggestions,
+  placeholder,
+  createLabel,
+  emptyLabel,
+  removeLabel,
+  "aria-invalid": ariaInvalid,
+}: GenreComboboxProps) {
+  const [inputValue, setInputValue] = React.useState("")
+
+  // El texto a "crear": null si está vacío o si ya existe (normalizado) entre
+  // las sugerencias o lo ya seleccionado. Si no, la grafía cruda tipeada.
+  const createValue = React.useMemo(() => {
+    const trimmed = inputValue.trim()
+    if (!trimmed) return null
+    const key = normalizeGenre(trimmed)
+    const selected = new Set(value.map(normalizeGenre))
+    const exists = selected.has(key) || suggestions.some((s) => normalizeGenre(s) === key)
+    return exists ? null : trimmed
+  }, [inputValue, value, suggestions])
+
+  // Items del dropdown: sugerencias no seleccionadas que matchean (substring
+  // normalizado) + la opción de crear al final si corresponde. Filtramos
+  // nosotros y desactivamos el filtro interno (`filter={null}`).
+  const items = React.useMemo(() => {
+    const q = normalizeGenre(inputValue)
+    const selected = new Set(value.map(normalizeGenre))
+    const matches = suggestions.filter(
+      (s) => !selected.has(normalizeGenre(s)) && (q === "" || normalizeGenre(s).includes(q))
+    )
+    return createValue ? [...matches, createValue] : matches
+  }, [inputValue, value, suggestions, createValue])
+
+  return (
+    <Combobox.Root
+      multiple
+      items={items}
+      value={value}
+      onValueChange={(next) => {
+        onValueChange(next as string[])
+        setInputValue("")
+      }}
+      inputValue={inputValue}
+      onInputValueChange={setInputValue}
+      filter={null}
+    >
+      <Combobox.Chips
+        className={cn(
+          "flex min-h-10 w-full flex-wrap items-center gap-xs rounded-m bg-bg-surface-2 px-s py-1.5",
+          "border border-border text-body transition-colors",
+          "focus-within:border-brand focus-within:ring-2 focus-within:ring-brand/30",
+          ariaInvalid &&
+            "border-status-danger ring-2 ring-status-danger/30 focus-within:border-status-danger"
+        )}
+      >
+        <Combobox.Value>
+          {(selected: string[]) =>
+            selected.map((genre) => (
+              <Combobox.Chip
+                key={genre}
+                aria-label={genre}
+                className="inline-flex items-center gap-1 rounded-full bg-bg-surface px-s py-0.5 text-eyebrow text-fg-primary"
+              >
+                {genre}
+                <Combobox.ChipRemove
+                  aria-label={removeLabel}
+                  className="inline-flex items-center justify-center rounded-full text-fg-secondary transition-colors hover:text-status-danger"
+                >
+                  <X className="size-3" aria-hidden={true} />
+                </Combobox.ChipRemove>
+              </Combobox.Chip>
+            ))
+          }
+        </Combobox.Value>
+        <Combobox.Input
+          id={id}
+          aria-invalid={ariaInvalid}
+          placeholder={value.length === 0 ? placeholder : undefined}
+          className="min-w-[8ch] flex-1 bg-transparent text-body text-fg-primary outline-none placeholder:text-fg-tertiary"
+        />
+      </Combobox.Chips>
+
+      <Combobox.Portal>
+        <Combobox.Positioner sideOffset={4} className="z-50">
+          <Combobox.Popup className="max-h-60 w-(--anchor-width) overflow-y-auto rounded-m border border-border bg-bg-surface p-1 shadow-md">
+            <Combobox.Empty className="px-s py-1.5 text-body text-fg-tertiary">
+              {emptyLabel}
+            </Combobox.Empty>
+            <Combobox.List>
+              {(item: string) => (
+                <Combobox.Item
+                  key={item}
+                  value={item}
+                  className={cn(
+                    "flex cursor-pointer items-center justify-between gap-2 rounded-s px-s py-1.5",
+                    "text-body text-fg-primary outline-none",
+                    "data-highlighted:bg-bg-surface-2 data-selected:text-brand"
+                  )}
+                >
+                  <span>{createValue === item ? createLabel(item) : item}</span>
+                  <Combobox.ItemIndicator>
+                    <Check className="size-4 text-brand" aria-hidden={true} />
+                  </Combobox.ItemIndicator>
+                </Combobox.Item>
+              )}
+            </Combobox.List>
+          </Combobox.Popup>
+        </Combobox.Positioner>
+      </Combobox.Portal>
+    </Combobox.Root>
+  )
+}

--- a/src/components/events/GenreCombobox.tsx
+++ b/src/components/events/GenreCombobox.tsx
@@ -38,8 +38,11 @@ export interface GenreComboboxProps {
   createLabel: (value: string) => string
   /** Texto cuando no hay coincidencias ni opción de crear. */
   emptyLabel: string
-  /** aria-label para el botón de quitar cada chip. */
-  removeLabel: string
+  /** aria-label del botón de quitar — recibe el género para distinguir cada
+   * chip ante un lector de pantalla, ej. `Quitar Tango`. */
+  removeLabel: (genre: string) => string
+  /** ID del helper text para asociarlo al input vía aria-describedby. */
+  "aria-describedby"?: string
   "aria-invalid"?: boolean
 }
 
@@ -52,6 +55,7 @@ export function GenreCombobox({
   createLabel,
   emptyLabel,
   removeLabel,
+  "aria-describedby": ariaDescribedby,
   "aria-invalid": ariaInvalid,
 }: GenreComboboxProps) {
   const [inputValue, setInputValue] = React.useState("")
@@ -107,11 +111,11 @@ export function GenreCombobox({
               <Combobox.Chip
                 key={genre}
                 aria-label={genre}
-                className="inline-flex items-center gap-1 rounded-full bg-bg-surface px-s py-0.5 text-eyebrow text-fg-primary"
+                className="inline-flex items-center gap-1 rounded-full bg-bg-surface px-s py-0.5 text-caption text-fg-primary"
               >
                 {genre}
                 <Combobox.ChipRemove
-                  aria-label={removeLabel}
+                  aria-label={removeLabel(genre)}
                   className="inline-flex items-center justify-center rounded-full text-fg-secondary transition-colors hover:text-status-danger"
                 >
                   <X className="size-3" aria-hidden={true} />
@@ -122,6 +126,7 @@ export function GenreCombobox({
         </Combobox.Value>
         <Combobox.Input
           id={id}
+          aria-describedby={ariaDescribedby}
           aria-invalid={ariaInvalid}
           placeholder={value.length === 0 ? placeholder : undefined}
           className="min-w-[8ch] flex-1 bg-transparent text-body text-fg-primary outline-none placeholder:text-fg-tertiary"

--- a/src/lib/genres.test.ts
+++ b/src/lib/genres.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import { normalizeGenre, dedupeGenres, mergeGenreSuggestions, BASE_GENRES } from "./genres"
+
+describe("normalizeGenre", () => {
+  it("lowercases", () => {
+    expect(normalizeGenre("REGGAE")).toBe("reggae")
+  })
+
+  it("strips diacritics", () => {
+    expect(normalizeGenre("Réggae")).toBe("reggae")
+    expect(normalizeGenre("Folclóre")).toBe("folclore")
+  })
+
+  it("collapses internal whitespace and trims", () => {
+    expect(normalizeGenre("  Latin   Jazz  ")).toBe("latin jazz")
+  })
+
+  it("treats case/accent variants as equal", () => {
+    expect(normalizeGenre("Reggae")).toBe(normalizeGenre("réggae"))
+  })
+})
+
+describe("dedupeGenres", () => {
+  it("trims each value", () => {
+    expect(dedupeGenres(["  Blues  "])).toEqual(["Blues"])
+  })
+
+  it("drops empty / whitespace-only entries", () => {
+    expect(dedupeGenres(["", "   ", "Blues"])).toEqual(["Blues"])
+  })
+
+  it("dedupes case/accent-insensitive keeping the first spelling", () => {
+    expect(dedupeGenres(["Reggae", "reggae", "RÉGGAE"])).toEqual(["Reggae"])
+  })
+
+  it("preserves order of survivors", () => {
+    expect(dedupeGenres(["Latin Pop", "Blues", "Reggae"])).toEqual([
+      "Latin Pop",
+      "Blues",
+      "Reggae",
+    ])
+  })
+
+  it("returns empty array for all-empty input", () => {
+    expect(dedupeGenres(["", "  "])).toEqual([])
+  })
+})
+
+describe("mergeGenreSuggestions", () => {
+  it("includes the curated base list", () => {
+    const result = mergeGenreSuggestions([])
+    for (const g of BASE_GENRES) {
+      expect(result).toContain(g)
+    }
+  })
+
+  it("adds used genres not present in the base", () => {
+    expect(mergeGenreSuggestions(["Blues"])).toContain("Blues")
+  })
+
+  it("does not duplicate a used genre that matches the base (case/accent-insensitive)", () => {
+    const result = mergeGenreSuggestions(["tango", "TANGO"])
+    expect(result.filter((g) => normalizeGenre(g) === "tango")).toEqual(["Tango"])
+  })
+
+  it("sorts alphabetically (accent-insensitive)", () => {
+    const result = mergeGenreSuggestions(["Ámbar", "zamba"])
+    const sorted = [...result].sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" })
+    )
+    expect(result).toEqual(sorted)
+  })
+})

--- a/src/lib/genres.ts
+++ b/src/lib/genres.ts
@@ -1,0 +1,71 @@
+/**
+ * Utilidades de géneros de evento.
+ *
+ * Los géneros son strings libres (no enum, no tabla catálogo). Para empujar
+ * reutilización y minimizar duplicados semánticos ("Reggae" vs "reggae" vs
+ * "Réggae"), todo el matcheo y la deduplicación se hacen sobre una forma
+ * NORMALIZADA: minúsculas, sin acentos y con whitespace colapsado. La grafía
+ * que se guarda/muestra es siempre la primera tal cual la tipeó el usuario.
+ */
+
+/** Lista curada base — semilla de sugerencias del combobox de género. El
+ * catálogo "crece solo": las sugerencias reales son esta base unida a los
+ * géneros ya usados en eventos. Mantener consistente con `genreAccent`. */
+export const BASE_GENRES = [
+  "Tango",
+  "Salsa",
+  "Cumbia",
+  "Reggaeton",
+  "Merengue",
+  "Son Cubano",
+  "Bossa Nova",
+  "Vallenato",
+  "Flamenco Latino",
+  "Latin Jazz",
+  "Folklore",
+] as const
+
+/**
+ * Forma canónica para comparar dos géneros: minúsculas, sin diacríticos y
+ * con el whitespace interno colapsado. NO es la forma que se guarda — solo
+ * sirve para igualar/matchear. "Réggae ", "REGGAE", "reggae" → "reggae".
+ */
+export function normalizeGenre(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+/**
+ * Limpia una lista de géneros para persistir: hace `trim`, descarta vacíos y
+ * deduplica case/acento-insensitive conservando la PRIMERA grafía ingresada.
+ * El orden relativo de los que sobreviven se mantiene.
+ */
+export function dedupeGenres(genres: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of genres) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    const key = normalizeGenre(trimmed)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    result.push(trimmed)
+  }
+  return result
+}
+
+/**
+ * Construye la lista de sugerencias para el form: une la base curada con los
+ * géneros ya usados en eventos, deduplica (case/acento-insensitive) y ordena
+ * alfabéticamente con `localeCompare` (acentos/locale-aware). Ante un choque
+ * normalizado entre base y usado, gana la grafía de la base (se procesa primero).
+ */
+export function mergeGenreSuggestions(usedGenres: string[]): string[] {
+  return dedupeGenres([...BASE_GENRES, ...usedGenres]).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: "base" })
+  )
+}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -175,8 +175,11 @@
       "price": "Preis oder Zugangsmodus",
       "pricePlaceholder": "€10 · Spendenbasiert · Eintritt frei",
       "genre": "Genre",
-      "noGenre": "— Kein Genre —",
-      "genreOther": "Andere"
+      "genreHelper": "Wähle eines oder mehrere. Fehlt es, tippe es ein, um es anzulegen.",
+      "genrePlaceholder": "Genres hinzufügen oder auswählen…",
+      "genreCreate": "„{value}“ erstellen",
+      "genreEmpty": "Keine Treffer",
+      "removeGenre": "Dieses Genre entfernen"
     }
   },
   "artistForm": {

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -179,7 +179,7 @@
       "genrePlaceholder": "Genres hinzufügen oder auswählen…",
       "genreCreate": "„{value}“ erstellen",
       "genreEmpty": "Keine Treffer",
-      "removeGenre": "Dieses Genre entfernen"
+      "removeGenre": "{genre} entfernen"
     }
   },
   "artistForm": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -179,7 +179,7 @@
       "genrePlaceholder": "Add or pick genres…",
       "genreCreate": "Create “{value}”",
       "genreEmpty": "No matches",
-      "removeGenre": "Remove this genre"
+      "removeGenre": "Remove {genre}"
     }
   },
   "artistForm": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -175,8 +175,11 @@
       "price": "Price or access mode",
       "pricePlaceholder": "€10 · Donation-based · Free entry",
       "genre": "Genre",
-      "noGenre": "— No genre —",
-      "genreOther": "Other"
+      "genreHelper": "Pick one or more. If it's not listed, type it to create it.",
+      "genrePlaceholder": "Add or pick genres…",
+      "genreCreate": "Create “{value}”",
+      "genreEmpty": "No matches",
+      "removeGenre": "Remove this genre"
     }
   },
   "artistForm": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -179,7 +179,7 @@
       "genrePlaceholder": "Agregá o elegí géneros…",
       "genreCreate": "Crear «{value}»",
       "genreEmpty": "Sin coincidencias",
-      "removeGenre": "Quitar este género"
+      "removeGenre": "Quitar {genre}"
     }
   },
   "artistForm": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -175,8 +175,11 @@
       "price": "Precio o modo",
       "pricePlaceholder": "€10 · Aporte voluntario · Entrada libre",
       "genre": "Género",
-      "noGenre": "— Sin género —",
-      "genreOther": "Otros"
+      "genreHelper": "Elegí uno o varios. Si no está en la lista, escribilo y crealo.",
+      "genrePlaceholder": "Agregá o elegí géneros…",
+      "genreCreate": "Crear «{value}»",
+      "genreEmpty": "Sin coincidencias",
+      "removeGenre": "Quitar este género"
     }
   },
   "artistForm": {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -5,6 +5,7 @@ import { unstable_cache, revalidateTag } from "next/cache"
 import { prisma } from "@/lib/prisma"
 import { rehydrateDate, rehydrateDates, startOfTodayBerlin } from "@/lib/date"
 import { generateUniqueSlug } from "@/lib/slugify"
+import { dedupeGenres, mergeGenreSuggestions } from "@/lib/genres"
 import { deleteImages } from "./cloudinary"
 
 /**
@@ -21,7 +22,7 @@ export interface EventSummary {
   title: string
   slug: string
   location: string
-  genre: string | null
+  genres: string[]
   time: string | null
   price: string | null
   dates: Date[]
@@ -57,7 +58,7 @@ export interface CreateEventInput {
   location: string
   address?: string
   organizer?: string
-  genre?: string
+  genres?: string[]
   time?: string
   price?: string
   artistId?: string
@@ -71,7 +72,7 @@ export interface UpdateEventInput {
   location?: string
   address?: string
   organizer?: string
-  genre?: string
+  genres?: string[]
   time?: string
   price?: string
   artistId?: string | null
@@ -87,7 +88,7 @@ export function mapToSummary(event: {
   title: string
   slug: string
   location: string
-  genre: string | null
+  genres: string[]
   time: string | null
   price: string | null
   dates: { date: Date }[]
@@ -100,7 +101,7 @@ export function mapToSummary(event: {
     title: event.title,
     slug: event.slug,
     location: event.location,
-    genre: event.genre,
+    genres: event.genres,
     time: event.time,
     price: event.price,
     dates: event.dates.map((d: { date: Date }) => d.date),
@@ -333,7 +334,7 @@ const _getUpcomingEvents = unstable_cache(
         isDeleted: false,
         isActive: true,
         dates: { some: { date: { gte: today } } },
-        ...(filters?.genre ? { genre: filters.genre } : {}),
+        ...(filters?.genre ? { genres: { has: filters.genre } } : {}),
         ...(filters?.city ? { location: { contains: filters.city, mode: "insensitive" } } : {}),
       },
       include: eventInclude,
@@ -427,7 +428,7 @@ async function _getEventBySlugImpl(slug: string): Promise<EventDetail | null> {
     title: event.title,
     slug: event.slug,
     location: event.location,
-    genre: event.genre,
+    genres: event.genres,
     dates: event.dates.map((d: { date: Date }) => d.date),
     artistName: event.artist?.name ?? null,
     coverImage: cover?.url ?? null,
@@ -447,22 +448,45 @@ async function _getEventBySlugImpl(slug: string): Promise<EventDetail | null> {
   }
 }
 
+/**
+ * Géneros que aparecen en al menos un evento activo con fecha futura. Usado
+ * por los filtros públicos (pills de home / `/events`). Como `genres` es un
+ * array, no se puede `distinct` en SQL sobre los elementos: traemos los arrays
+ * y los aplanamos + deduplicamos (case/acento-insensitive) + ordenamos en
+ * memoria. El dataset es chico; no justifica un `unnest` crudo.
+ */
 export const getActiveGenres = unstable_cache(
   async (): Promise<string[]> => {
     const rows = await prisma.event.findMany({
       where: {
         isDeleted: false,
         isActive: true,
-        genre: { not: null },
         dates: { some: { date: { gte: startOfTodayBerlin() } } },
       },
-      select: { genre: true },
-      distinct: ["genre"],
-      orderBy: { genre: "asc" },
+      select: { genres: true },
     })
-    return rows.map((r) => r.genre as string)
+    return dedupeGenres(rows.flatMap((r) => r.genres)).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" })
+    )
   },
   ["active-genres"],
+  { revalidate: 300, tags: ["events"] }
+)
+
+/**
+ * Sugerencias de género para el form de evento: la lista curada base unida a
+ * TODOS los géneros ya usados en eventos no borrados (incluye pasados y
+ * borradores, para que un género tipeado una vez quede disponible siempre).
+ */
+export const getGenreSuggestions = unstable_cache(
+  async (): Promise<string[]> => {
+    const rows = await prisma.event.findMany({
+      where: { isDeleted: false },
+      select: { genres: true },
+    })
+    return mergeGenreSuggestions(rows.flatMap((r) => r.genres))
+  },
+  ["genre-suggestions"],
   { revalidate: 300, tags: ["events"] }
 )
 
@@ -692,7 +716,7 @@ export async function createEvent(
         location: data.location,
         address: data.address,
         organizer: data.organizer,
-        genre: data.genre,
+        genres: dedupeGenres(data.genres ?? []),
         time: data.time,
         price: data.price,
         artistId: data.artistId,
@@ -739,11 +763,12 @@ export async function updateEvent(id: string, data: UpdateEventInput): Promise<v
   }
 
   // Update event fields
-  const { keepImageIds: _k, newImages: _n, dates, ...fields } = data
+  const { keepImageIds: _k, newImages: _n, dates, genres, ...fields } = data
   await prisma.event.update({
     where: { id },
     data: {
       ...fields,
+      ...(genres !== undefined ? { genres: dedupeGenres(genres) } : {}),
       ...(dates?.length
         ? {
             dates: {


### PR DESCRIPTION
## Qué

Un evento ahora puede tener **varios géneros** y, si un género no existe, se puede **crear al vuelo** desde el form. Reemplaza `Event.genre` (string único + `<select>`) por `Event.genres String[]` con un combobox multi-select creatable.

Disparador: cargar un evento cuyo género es "Fusión Multicultural: Latin Pop, Blues, Reggae" — tres géneros, dos fuera de la lista curada.

Spec: `docs/superpowers/specs/2026-06-12-event-multiple-genres-design.md`.

## Cambios

- **Modelo**: `Event.genre String?` → `genres String[]` + índice GIN (`@@index([genres], type: Gin)`) para el filtro público.
- **Migración manual** (`prisma/migrations-manual/2026-06-12_…sql`): transaccional e idempotente, backfilea el género único al array **antes** de dropear la columna vieja, y crea el índice GIN. Ya aplicada en la DB de dev (9/9 eventos preservados).
- **Lib pura** `src/lib/genres.ts` (+ 13 tests): `normalizeGenre` (case + acentos), `dedupeGenres` (conserva primera grafía), `mergeGenreSuggestions`.
- **Combobox** `GenreCombobox` sobre Base UI: chips removibles, filtrado **normalizado** (tipear "regae" sugiere "Reggae" y **no** ofrece crear), opción "crear «X»" solo si no hay match.
- **Servicios/API**: filtro `genres:{has}`, `getGenreSuggestions`, zod `genre` → `genres` array, create/update normalizan con `dedupeGenres`.
- **Display**: N badges en card, row, detalle público y admin.
- **i18n** es/en/de: quita `noGenre`/`genreOther`, agrega claves del combobox.

## Verificación

- `tsc --noEmit` sin errores · `vitest` 13/13 · `eslint` limpio · `prisma validate` OK · **`next build` verde** (Node 22.13.1).
- Migración aplicada y verificada en dev: backfill correcto, índice GIN presente, `has('Folklore')` → 5.
- Review interno (architecture / api-contract / design-system / a11y): hallazgos de alto valor aplicados (a11y del aria-label de quitar + helper asociado; `text-caption` en el chip; índice GIN). Resto diferido con criterio.

## Deploy (manual, NO en este PR)

El PR toca `prisma/schema.prisma`. Además de `deploy.sh`, en **producción** hay que aplicar la migración SQL manual contra Neon + `prisma db push` + `prisma generate`. La migración dropea la columna `genre` (backfilea primero).

## Notas

- Los 2 eventos con el viejo sentinel "Otros" quedaron como `genres = ['Otros']` (género literal). Limpieza opcional aparte.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Events now support multiple genres; multi-select combobox with creatable suggestions and removable chips
  * Genre suggestions merged from base list and used genres

* **Improvements**
  * Multiple genre badges shown across the app
  * Case- and diacritic-insensitive normalization and deduplication of genres
  * Improved filtering/search by genre membership

* **Chores**
  * Database migration script to backfill and index genres

* **Tests**
  * Unit tests covering normalization, dedupe, and suggestion logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->