### PR TITLE
feat(legal): sección Umami en Datenschutz (es/en/de)

### DIFF
--- a/src/app/[locale]/(public)/datenschutz/page.tsx
+++ b/src/app/[locale]/(public)/datenschutz/page.tsx
@@ -7,8 +7,10 @@
  * (datos compartidos en `@/components/legal/legal-data`).
  *
  * Terceros declarados: Cloudinary (imágenes), Resend (emails), Neon
- * (base de datos). El sitio NO usa Google OAuth ni analytics/tracking,
- * así que no se declaran.
+ * (base de datos). Analytics: Umami self-hosted (sección propia, NO va
+ * en processors — los datos no salen de nuestro servidor). Es cookieless,
+ * así que la sección de cookies sigue siendo exacta. El sitio NO usa
+ * Google OAuth.
  *
  * Server component estático.
  */
@@ -128,6 +130,10 @@ export default async function DatenschutzPage({
 
       <LegalSection heading={t("cookiesHeading")}>
         <p>{t("cookiesBody")}</p>
+      </LegalSection>
+
+      <LegalSection heading={t("analyticsHeading")}>
+        <p>{t("analyticsBody")}</p>
       </LegalSection>
 
       <LegalSection heading={t("rightsHeading")}>

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -792,6 +792,8 @@
     "processorsNeon": "Neon — gehostete PostgreSQL-Datenbank, in der die Anwendungsdaten gespeichert werden. <link>Datenschutzerklärung von Neon</link>.",
     "cookiesHeading": "Cookies",
     "cookiesBody": "Diese Website verwendet ausschließlich technisch notwendige Cookies: ein Cookie für deine angemeldete Sitzung (Better Auth) und ein Cookie für deine Sprachpräferenz (NEXT_LOCALE). Wir setzen keine Analyse-, Tracking- oder Marketing-Cookies ein. Da nur technisch notwendige Cookies verwendet werden, ist hierfür keine Einwilligung erforderlich (§ 25 Abs. 2 TDDDG).",
+    "analyticsHeading": "Webanalyse (Umami)",
+    "analyticsBody": "Zur Reichweitenmessung nutzen wir die Open-Source-Software Umami, die wir selbst auf unserem eigenen Server innerhalb der Europäischen Union betreiben. Umami arbeitet ohne Cookies und erstellt keine personenbezogenen Profile: Erfasst werden ausschließlich aggregierte Informationen wie aufgerufene Seiten, Referrer, Browser- und Gerätetyp sowie das Herkunftsland. IP-Adressen werden nicht gespeichert. Die Daten verlassen unseren Server nicht und werden nicht an Dritte weitergegeben. Rechtsgrundlage ist unser berechtigtes Interesse an der statistischen Analyse und Verbesserung unseres Angebots (Art. 6 Abs. 1 lit. f DSGVO).",
     "rightsHeading": "Deine Rechte",
     "rightsIntro": "Dir stehen nach der DSGVO jederzeit folgende Rechte bezüglich deiner personenbezogenen Daten zu:",
     "rightAccess": "Recht auf Auskunft über die zu deiner Person gespeicherten Daten.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -792,6 +792,8 @@
     "processorsNeon": "Neon — managed PostgreSQL database where the application data is stored. <link>Neon privacy policy</link>.",
     "cookiesHeading": "Cookies",
     "cookiesBody": "This website uses exclusively technically necessary cookies: a cookie for your signed-in session (Better Auth) and a cookie for your language preference (NEXT_LOCALE). We do not use analytics, tracking or marketing cookies. As only technically necessary cookies are used, no consent is required for them.",
+    "analyticsHeading": "Web analytics (Umami)",
+    "analyticsBody": "To measure how the site is used, we run Umami, an open-source analytics tool self-hosted on our own server within the European Union. Umami works without cookies and builds no personal profiles: it only collects aggregated information such as pages visited, referrer, browser and device type, and country. IP addresses are not stored. The data never leaves our server and is not shared with third parties. The legal basis is our legitimate interest in the statistical analysis and improvement of the site (Art. 6(1)(f) GDPR).",
     "rightsHeading": "Your rights",
     "rightsIntro": "Under the GDPR, you have the following rights regarding your personal data at any time:",
     "rightAccess": "Right of access to the data stored about you.",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -792,6 +792,8 @@
     "processorsNeon": "Neon — base de datos PostgreSQL gestionada donde se almacenan los datos de la aplicación. <link>Política de privacidad de Neon</link>.",
     "cookiesHeading": "Cookies",
     "cookiesBody": "Este sitio usa exclusivamente cookies técnicamente necesarias: una cookie para tu sesión iniciada (Better Auth) y una cookie para tu preferencia de idioma (NEXT_LOCALE). No usamos cookies de análisis, seguimiento ni marketing. Como solo se usan cookies técnicamente necesarias, no se requiere consentimiento para ello.",
+    "analyticsHeading": "Análisis web (Umami)",
+    "analyticsBody": "Para medir el uso del sitio utilizamos Umami, un software de código abierto que alojamos en nuestro propio servidor dentro de la Unión Europea. Umami funciona sin cookies y no crea perfiles personales: solo recoge información agregada como páginas visitadas, página de origen (referrer), tipo de navegador y dispositivo, y país. No se almacenan direcciones IP. Los datos no salen de nuestro servidor ni se comparten con terceros. La base jurídica es nuestro interés legítimo en el análisis estadístico y la mejora del sitio (art. 6.1.f RGPD).",
     "rightsHeading": "Tus derechos",
     "rightsIntro": "Conforme al RGPD, en cualquier momento te asisten los siguientes derechos sobre tus datos personales:",
     "rightAccess": "Derecho de acceso a los datos almacenados sobre tu persona.",


### PR DESCRIPTION
## Qué

Sección **"Webanalyse (Umami)"** en la página Datenschutz, en los tres locales (ES/EN/DE). Complemento legal del PR #64 (Umami self-hosted).

## Contenido de la sección

- Umami self-hosted en servidor propio **dentro de la UE** (clouding.io, España — verificado vía RDAP del IP).
- Cookieless, sin perfiles personales, solo información agregada (páginas, referrer, browser/dispositivo, país), **sin almacenar IPs**.
- Los datos no salen del servidor ni van a terceros → sección propia, NO entra en la lista de processors.
- Base jurídica: interés legítimo, art. 6.1.f DSGVO/RGPD/GDPR.

## Decisiones

- La sección de cookies existente sigue siendo exacta (Umami es cookieless) — documentado en el JSDoc de la página.
- Review i18n interno aplicado: ES alineado al formato de cita del resto de la página ("base jurídica", "art. 6.1.f RGPD") y ES/EN alineados al alcance del texto DE (que es la versión vinculante).
- EN mantiene la ortografía británica de la página legal existente (consistencia interna).

## Verificación

JSON de los 3 locales parsea · tsc sin errores · misma posición del namespace en los tres archivos (sin riesgo de MISSING_MESSAGE).

## Nota

Como todo texto legal: validación por humano/abogado recomendada antes o después del merge — el texto sigue el boilerplate estándar de Datenschutzerklärungen para Umami.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced privacy policy with transparent analytics disclosure via Umami
  * Clarified that analytics are self-hosted, cookieless, and collect only aggregated data without storing personal information or IP addresses
  * Added analytics section with multilingual support (German, English, Spanish)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->