### PR TITLE
chore(deps): bump better-auth 1.6.5 → 1.6.18 (reemplaza #62)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@prisma/adapter-pg": "^7.7.0",
         "@prisma/client": "^7.7.0",
         "@trigger.dev/sdk": "^4.4.6",
-        "better-auth": "^1.6.5",
+        "better-auth": "^1.6.18",
         "class-variance-authority": "^0.7.1",
         "cloudinary": "^2.9.0",
         "clsx": "^2.1.1",
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.5.tgz",
-      "integrity": "sha512-T3u4rVsJcMWShG2qfQUlU1HdkQGLYX0+lcR48QV2Cp2kpBOLOTYdt+p6zZtGm2Omx/ReEouRQyKy7pYtahRQuA==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.18.tgz",
+      "integrity": "sha512-mlPZBKHY6gZdJtuY6LiuKjN2r8AWu0LCss7CEnI0xMbE9D7Sw6WofwPPwiMm+0Hi0QBKIaZGYRmR7/WasbOs+Q==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.39.0",
@@ -625,38 +625,41 @@
         "zod": "^4.3.6"
       },
       "peerDependencies": {
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21",
+        "@better-auth/utils": "0.4.1",
+        "@better-fetch/fetch": "1.3.0",
         "@cloudflare/workers-types": ">=4",
         "@opentelemetry/api": "^1.9.0",
-        "better-call": "1.3.5",
+        "better-call": "1.3.6",
         "jose": "^6.1.0",
-        "kysely": "^0.28.5",
+        "kysely": "^0.28.5 || ^0.29.0",
         "nanostores": "^1.0.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
         }
       }
     },
     "node_modules/@better-auth/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@better-auth/drizzle-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.5.tgz",
-      "integrity": "sha512-9YjPW35+h66D+QA+YqEJ9pFP97ClLFR+QrTPZojkeP0PTYqpW0ErBK3p1pwRTJG88yK+o3Y4yOwoacMTBxz0jQ==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.18.tgz",
+      "integrity": "sha512-VFcW2YMLZt0YAD0hy6BcMkjPh4Rh9khV71jnV2uL3udqz599Z1P4PiuWO6XZLELTvb/bbAUnxS5ZnyXQwFDAPQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
+        "@better-auth/core": "^1.6.18",
+        "@better-auth/utils": "0.4.1",
         "drizzle-orm": "^0.45.2"
       },
       "peerDependenciesMeta": {
@@ -666,14 +669,14 @@
       }
     },
     "node_modules/@better-auth/kysely-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.5.tgz",
-      "integrity": "sha512-kbevd70qzKNR3ZHF7q6/e0XXYRCXanLB2rvmTd3T8WbNEd9kYMqKjgTGNxL1ri5N+PEDUK6zfHx/HrvaEOfoHw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.18.tgz",
+      "integrity": "sha512-7Q9+LYWiVD8t3nrxN/fPqZOgUQFcVh+KUo95CDj2+Hfnf4GCb6/ZsQrEnBXBgplwBQbUOYN58Lp/uevb6ugwFQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "kysely": "^0.28.14"
+        "@better-auth/core": "^1.6.18",
+        "@better-auth/utils": "0.4.1",
+        "kysely": "^0.28.17 || ^0.29.0"
       },
       "peerDependenciesMeta": {
         "kysely": {
@@ -682,23 +685,23 @@
       }
     },
     "node_modules/@better-auth/memory-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.5.tgz",
-      "integrity": "sha512-5qFUpSdQi+RwHSmNyHMSsJIrFjed8d/ASS61L2xyW7sjBLTIuR7JcgS6hif5cQbtPeq+Qz+Wct5q8oKw33qyqQ==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.18.tgz",
+      "integrity": "sha512-jHulNRsA0OGKAACmsCNfAbH2z0NEoLQCLdZTU6Pvqn/Cd+xh7aFz0oys69KyKZp2r30QUjuEG9FrrqS8ASWDiw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0"
+        "@better-auth/core": "^1.6.18",
+        "@better-auth/utils": "0.4.1"
       }
     },
     "node_modules/@better-auth/mongo-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.5.tgz",
-      "integrity": "sha512-HvOUFTiSEFSGTzL/vE3FntTwQiZ79O/V+QcsCimR+65Bj3tOqdFaC1G2Yd1dQ9l2YHNXA9SNBrGekbk66RzJMw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.18.tgz",
+      "integrity": "sha512-A6aD3sKsptQl5sBq2wFoLGckEIM5Pa93T//R1DR+erAZOMejZGyaqYaPXWwRk7ZejFOyrftMm98OP0IJsz52gg==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
+        "@better-auth/core": "^1.6.18",
+        "@better-auth/utils": "0.4.1",
         "mongodb": "^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
@@ -708,13 +711,13 @@
       }
     },
     "node_modules/@better-auth/prisma-adapter": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.5.tgz",
-      "integrity": "sha512-d7PUO5XoimYYDEG/DoYVbOSbyVYJBDuZgvY9pjf8INccBTCD1BzcyEJ9NQil4huXWj4fcNaGOt2FG0OI8NtWOA==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.18.tgz",
+      "integrity": "sha512-9hJrDYDqGpb53o8BUuB8uunkkeY+nACzYpZr06R8+22zTFS/NL/jLwgUlK3Xf+1VjhBoXAoEBKJ3ghVUGu6jFw==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
+        "@better-auth/core": "^1.6.18",
+        "@better-auth/utils": "0.4.1",
         "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
@@ -728,29 +731,30 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.5.tgz",
-      "integrity": "sha512-Ag3CjAP+tLretKPq+pYdU/gU4pFIcey/AoNQzw671wV5JQZXrMitS65INi8j8QuYfol2xgQrht5KVlcxGrkhHQ==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.18.tgz",
+      "integrity": "sha512-C/sWZzDAFrtb8bFs+yLHLYYfk1Yffw2GnKXerxTGO3rHI7qV2Ktf359nAf3IdZr+cC/404fFk4hkDCnQiGCkZA==",
       "license": "MIT",
       "peerDependencies": {
-        "@better-auth/core": "^1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21"
+        "@better-auth/core": "^1.6.18",
+        "@better-auth/utils": "0.4.1",
+        "@better-fetch/fetch": "1.3.0"
       }
     },
     "node_modules/@better-auth/utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.0.tgz",
-      "integrity": "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.1.tgz",
+      "integrity": "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.0.1"
       }
     },
     "node_modules/@better-fetch/fetch": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.0.tgz",
+      "integrity": "sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==",
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -6689,26 +6693,26 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.5.tgz",
-      "integrity": "sha512-rSt8JtJOJK0MqPShXINCmM6DV30GsDvnCTlIxQIzP9OpUx/umA40nUc4ALZHQyqAPbw1ib/a549kIWw/WyxxKA==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.18.tgz",
+      "integrity": "sha512-6jONqD0gNjE0S6ehhSZhZ7We0rBwjAzbqnQMJQg/zY0387M+agak7VsOAuE78r7Z0Qv7C/KBRKhHSuyJDQ4iLw==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.6.5",
-        "@better-auth/drizzle-adapter": "1.6.5",
-        "@better-auth/kysely-adapter": "1.6.5",
-        "@better-auth/memory-adapter": "1.6.5",
-        "@better-auth/mongo-adapter": "1.6.5",
-        "@better-auth/prisma-adapter": "1.6.5",
-        "@better-auth/telemetry": "1.6.5",
-        "@better-auth/utils": "0.4.0",
-        "@better-fetch/fetch": "1.1.21",
+        "@better-auth/core": "1.6.18",
+        "@better-auth/drizzle-adapter": "1.6.18",
+        "@better-auth/kysely-adapter": "1.6.18",
+        "@better-auth/memory-adapter": "1.6.18",
+        "@better-auth/mongo-adapter": "1.6.18",
+        "@better-auth/prisma-adapter": "1.6.18",
+        "@better-auth/telemetry": "1.6.18",
+        "@better-auth/utils": "0.4.1",
+        "@better-fetch/fetch": "1.3.0",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
-        "better-call": "1.3.5",
+        "better-call": "1.3.6",
         "defu": "^6.1.4",
         "jose": "^6.1.3",
-        "kysely": "^0.28.14",
+        "kysely": "^0.28.17 || ^0.29.0",
         "nanostores": "^1.1.1",
         "zod": "^4.3.6"
       },
@@ -6806,9 +6810,9 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
-      "integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.6.tgz",
+      "integrity": "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==",
       "license": "MIT",
       "dependencies": {
         "@better-auth/utils": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "@trigger.dev/sdk": "^4.4.6",
-    "better-auth": "^1.6.5",
+    "better-auth": "^1.6.18",
     "class-variance-authority": "^0.7.1",
     "cloudinary": "^2.9.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Qué

Bump de **better-auth 1.6.5 → 1.6.18** (último patch del minor 1.6).

**Reemplaza el PR #62** de Dependabot, que estaba basado en main del 4-jun (9 días stale, le faltaba todo el trabajo de hoy: calendario, géneros, Umami). En vez de mergear ese lockfile viejo, regeneré el bump fresco sobre el main actual.

`^1.6.11` resuelve a 1.6.18 → mismo minor, sin breaking changes por semver (solo bugfixes).

## Verificación local

- `tsc --noEmit` sin errores · `vitest` 13/13 · `next build` verde.
- **Smoke test runtime** (build levantado contra la DB de dev): `/api/auth/get-session` → `null` + 200 (sin crash), `/api/auth/sign-in/email` con credenciales inválidas → 401 (no 500), sin errores de better-auth en el log.

## Nota de deploy

Como el deploy buildea local y rsyncea `node_modules`, este cambio llega a prod en el próximo `deploy.sh` (que ya hace `npm`-equivalent + restart). No toca schema ni env.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `better-auth` dependency to version 1.6.18

<!-- end of auto-generated comment: release notes by coderabbit.ai -->