### PR TITLE
feat(admin): link de nav a /admin/calendar (gestión de scene events)

### DIFF
--- a/src/components/dashboard/DashboardMobileTabs.tsx
+++ b/src/components/dashboard/DashboardMobileTabs.tsx
@@ -17,7 +17,7 @@
 
 import type { ComponentType, SVGProps } from "react"
 import { Link, usePathname } from "@/i18n/navigation"
-import { Home, Calendar, Users, User, ClipboardList, UserCog } from "lucide-react"
+import { Home, Calendar, CalendarDays, Users, User, ClipboardList, UserCog } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { DashboardRole } from "./shell-constants"
 
@@ -26,6 +26,7 @@ import type { DashboardRole } from "./shell-constants"
 export type DashboardTabIconKey =
   | "home"
   | "calendar"
+  | "calendarDays"
   | "users"
   | "user"
   | "clipboardList"
@@ -37,6 +38,7 @@ const ICON_BY_KEY: Record<
 > = {
   home: Home,
   calendar: Calendar,
+  calendarDays: CalendarDays,
   users: Users,
   user: User,
   clipboardList: ClipboardList,

--- a/src/components/dashboard/DashboardNav.tsx
+++ b/src/components/dashboard/DashboardNav.tsx
@@ -27,6 +27,7 @@ export function DashboardNav({ role }: DashboardNavProps) {
           { href: `/${locale}/admin/applications`, label: tAdmin("applications") },
           { href: `/${locale}/admin/users`, label: tAdmin("users") },
           { href: `/${locale}/admin/events`, label: tAdmin("allEvents") },
+          { href: `/${locale}/admin/calendar`, label: tAdmin("calendar") },
         ]
       : []),
   ]

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -124,7 +124,7 @@ async function getDashboardNavItems(
       label: tSidebar("admin.calendar"),
       shortLabel: tSidebar("admin.calendar"),
       href: "/admin/calendar",
-      iconKey: "calendar",
+      iconKey: "calendarDays",
     },
   ]
 }

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -120,6 +120,12 @@ async function getDashboardNavItems(
       href: "/admin/events",
       iconKey: "calendar",
     },
+    {
+      label: tSidebar("admin.calendar"),
+      shortLabel: tSidebar("admin.calendar"),
+      href: "/admin/calendar",
+      iconKey: "calendar",
+    },
   ]
 }
 

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -317,7 +317,8 @@
         "admin": {
           "applications": "Bewerbungen",
           "users": "Benutzer",
-          "events": "Veranstaltungen"
+          "events": "Veranstaltungen",
+          "calendar": "Kalender"
         }
       },
       "mobileTabs": {
@@ -472,6 +473,7 @@
     "colTitle": "Titel",
     "colGenre": "Genre",
     "colArtist": "Künstler",
+    "calendar": "Kalender",
     "applications": "Bewerbungen",
     "applicationsLabel": "Adminbereich",
     "applicationsPending": "Ausstehend",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -317,7 +317,8 @@
         "admin": {
           "applications": "Applications",
           "users": "Users",
-          "events": "Events"
+          "events": "Events",
+          "calendar": "Calendar"
         }
       },
       "mobileTabs": {
@@ -472,6 +473,7 @@
     "colTitle": "Title",
     "colGenre": "Genre",
     "colArtist": "Artist",
+    "calendar": "Calendar",
     "applications": "Applications",
     "applicationsLabel": "Admin panel",
     "applicationsPending": "Pending",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -317,7 +317,8 @@
         "admin": {
           "applications": "Aplicaciones",
           "users": "Usuarios",
-          "events": "Eventos"
+          "events": "Eventos",
+          "calendar": "Calendario"
         }
       },
       "mobileTabs": {
@@ -472,6 +473,7 @@
     "colTitle": "Título",
     "colGenre": "Género",
     "colArtist": "Artista",
+    "calendar": "Calendario",
     "applications": "Solicitudes",
     "applicationsLabel": "Panel de administración",
     "applicationsPending": "Pendientes",


### PR DESCRIPTION
El admin ya podía crear/borrar entradas de escena en `/admin/calendar`, pero **no había link** en el nav para llegar (estaba escondido). Agrega el item.

- `DashboardNav.tsx` (sidebar desktop): suma el link admin → `/admin/calendar`.
- `DashboardShell.tsx` (tab bar mobile admin): suma el item (iconKey `calendar`).
- i18n (es/en/de): etiqueta nueva en los namespaces `admin` y `dashboard.shell.nav.admin` → Calendario / Calendar / Kalender.

Sin lógica nueva (la página y el `DELETE` ya existían). El tab bar mobile admin pasa de 3 a 4 items — verificar que no se apriete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a new admin “Calendar” navigation option in the dashboard for authorized users
* Added localized “Calendar” labels for the admin dashboard navigation in English, German, and Spanish

<!-- end of auto-generated comment: release notes by coderabbit.ai -->